### PR TITLE
import Wisconsin images for HGV (wisconsinImages4hgv)

### DIFF
--- a/HGV_meta_EpiDoc/HGV14/13705.xml
+++ b/HGV_meta_EpiDoc/HGV14/13705.xml
@@ -108,7 +108,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5394"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5394"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13707a.xml
+++ b/HGV_meta_EpiDoc/HGV14/13707a.xml
@@ -115,7 +115,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5407"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5407"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13707b.xml
+++ b/HGV_meta_EpiDoc/HGV14/13707b.xml
@@ -97,7 +97,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5463"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5463"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13708.xml
+++ b/HGV_meta_EpiDoc/HGV14/13708.xml
@@ -117,7 +117,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5408"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5408"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13709.xml
+++ b/HGV_meta_EpiDoc/HGV14/13709.xml
@@ -129,7 +129,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5409"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5409"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13710.xml
+++ b/HGV_meta_EpiDoc/HGV14/13710.xml
@@ -111,7 +111,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5410"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5410"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13711.xml
+++ b/HGV_meta_EpiDoc/HGV14/13711.xml
@@ -100,7 +100,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5465"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5465"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13714.xml
+++ b/HGV_meta_EpiDoc/HGV14/13714.xml
@@ -95,7 +95,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5284"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5284"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13716.xml
+++ b/HGV_meta_EpiDoc/HGV14/13716.xml
@@ -93,7 +93,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5345"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5345"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13718.xml
+++ b/HGV_meta_EpiDoc/HGV14/13718.xml
@@ -109,7 +109,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5363"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5363"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13719.xml
+++ b/HGV_meta_EpiDoc/HGV14/13719.xml
@@ -109,7 +109,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5416"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5416"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13722.xml
+++ b/HGV_meta_EpiDoc/HGV14/13722.xml
@@ -115,7 +115,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5418"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5418"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13723.xml
+++ b/HGV_meta_EpiDoc/HGV14/13723.xml
@@ -117,7 +117,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5428"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5428"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13725.xml
+++ b/HGV_meta_EpiDoc/HGV14/13725.xml
@@ -117,7 +117,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5429"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5429"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13726.xml
+++ b/HGV_meta_EpiDoc/HGV14/13726.xml
@@ -111,7 +111,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5442"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5442"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13727.xml
+++ b/HGV_meta_EpiDoc/HGV14/13727.xml
@@ -142,7 +142,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5443"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5443"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13728.xml
+++ b/HGV_meta_EpiDoc/HGV14/13728.xml
@@ -147,7 +147,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5447"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5447"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13729.xml
+++ b/HGV_meta_EpiDoc/HGV14/13729.xml
@@ -134,7 +134,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5450"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5450"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV14/13730.xml
+++ b/HGV_meta_EpiDoc/HGV14/13730.xml
@@ -126,7 +126,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5451"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5451"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV15/14423.xml
+++ b/HGV_meta_EpiDoc/HGV15/14423.xml
@@ -127,7 +127,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5403"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5403"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15861.xml
+++ b/HGV_meta_EpiDoc/HGV16/15861.xml
@@ -105,7 +105,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5395"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5395"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15873.xml
+++ b/HGV_meta_EpiDoc/HGV16/15873.xml
@@ -96,7 +96,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5396"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5396"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15882.xml
+++ b/HGV_meta_EpiDoc/HGV16/15882.xml
@@ -97,7 +97,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5397"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5397"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15884.xml
+++ b/HGV_meta_EpiDoc/HGV16/15884.xml
@@ -98,7 +98,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5398"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5398"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15889.xml
+++ b/HGV_meta_EpiDoc/HGV16/15889.xml
@@ -103,7 +103,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5156"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5156"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15890.xml
+++ b/HGV_meta_EpiDoc/HGV16/15890.xml
@@ -91,7 +91,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5173"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5173"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15891.xml
+++ b/HGV_meta_EpiDoc/HGV16/15891.xml
@@ -114,7 +114,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5189"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5189"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15892.xml
+++ b/HGV_meta_EpiDoc/HGV16/15892.xml
@@ -94,7 +94,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5350"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5350"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15893.xml
+++ b/HGV_meta_EpiDoc/HGV16/15893.xml
@@ -106,7 +106,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5352"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5352"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15894.xml
+++ b/HGV_meta_EpiDoc/HGV16/15894.xml
@@ -112,7 +112,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5359"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5359"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15895.xml
+++ b/HGV_meta_EpiDoc/HGV16/15895.xml
@@ -98,7 +98,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5360"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5360"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15896.xml
+++ b/HGV_meta_EpiDoc/HGV16/15896.xml
@@ -92,7 +92,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5362"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5362"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15897.xml
+++ b/HGV_meta_EpiDoc/HGV16/15897.xml
@@ -114,7 +114,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5415"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5415"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15898.xml
+++ b/HGV_meta_EpiDoc/HGV16/15898.xml
@@ -107,7 +107,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5420"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5420"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15899.xml
+++ b/HGV_meta_EpiDoc/HGV16/15899.xml
@@ -95,7 +95,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5423"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5423"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15900.xml
+++ b/HGV_meta_EpiDoc/HGV16/15900.xml
@@ -116,7 +116,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5424"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5424"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15901.xml
+++ b/HGV_meta_EpiDoc/HGV16/15901.xml
@@ -96,7 +96,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5425"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5425"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15903.xml
+++ b/HGV_meta_EpiDoc/HGV16/15903.xml
@@ -105,7 +105,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5446"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5446"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15904.xml
+++ b/HGV_meta_EpiDoc/HGV16/15904.xml
@@ -107,7 +107,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5449"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5449"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16812.xml
+++ b/HGV_meta_EpiDoc/HGV17/16812.xml
@@ -99,7 +99,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5379"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5379"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16813.xml
+++ b/HGV_meta_EpiDoc/HGV17/16813.xml
@@ -94,7 +94,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5380"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5380"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16815.xml
+++ b/HGV_meta_EpiDoc/HGV17/16815.xml
@@ -124,7 +124,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5383"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5383"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16816.xml
+++ b/HGV_meta_EpiDoc/HGV17/16816.xml
@@ -107,7 +107,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5384"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5384"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16817.xml
+++ b/HGV_meta_EpiDoc/HGV17/16817.xml
@@ -117,7 +117,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5385"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5385"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16818.xml
+++ b/HGV_meta_EpiDoc/HGV17/16818.xml
@@ -107,7 +107,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5386"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5386"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16819.xml
+++ b/HGV_meta_EpiDoc/HGV17/16819.xml
@@ -103,7 +103,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5388"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5388"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16820.xml
+++ b/HGV_meta_EpiDoc/HGV17/16820.xml
@@ -123,7 +123,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5390"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5390"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16821.xml
+++ b/HGV_meta_EpiDoc/HGV17/16821.xml
@@ -109,7 +109,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5391"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5391"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16823.xml
+++ b/HGV_meta_EpiDoc/HGV17/16823.xml
@@ -128,7 +128,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5393"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5393"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16824.xml
+++ b/HGV_meta_EpiDoc/HGV17/16824.xml
@@ -97,7 +97,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5401"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5401"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV17/16827.xml
+++ b/HGV_meta_EpiDoc/HGV17/16827.xml
@@ -97,7 +97,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5404"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5404"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV26/25107.xml
+++ b/HGV_meta_EpiDoc/HGV26/25107.xml
@@ -111,7 +111,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5399"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5399"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV27/26682.xml
+++ b/HGV_meta_EpiDoc/HGV27/26682.xml
@@ -112,7 +112,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5347"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5347"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV27/26683.xml
+++ b/HGV_meta_EpiDoc/HGV27/26683.xml
@@ -108,7 +108,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5358"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5358"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV27/26684.xml
+++ b/HGV_meta_EpiDoc/HGV27/26684.xml
@@ -95,7 +95,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5364"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5364"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV27/26686.xml
+++ b/HGV_meta_EpiDoc/HGV27/26686.xml
@@ -115,7 +115,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5431"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5431"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV27/26688.xml
+++ b/HGV_meta_EpiDoc/HGV27/26688.xml
@@ -106,7 +106,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5433"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5433"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV27/26689.xml
+++ b/HGV_meta_EpiDoc/HGV27/26689.xml
@@ -121,7 +121,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5448"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5448"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV27/26917.xml
+++ b/HGV_meta_EpiDoc/HGV27/26917.xml
@@ -94,7 +94,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5377"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5377"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV27/26918.xml
+++ b/HGV_meta_EpiDoc/HGV27/26918.xml
@@ -96,7 +96,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5389"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5389"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV27/26919.xml
+++ b/HGV_meta_EpiDoc/HGV27/26919.xml
@@ -92,7 +92,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5453"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5453"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV27/26920.xml
+++ b/HGV_meta_EpiDoc/HGV27/26920.xml
@@ -106,7 +106,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5400"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5400"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV3/2455.xml
+++ b/HGV_meta_EpiDoc/HGV3/2455.xml
@@ -122,7 +122,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5440"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5440"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV3/2456.xml
+++ b/HGV_meta_EpiDoc/HGV3/2456.xml
@@ -209,7 +209,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5441"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5441"/>
                </figure>
                <figure>
                   <graphic url="http://ipap.csad.ox.ac.uk/4DLink4/4DACTION/IPAPwebquery?vPub=P.Cair.Zen.&amp;vVol=3&amp;vNum=59328"/>

--- a/HGV_meta_EpiDoc/HGV31/30209.xml
+++ b/HGV_meta_EpiDoc/HGV31/30209.xml
@@ -86,7 +86,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5419"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5419"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV31/30210.xml
+++ b/HGV_meta_EpiDoc/HGV31/30210.xml
@@ -97,7 +97,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5421"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5421"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV31/30421.xml
+++ b/HGV_meta_EpiDoc/HGV31/30421.xml
@@ -88,7 +88,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5406"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5406"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV33/32545.xml
+++ b/HGV_meta_EpiDoc/HGV33/32545.xml
@@ -90,7 +90,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5351"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5351"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV33/32546.xml
+++ b/HGV_meta_EpiDoc/HGV33/32546.xml
@@ -119,7 +119,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5434"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5434"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV33/32547.xml
+++ b/HGV_meta_EpiDoc/HGV33/32547.xml
@@ -87,7 +87,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5435"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5435"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV33/32548.xml
+++ b/HGV_meta_EpiDoc/HGV33/32548.xml
@@ -89,7 +89,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5436"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5436"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV35/34840.xml
+++ b/HGV_meta_EpiDoc/HGV35/34840.xml
@@ -98,7 +98,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5426"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5426"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV36/35940.xml
+++ b/HGV_meta_EpiDoc/HGV36/35940.xml
@@ -95,7 +95,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5427"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5427"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV39/38647.xml
+++ b/HGV_meta_EpiDoc/HGV39/38647.xml
@@ -100,7 +100,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5349"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5349"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV39/38681.xml
+++ b/HGV_meta_EpiDoc/HGV39/38681.xml
@@ -111,7 +111,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5387"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5387"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV92/91809.xml
+++ b/HGV_meta_EpiDoc/HGV92/91809.xml
@@ -97,7 +97,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5422"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-5422"/>
                </figure>
             </p>
          </div>


### PR DESCRIPTION
imported data taken from the following file

https://docs.google.com/spreadsheets/d/1syFMtqJKJ7wtzHzr3FtfZu_AmDGKjDgwlA_h3P-64Kg/edit#gid=1500525653

**example old url**

http://wwwapp.cc.columbia.edu/ldpd/app/apis/item?mode=item&amp;key=wisconsin.apis.5390

**example new url**

https://quod.lib.umich.edu/a/apis/x-5390

