### PR TITLE
apply correct EpiDoc tags to author names

### DIFF
--- a/Biblio/85/84383.xml
+++ b/Biblio/85/84383.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84383" type="review">
    <author>
-      <name>Germaine</name>
-   </author>
-   <author>
-      <name>Aujac</name>
+      <forename>Germaine</forename>
+      <surname>Aujac</surname>
    </author>
    <date>2014</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84384.xml
+++ b/Biblio/85/84384.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84384" type="review">
    <author>
-      <name>Julien</name>
-   </author>
-   <author>
-      <name>Delhez</name>
+      <forename>Julien</forename>
+      <surname>Delhez</surname>
    </author>
    <date>2015</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84385.xml
+++ b/Biblio/85/84385.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84385" type="review">
    <author>
-      <name>Monique</name>
-   </author>
-   <author>
-      <name>Dondin-Payre</name>
+      <forename>Monique</forename>
+      <surname>Dondin-Payre</surname>
    </author>
    <date>2014</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84386.xml
+++ b/Biblio/85/84386.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84386" type="review">
    <author>
-      <name>Christian</name>
-   </author>
-   <author>
-      <name>Laes</name>
+      <forename>Christian</forename>
+      <surname>Laes</surname>
    </author>
    <date>2015</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84387.xml
+++ b/Biblio/85/84387.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84387" type="review">
    <author>
-      <name>Claire-Emmanuelle</name>
-   </author>
-   <author>
-      <name>Nardone</name>
+      <forename>Claire-Emmanuelle</forename>
+      <surname>Nardone</surname>
    </author>
    <date>2015</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84388.xml
+++ b/Biblio/85/84388.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84388" type="review">
    <author>
-      <name>Jan</name>
-   </author>
-   <author>
-      <name>Moje</name>
+      <forename>Jan</forename>
+      <surname>Moje</surname>
    </author>
    <date>2016</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84389.xml
+++ b/Biblio/85/84389.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84389" type="review">
    <author>
-      <name>Günther</name>
-   </author>
-   <author>
-      <name>Poethke</name>
+      <forename>Günther</forename>
+      <surname>Poethke</surname>
    </author>
    <date>2015</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84390.xml
+++ b/Biblio/85/84390.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84390" type="review">
    <author>
-      <name>Anna</name>
-   </author>
-   <author>
-      <name>Monte</name>
+      <forename>Anna</forename>
+      <surname>Monte</surname>
    </author>
    <date>2016</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84391.xml
+++ b/Biblio/85/84391.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84391" type="review">
    <author>
-      <name>Arthur</name>
-   </author>
-   <author>
-      <name>Verhoogt</name>
+      <forename>Arthur</forename>
+      <surname>Verhoogt</surname>
    </author>
    <date>2015</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84392.xml
+++ b/Biblio/85/84392.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84392" type="review">
    <author>
-      <name>Ian S.</name>
-   </author>
-   <author>
-      <name>Moyer</name>
+      <forename>Ian S.</forename>
+      <surname>Moyer</surname>
    </author>
    <date>2015</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84393.xml
+++ b/Biblio/85/84393.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84393" type="review">
    <author>
-      <name>Sandra</name>
-   </author>
-   <author>
-      <name>Lippert</name>
+      <forename>Sandra</forename>
+      <surname>Lippert</surname>
    </author>
    <date>2015</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84394.xml
+++ b/Biblio/85/84394.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84394" type="review">
    <author>
-      <name>Richard</name>
-   </author>
-   <author>
-      <name>Jasnow</name>
+      <forename>Richard</forename>
+      <surname>Jasnow</surname>
    </author>
    <bibl>
       <ptr target="http://bmcr.brynmawr.edu/2013/2013-09-38.html"/>

--- a/Biblio/85/84395.xml
+++ b/Biblio/85/84395.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84395" type="review">
    <author>
-      <name>Irene Pajón</name>
-   </author>
-   <author>
-      <name>Leyra</name>
+      <forename>Irene</forename>
+      <surname>Pajón Leyra</surname>
    </author>
    <bibl>
       <ptr target="http://bmcr.brynmawr.edu/2013/2013-09-15.html"/>

--- a/Biblio/85/84396.xml
+++ b/Biblio/85/84396.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84396" type="review">
    <author>
-      <name>Yvona</name>
-   </author>
-   <author>
-      <name>Trnka-Amrhein</name>
+      <forename>Yvona</forename>
+      <surname>Trnka-Amrhein</surname>
    </author>
    <bibl>
       <ptr target="http://bmcr.brynmawr.edu/2014/2014-08-56.html"/>

--- a/Biblio/85/84397.xml
+++ b/Biblio/85/84397.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84397" type="review">
    <author>
-      <name>Paul Edmund</name>
-   </author>
-   <author>
-      <name>Stanwick</name>
+      <forename>Paul Edmund</forename>
+      <surname>Stanwick</surname>
    </author>
    <bibl>
       <ptr target="http://bmcr.brynmawr.edu/2010/2010-02-03.html"/>

--- a/Biblio/85/84398.xml
+++ b/Biblio/85/84398.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84398" type="review">
    <author>
-      <name>Arthur</name>
-   </author>
-   <author>
-      <name>Verhoogt</name>
+      <forename>Arthur</forename>
+      <surname>Verhoogt</surname>
    </author>
    <bibl>
       <ptr target="http://bmcr.brynmawr.edu/2015/2015-08-13.html"/>

--- a/Biblio/85/84399.xml
+++ b/Biblio/85/84399.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84399" type="review">
    <author>
-      <name>Federicomaria</name>
-   </author>
-   <author>
-      <name>Muccioli</name>
+      <forename>Federicomaria</forename>
+      <surname>Muccioli</surname>
    </author>
    <bibl>
       <ptr target="http://bmcr.brynmawr.edu/2015/2015-05-11.html"/>

--- a/Biblio/85/84400.xml
+++ b/Biblio/85/84400.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84400" type="review">
    <author>
-      <name>Joachim</name>
-   </author>
-   <author>
-      <name>Hengstl</name>
+      <forename>Joachim</forename>
+      <surname>Hengstl</surname>
    </author>
    <bibl>
       <ptr target="http://bmcr.brynmawr.edu/2016/2016-01-21.html"/>

--- a/Biblio/85/84401.xml
+++ b/Biblio/85/84401.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84401" type="review">
    <author>
-      <name>Robert</name>
-   </author>
-   <author>
-      <name>Lamberton</name>
+      <forename>Robert</forename>
+      <surname>Lamberton</surname>
    </author>
    <bibl>
       <ptr target="http://bmcr.brynmawr.edu/2015/2015-01-40.html"/>

--- a/Biblio/85/84402.xml
+++ b/Biblio/85/84402.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84402" type="review">
    <author>
-      <name>David</name>
-   </author>
-   <author>
-      <name>Frankfurter</name>
+      <forename>David</forename>
+      <surname>Frankfurter</surname>
    </author>
    <bibl>
       <ptr target="http://bmcr.brynmawr.edu/2016/2016-10-13.html"/>

--- a/Biblio/85/84403.xml
+++ b/Biblio/85/84403.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84403" type="review">
    <author>
-      <name>Felipe</name>
-   </author>
-   <author>
-      <name>Rojas</name>
+      <forename>Felipe</forename>
+      <surname>Rojas</surname>
    </author>
    <bibl>
       <ptr target="http://bmcr.brynmawr.edu/2017/2017-02-08.html"/>

--- a/Biblio/85/84404.xml
+++ b/Biblio/85/84404.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84404" type="review">
    <author>
-      <name>Bethany</name>
-   </author>
-   <author>
-      <name>Simpson</name>
+      <forename>Bethany</forename>
+      <surname>Simpson</surname>
    </author>
    <bibl>
       <ptr target="http://bmcr.brynmawr.edu/2015/2015-05-38.html"/>

--- a/Biblio/85/84405.xml
+++ b/Biblio/85/84405.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84405" type="review">
    <author>
-      <name>Naïm</name>
-   </author>
-   <author>
-      <name>Vanthieghem</name>
+      <forename>Naïm</forename>
+      <surname>Vanthieghem</surname>
    </author>
    <date>2015</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84406.xml
+++ b/Biblio/85/84406.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84406" type="review">
    <author>
-      <name>Nídia Catorze</name>
-   </author>
-   <author>
-      <name>Santos</name>
+      <forename>Nídia Catorze</forename>
+      <surname>Santos</surname>
    </author>
    <date>2014</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84407.xml
+++ b/Biblio/85/84407.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84407" type="review">
    <author>
-      <name>Stefan</name>
-   </author>
-   <author>
-      <name>Pfeiffer</name>
+      <forename>Stefan</forename>
+      <surname>Pfeiffer</surname>
    </author>
    <date>2016</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84408.xml
+++ b/Biblio/85/84408.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84408" type="review">
    <author>
-      <name>Edwige</name>
-   </author>
-   <author>
-      <name>Lovergne</name>
+      <forename>Edwige</forename>
+      <surname>Lovergne</surname>
    </author>
    <bibl>
       <ptr target="http://histara.sorbonne.fr/cr.php?cr=1881"/>

--- a/Biblio/85/84409.xml
+++ b/Biblio/85/84409.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84409" type="review">
    <author>
-      <name>Jean-Louis</name>
-   </author>
-   <author>
-      <name>Podvin</name>
+      <forename>Jean-Louis</forename>
+      <surname>Podvin</surname>
    </author>
    <bibl>
       <ptr target="http://histara.sorbonne.fr/cr.php?cr=1934"/>

--- a/Biblio/85/84410.xml
+++ b/Biblio/85/84410.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84410" type="review">
    <author>
-      <name>Louis</name>
-   </author>
-   <author>
-      <name>Brousseau</name>
+      <forename>Louis</forename>
+      <surname>Brousseau</surname>
    </author>
    <bibl>
       <ptr target="http://histara.sorbonne.fr/cr.php?cr=716"/>

--- a/Biblio/85/84411.xml
+++ b/Biblio/85/84411.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84411" type="review">
    <author>
-      <name>Nicolas</name>
-   </author>
-   <author>
-      <name>Amoroso</name>
+      <forename>Nicolas</forename>
+      <surname>Amoroso</surname>
    </author>
    <bibl>
       <ptr target="http://histara.sorbonne.fr/cr.php?cr=2370"/>

--- a/Biblio/85/84412.xml
+++ b/Biblio/85/84412.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84412" type="review">
    <author>
-      <name>Nicholas K.</name>
-   </author>
-   <author>
-      <name>Rauh</name>
+      <forename>Nicholas K.</forename>
+      <surname>Rauh</surname>
    </author>
    <date>2015</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84413.xml
+++ b/Biblio/85/84413.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84413" type="review">
    <author>
-      <name>Stian Sundell</name>
-   </author>
-   <author>
-      <name>Torjussen</name>
+      <forename>Stian Sundell</forename>
+      <surname>Torjussen</surname>
    </author>
    <date>2016</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84414.xml
+++ b/Biblio/85/84414.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84414" type="review">
    <author>
-      <name>Valeria Gigante</name>
-   </author>
-   <author>
-      <name>Lanzara</name>
+      <forename>Valeria</forename>
+      <surname>Gigante Lanzara</surname>
    </author>
    <date>2012</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84415.xml
+++ b/Biblio/85/84415.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84415" type="review">
    <author>
-      <name>Véronique</name>
-   </author>
-   <author>
-      <name>Dasen</name>
+      <forename>Véronique</forename>
+      <surname>Dasen</surname>
    </author>
    <relatedItem type="appearsIn">
       <bibl>

--- a/Biblio/85/84416.xml
+++ b/Biblio/85/84416.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84416" type="review">
    <author>
-      <name>Typhaine</name>
-   </author>
-   <author>
-      <name>Haziza</name>
+      <forename>Typhaine</forename>
+      <surname>Haziza</surname>
    </author>
    <date>2014</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84417.xml
+++ b/Biblio/85/84417.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84417" type="review">
    <author>
-      <name>Adriano</name>
-   </author>
-   <author>
-      <name>Savio</name>
+      <forename>Adriano</forename>
+      <surname>Savio</surname>
    </author>
    <date>2010</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84418.xml
+++ b/Biblio/85/84418.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84418" type="review">
    <author>
-      <name>Arnaud</name>
-   </author>
-   <author>
-      <name>Suspène</name>
+      <forename>Arnaud</forename>
+      <surname>Suspène</surname>
    </author>
    <date>2010</date>
    <relatedItem type="appearsIn">

--- a/Biblio/85/84419.xml
+++ b/Biblio/85/84419.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b84419" type="review">
    <author>
-      <name>Vincenzo</name>
-   </author>
-   <author>
-      <name>Ortoleva</name>
+      <forename>Vincenzo</forename>
+      <surname>Ortoleva</surname>
    </author>
    <date>2013</date>
    <relatedItem type="appearsIn">


### PR DESCRIPTION
Bei den zuletzt importierten CRs Trennung Vor- und Nachname bei author,
händisch einzelne anpassen

>>> https://github.com/papyri/idp.data/commit/24511e34184addd227d8d79d277c6a9038d650b3