### PR TITLE
New HGV metadata

### DIFF
--- a/HGV_meta_EpiDoc/HGV134/133428.xml
+++ b/HGV_meta_EpiDoc/HGV134/133428.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A poll tax receipt from Roman Elephantine</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133428</idno>
+        <idno type="TM">133428</idno>
+        <idno type="ddb-filename">apf.56.259_1</idno>
+        <idno type="ddb-hybrid">apf;56;259_1</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 1127</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Elephantine</origPlace>
+              <origDate when="0079-08-23">23. Aug. 79</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="http://www.trismegistos.org/place/621 http://pleiades.stoa.org/places/786021">Elephantine</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">259</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 259</biblScope>
+            <biblScope type="number">Nr. 1</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate VIII</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133429.xml
+++ b/HGV_meta_EpiDoc/HGV134/133429.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A poll tax receipt from Roman Edfou</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133429</idno>
+        <idno type="TM">133429</idno>
+        <idno type="ddb-filename">apf.56.260_2</idno>
+        <idno type="ddb-hybrid">apf;56;260_2</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 966</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Apollonopolis</origPlace>
+              <origDate when="0107" cert="low">107 (?)</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="http://www.trismegistos.org/place/270 http://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">260</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 260</biblScope>
+            <biblScope type="number">Nr. 2</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate IX</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133430.xml
+++ b/HGV_meta_EpiDoc/HGV134/133430.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for poll and bath taxes</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133430</idno>
+        <idno type="TM">133430</idno>
+        <idno type="ddb-filename">apf.56.263_3</idno>
+        <idno type="ddb-hybrid">apf;56;263_3</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 653</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0088-05-12">12. Mai 88</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">263</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 263</biblScope>
+            <biblScope type="number">Nr. 3</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate IX</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133431.xml
+++ b/HGV_meta_EpiDoc/HGV134/133431.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for the bath tax</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133431</idno>
+        <idno type="TM">133431</idno>
+        <idno type="ddb-filename">apf.56.264_4</idno>
+        <idno type="ddb-hybrid">apf;56;264_4</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 1589</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0098-06-14">14. Juni 98</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">264</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 264</biblScope>
+            <biblScope type="number">Nr. 4</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate X</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133432.xml
+++ b/HGV_meta_EpiDoc/HGV134/133432.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for poll and bath taxes</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133432</idno>
+        <idno type="TM">133432</idno>
+        <idno type="ddb-filename">apf.56.265_5</idno>
+        <idno type="ddb-hybrid">apf;56;265_5</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 2440</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0044-08-15">15. Aug. 44</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">265</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+        <term n="4">Kopfsteuer (laographia)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 265</biblScope>
+            <biblScope type="number">Nr. 5</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate X</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133433.xml
+++ b/HGV_meta_EpiDoc/HGV134/133433.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for poll and bath taxes</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133433</idno>
+        <idno type="TM">133433</idno>
+        <idno type="ddb-filename">apf.56.266_6</idno>
+        <idno type="ddb-hybrid">apf;56;266_6</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 1243</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0050-03-29">29. März 50</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">266</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+        <term n="4">Kopfsteuer (laographia)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 266</biblScope>
+            <biblScope type="number">Nr. 6</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate XI</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133434.xml
+++ b/HGV_meta_EpiDoc/HGV134/133434.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for poll and bath taxes</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133434</idno>
+        <idno type="TM">133434</idno>
+        <idno type="ddb-filename">apf.56.266_7</idno>
+        <idno type="ddb-hybrid">apf;56;266_7</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 920</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0056-09-11">11. Sept. 56</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">266</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+        <term n="4">Kopfsteuer (laographia)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 266</biblScope>
+            <biblScope type="number">Nr. 7</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate XI</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133435.xml
+++ b/HGV_meta_EpiDoc/HGV134/133435.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for the dike (and bath) taxes</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133435</idno>
+        <idno type="TM">133435</idno>
+        <idno type="ddb-filename">apf.56.267_8</idno>
+        <idno type="ddb-hybrid">apf;56;267_8</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 1383</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0113-08-17">17. Aug. 113</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">267</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 267</biblScope>
+            <biblScope type="number">Nr. 8</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate XII</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133436.xml
+++ b/HGV_meta_EpiDoc/HGV134/133436.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for poll and bath taxes</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133436</idno>
+        <idno type="TM">133436</idno>
+        <idno type="ddb-filename">apf.56.268_9</idno>
+        <idno type="ddb-hybrid">apf;56;268_9</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 1361</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0117-09-19">19. Sept. 117</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">268</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+        <term n="4">Kopfsteuer (laographia)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 268</biblScope>
+            <biblScope type="number">Nr. 9</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate XII</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133437.xml
+++ b/HGV_meta_EpiDoc/HGV134/133437.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Recipt for a tax on two mummies</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133437</idno>
+        <idno type="TM">133437</idno>
+        <idno type="ddb-filename">apf.56.269_10</idno>
+        <idno type="ddb-hybrid">apf;56;269_10</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 2505</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0127-07-15">15. Juli 127</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">269</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 269</biblScope>
+            <biblScope type="number">Nr. 10</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate XIII</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133438.xml
+++ b/HGV_meta_EpiDoc/HGV134/133438.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for the dike and bath taxes</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133438</idno>
+        <idno type="TM">133438</idno>
+        <idno type="ddb-filename">apf.56.269_11</idno>
+        <idno type="ddb-hybrid">apf;56;269_11</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 2444</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0149-12-01">1. Dez. 149</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">269</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 269</biblScope>
+            <biblScope type="number">Nr. 11</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate XIII</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133439.xml
+++ b/HGV_meta_EpiDoc/HGV134/133439.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for the tax on weavers</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133439</idno>
+        <idno type="TM">133439</idno>
+        <idno type="ddb-filename">apf.56.270_12</idno>
+        <idno type="ddb-hybrid">apf;56;270_12</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 2382</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0167-02-21">21. Febr. 167</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">270</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 270</biblScope>
+            <biblScope type="number">Nr. 12</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate XIV</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133440.xml
+++ b/HGV_meta_EpiDoc/HGV134/133440.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for payment to the granary of the villages</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133440</idno>
+        <idno type="TM">133440</idno>
+        <idno type="ddb-filename">apf.56.271_13</idno>
+        <idno type="ddb-hybrid">apf;56;271_13</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 1362</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0151-08-13">13. Aug. 151</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">271</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 271</biblScope>
+            <biblScope type="number">Nr. 13</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate XIV</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133441.xml
+++ b/HGV_meta_EpiDoc/HGV134/133441.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for payment to the granary of the villages</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133441</idno>
+        <idno type="TM">133441</idno>
+        <idno type="ddb-filename">apf.56.271_14</idno>
+        <idno type="ddb-hybrid">apf;56;271_14</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 754</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0192-05-28">28. Mai 192</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">271</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 271</biblScope>
+            <biblScope type="number">Nr. 14</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate XV</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133442.xml
+++ b/HGV_meta_EpiDoc/HGV134/133442.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for payment to the granary of the villages</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133442</idno>
+        <idno type="TM">133442</idno>
+        <idno type="ddb-filename">apf.56.272_15</idno>
+        <idno type="ddb-hybrid">apf;56;272_15</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 1133</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0194">194</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">272</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 272</biblScope>
+            <biblScope type="number">Nr. 15</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate XV</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV134/133443.xml
+++ b/HGV_meta_EpiDoc/HGV134/133443.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for payment to the granary of the villages</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">133443</idno>
+        <idno type="TM">133443</idno>
+        <idno type="ddb-filename">apf.56.272_16</idno>
+        <idno type="ddb-hybrid">apf;56;272_16</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">VM 2555</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate when="0195-06-23">23. Juni 195</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/78505"/>
+            <biblScope type="pp">272</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 272</biblScope>
+            <biblScope type="number">Nr. 16</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Plate XVI</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641986.xml
+++ b/HGV_meta_EpiDoc/HGV642/641986.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for the tax on weavers</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641986</idno>
+        <idno type="TM">641986</idno>
+        <idno type="ddb-filename">apf.61.324_1</idno>
+        <idno type="ddb-hybrid">apf;61;324_1</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 652</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+              <origDate when="-0013-12-19">19. Dez. 13 v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="http://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="http://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">324</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 324</biblScope>
+            <biblScope type="number">Nr. 1</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 325</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2792512"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641988.xml
+++ b/HGV_meta_EpiDoc/HGV642/641988.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Private letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641988</idno>
+        <idno type="TM">641988</idno>
+        <idno type="ddb-filename">apf.61.326_2</idno>
+        <idno type="ddb-hybrid">apf;61;326_2</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 736</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate when="0025-05-26">26. Mai 25</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">326</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief (privat)</term>
+        <term n="2">Bälle</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 326</biblScope>
+            <biblScope type="number">Nr. 2</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 327</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2757433"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641989.xml
+++ b/HGV_meta_EpiDoc/HGV642/641989.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for rent</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641989</idno>
+        <idno type="TM">641989</idno>
+        <idno type="ddb-filename">apf.61.328_3</idno>
+        <idno type="ddb-hybrid">apf;61;328_3</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 1686</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hermopolites, Egypt</origPlace>
+              <origDate when="0102-09-22">22. Sept. 102</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">328</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Pacht</term>
+        <term n="3">Land</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 328</biblScope>
+            <biblScope type="number">Nr. 3</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 328</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2759090"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641990.xml
+++ b/HGV_meta_EpiDoc/HGV642/641990.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for laographia</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641990</idno>
+        <idno type="TM">641990</idno>
+        <idno type="ddb-filename">apf.61.329_4</idno>
+        <idno type="ddb-hybrid">apf;61;329_4</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 714</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoiton Polis (Arsinoites, Egypt)</origPlace>
+              <origDate when="0192-10-05">5. Okt. 192</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">Arsinoiton Polis</placeName>
+                <placeName n="2" type="ancient" subtype="nome">Arsinoites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">329</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+        <term n="4">Kopfsteuer (laographia)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 329</biblScope>
+            <biblScope type="number">Nr. 4</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 330</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2757565"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641991.xml
+++ b/HGV_meta_EpiDoc/HGV642/641991.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for laographia</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641991</idno>
+        <idno type="TM">641991</idno>
+        <idno type="ddb-filename">apf.61.331_5</idno>
+        <idno type="ddb-hybrid">apf;61;331_5</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 1388</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoiton Polis (Arsinoites, Egypt)</origPlace>
+              <origDate when="0193-06-05">5. Juni 193</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">Arsinoiton Polis</placeName>
+                <placeName n="2" type="ancient" subtype="nome">Arsinoites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">331</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+        <term n="4">Kopfsteuer (laographia)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 331</biblScope>
+            <biblScope type="number">Nr. 5</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 332</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2758269"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641992.xml
+++ b/HGV_meta_EpiDoc/HGV642/641992.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Epistolary close</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641992</idno>
+        <idno type="TM">641992</idno>
+        <idno type="ddb-filename">apf.61.333_6</idno>
+        <idno type="ddb-hybrid">apf;61;333_6</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 540</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">333</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 333</biblScope>
+            <biblScope type="number">Nr. 6</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 333</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2792379"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641993.xml
+++ b/HGV_meta_EpiDoc/HGV642/641993.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Note about a payment in grain</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641993</idno>
+        <idno type="TM">641993</idno>
+        <idno type="ddb-filename">apf.61.334_7</idno>
+        <idno type="ddb-hybrid">apf;61;334_7</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 110</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites, Egypt</origPlace>
+              <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">334</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Notiz</term>
+        <term n="2">Zahlung</term>
+        <term n="3">Getreide</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 334</biblScope>
+            <biblScope type="number">Nr. 7</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 334</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2756882"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641994.xml
+++ b/HGV_meta_EpiDoc/HGV642/641994.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Note about a payment in grain</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641994</idno>
+        <idno type="TM">641994</idno>
+        <idno type="ddb-filename">apf.61.335_8</idno>
+        <idno type="ddb-hybrid">apf;61;335_8</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 683</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hermopolites, Egypt</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">335</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Notiz</term>
+        <term n="2">Zahlung</term>
+        <term n="3">Getreide</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 335</biblScope>
+            <biblScope type="number">Nr. 8</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 335</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2792473"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641995.xml
+++ b/HGV_meta_EpiDoc/HGV642/641995.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Address label</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641995</idno>
+        <idno type="TM">641995</idno>
+        <idno type="ddb-filename">apf.61.337_9</idno>
+        <idno type="ddb-hybrid">apf;61;337_9</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 159</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos ? (Oxyrhynchites, Egypt)</origPlace>
+              <origDate notBefore="0301" notAfter="0400" precision="low">IV</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" cert="low" ref="http://www.trismegistos.org/place/1524 http://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="http://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">337</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Adresse</term>
+        <term n="2">Zielort</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 337</biblScope>
+            <biblScope type="number">Nr. 9</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 337</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2756915"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641996.xml
+++ b/HGV_meta_EpiDoc/HGV642/641996.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Deed of surety</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641996</idno>
+        <idno type="TM">641996</idno>
+        <idno type="ddb-filename">apf.61.338_10</idno>
+        <idno type="ddb-hybrid">apf;61;338_10</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 2088</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0301" notAfter="0500" precision="low">IV-V</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">338</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Bürgschaft</term>
+        <term n="2">Gestellung</term>
+        <term n="3">Eid</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 338</biblScope>
+            <biblScope type="number">Nr. 10</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 339</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2760470"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641997.xml
+++ b/HGV_meta_EpiDoc/HGV642/641997.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of names</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641997</idno>
+        <idno type="TM">641997</idno>
+        <idno type="ddb-filename">apf.61.341_11</idno>
+        <idno type="ddb-hybrid">apf;61;341_11</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 154 v</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos ? (Oxyrhynchites, Egypt)</origPlace>
+              <origDate notBefore="0301" notAfter="0500" precision="low">IV-V</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" cert="low" ref="http://www.trismegistos.org/place/1524 http://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="http://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">341</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Liste</term>
+        <term n="2">Namen</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 341</biblScope>
+            <biblScope type="number">Nr. 11</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 342</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2756957"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641998.xml
+++ b/HGV_meta_EpiDoc/HGV642/641998.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Order to supply meat</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641998</idno>
+        <idno type="TM">641998</idno>
+        <idno type="ddb-filename">apf.61.343_12</idno>
+        <idno type="ddb-hybrid">apf;61;343_12</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 1962</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+              <origDate when="0484-12-21">21. Dez. 484</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="http://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="http://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">343</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Auftrag</term>
+        <term n="2">Lieferung</term>
+        <term n="3">Fleisch</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 343</biblScope>
+            <biblScope type="number">Nr. 12</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 344</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2759955"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/641999.xml
+++ b/HGV_meta_EpiDoc/HGV642/641999.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Subscriptions to a notarial contract</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">641999</idno>
+        <idno type="TM">641999</idno>
+        <idno type="ddb-filename">apf.61.345_13</idno>
+        <idno type="ddb-hybrid">apf;61;345_13</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 163(A)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0401" notAfter="0500" precision="low">V</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">345</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Vertrag</term>
+        <term n="2">Unterschriften</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 345</biblScope>
+            <biblScope type="number">Nr. 13</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 346</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2756975"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV642/642000.xml
+++ b/HGV_meta_EpiDoc/HGV642/642000.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Order to supply</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">642000</idno>
+        <idno type="TM">642000</idno>
+        <idno type="ddb-filename">apf.61.347_14</idno>
+        <idno type="ddb-hybrid">apf;61;347_14</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 1953</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+              <origDate notBefore="0527" notAfter="0528">527 - 528</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="http://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="http://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">347</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Auftrag</term>
+        <term n="2">Lieferung</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 347</biblScope>
+            <biblScope type="number">Nr. 14</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 348</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2760044"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV643/642001.xml
+++ b/HGV_meta_EpiDoc/HGV643/642001.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Order to supply?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">642001</idno>
+        <idno type="TM">642001</idno>
+        <idno type="ddb-filename">apf.61.349_15</idno>
+        <idno type="ddb-hybrid">apf;61;349_15</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 2039</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">349</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Auftrag</term>
+        <term n="2">Lieferung</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 349</biblScope>
+            <biblScope type="number">Nr. 15</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 349</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2760180"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV643/642002.xml
+++ b/HGV_meta_EpiDoc/HGV643/642002.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Writing exercise</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">642002</idno>
+        <idno type="TM">642002</idno>
+        <idno type="ddb-filename">apf.61.350_16</idno>
+        <idno type="ddb-hybrid">apf;61;350_16</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 2119</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">350</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Übung</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 350</biblScope>
+            <biblScope type="number">Nr. 16</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">keine</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2760373"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV643/642003.xml
+++ b/HGV_meta_EpiDoc/HGV643/642003.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for demosion</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">642003</idno>
+        <idno type="TM">642003</idno>
+        <idno type="ddb-filename">apf.61.351_17</idno>
+        <idno type="ddb-hybrid">apf;61;351_17</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 1685</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoiton Polis (Arsinoites, Egypt)</origPlace>
+              <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">Arsinoiton Polis</placeName>
+                <placeName n="2" type="ancient" subtype="nome">Arsinoites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="http://papyri.info/biblio/86392"/>
+            <biblScope type="pp">351</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Steuer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-04-09" who="http://papyri.info/editor/Mike%20Sampson">HGV entry generated</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">APF</title>
+            <biblScope type="volume">61</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 351</biblScope>
+            <biblScope type="number">Nr. 17</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 351</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2759255"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
New HGV metadata for some APF 56 and 61, courtesy of the generated-from-spreadsheet system I've been working on. NB: it is limited to the essential, basic metadata, so if there are specific things to note (e.g., Datierung or other general notes, mentioned dates), they won't have been included.