### PR TITLE
Biblio idnos

### DIFF
--- a/Biblio/96/95243.xml
+++ b/Biblio/96/95243.xml
@@ -7,5 +7,5 @@
   </author>
   <date>2008</date>
   <idno type="isbn">978-3-89500-584-8</idno>
-  <idno type="pi"> 95243</idno>
+  <idno type="pi">95243</idno>
 </bibl>

--- a/Biblio/96/95248.xml
+++ b/Biblio/96/95248.xml
@@ -12,4 +12,5 @@
   <date>2015</date>
   <publisher n="1">De Gruyter</publisher>
   <pubPlace n="1">Berlin</pubPlace>
+  <idno type="pi">95248</idno>
 </bibl>

--- a/Biblio/96/95252.xml
+++ b/Biblio/96/95252.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b2017-0004" type="book" subtype="edited">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b95252" type="book" subtype="edited">
   <title level="m" type="main">Papyrological Texts in Honor of Roger S. Bagnall</title>
   <series>
     <title level="s" type="main">American Studies in Papyrology</title>

--- a/Biblio/96/95255.xml
+++ b/Biblio/96/95255.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b2017-0009" type="article" subtype="authored" xml:lang="en">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b95255" type="article" subtype="authored" xml:lang="en">
   <title level="a" type="main">More on P.Oxy. 5094: Hecuba’s Father, Stesichorus, and a New Fragment of Ar(i)aethus of Tegea</title>
   <note type="subject">Papyri</note>
   <author n="1">

--- a/Biblio/96/95256.xml
+++ b/Biblio/96/95256.xml
@@ -26,4 +26,5 @@
   <note type="pageCount">62</note>
   <note type="prefacePageCount">xxxvii</note>
   <note type="illustration">2 plates</note>
+  <idno type="pi">95256</idno>
 </bibl>

--- a/Biblio/96/95256.xml
+++ b/Biblio/96/95256.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b2017-0010" type="book" subtype="edited" xml:lang="de">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b95256" type="book" subtype="edited" xml:lang="de">
   <title level="m" type="main">Anonymer Kommentar zu Platons Theaetet (Papyrus 9782) nebst drei Bruchstücken philosophischen Inhalts (Pap. N. 8; P. 9766. 9569)</title>
   <series>
     <title level="s" type="main">Berliner Klassikertexte</title>

--- a/Biblio/96/95257.xml
+++ b/Biblio/96/95257.xml
@@ -16,4 +16,5 @@
     </bibl>
   </relatedItem>
   <biblScope type="issue">9</biblScope>
+  <idno type="pi">95257</idno>
 </bibl>

--- a/Biblio/96/95257.xml
+++ b/Biblio/96/95257.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b2017-0005" type="article" subtype="journal" xml:lang="it">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b95257" type="article" subtype="journal" xml:lang="it">
   <title level="a" type="main">La maiuscola ogivale inclinata. Contributo preliminare</title>
   <author n="1">
     <forename>Pasquale</forename>

--- a/Biblio/96/95259.xml
+++ b/Biblio/96/95259.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b2017-0017" type="article" subtype="journal" xml:lang="en">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b95259" type="article" subtype="journal" xml:lang="en">
   <title level="a" type="main">Cybele on the Red Sea : New Verses from Berenike</title>
   <editor n="1">
     <forename>Rodney</forename>

--- a/Biblio/96/95259.xml
+++ b/Biblio/96/95259.xml
@@ -28,4 +28,5 @@
       <biblScope type="num">262</biblScope>
     </bibl>
   </relatedItem>
+  <idno type="pi">95259</idno>
 </bibl>

--- a/Biblio/96/95313.xml
+++ b/Biblio/96/95313.xml
@@ -15,5 +15,5 @@
     </bibl>
   </relatedItem>
   <idno type="bp">1989-0134</idno>
-  <idno type="pi">15676</idno>
+  <idno type="pi">95313</idno>
 </bibl>

--- a/Biblio/96/95324.xml
+++ b/Biblio/96/95324.xml
@@ -17,5 +17,5 @@
   </editor>
   <date>1983</date>
   <pubPlace n="1">Cairo</pubPlace>
-  <idno type="pi">95323</idno>
+  <idno type="pi">95324</idno>
 </bibl>

--- a/Biblio/96/95355.xml
+++ b/Biblio/96/95355.xml
@@ -14,5 +14,5 @@
     </bibl>
   </relatedItem>
   <biblScope type="issue">8</biblScope>
-  <idno type="pi">95354</idno>
+  <idno type="pi">95355</idno>
 </bibl>

--- a/Biblio/SoSOL/2012/0035.xml
+++ b/Biblio/SoSOL/2012/0035.xml
@@ -14,5 +14,6 @@
   <date>1941</date>
   <pubPlace n="1">Florence</pubPlace>
   <publisher n="1">E. Ariani</publisher>
+  <idno type="pi">2012-0035</idno>
   <idno type="checklist">clm-00069</idno>
 </bibl>


### PR DESCRIPTION
Corrected tei:idno[@type='pi'] and tei:bibl/@xml:id

I’m wondering though what to do with the idnos in the following file:

https://github.com/papyri/idp.data/blob/biblio_idnos/Biblio/SoSOL/2012/0035.xml