### PR TITLE
Correcting principal edition XML

### DIFF
--- a/DCLP/122/121928.xml
+++ b/DCLP/122/121928.xml
@@ -151,7 +151,7 @@
 </ab></div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl type="edition" subtype="principal">
+               <bibl type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/77551"/>

--- a/DCLP/122/121929.xml
+++ b/DCLP/122/121929.xml
@@ -156,7 +156,7 @@
 </ab></div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl type="edition" subtype="principal">
+               <bibl type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/77551"/>

--- a/DCLP/130/129740.xml
+++ b/DCLP/130/129740.xml
@@ -132,7 +132,7 @@ lin13: underdotted σ in νουσ[ , see blank space in editors diplomatic versi
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl type="edition" subtype="principal">
+               <bibl type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/78830"/>

--- a/DCLP/60/59447.xml
+++ b/DCLP/60/59447.xml
@@ -165,7 +165,7 @@
 </ab></div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/83723"/>

--- a/DCLP/60/59496.xml
+++ b/DCLP/60/59496.xml
@@ -371,7 +371,7 @@
                   <biblScope n="6" unit="fragment">col. 12</biblScope>
                   <biblScope n="7" unit="fragment">col. 13</biblScope>
                </bibl>
-               <bibl n="2" type="edition" subtype="principal">
+               <bibl n="2" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/83608"/>

--- a/DCLP/60/59556.xml
+++ b/DCLP/60/59556.xml
@@ -238,7 +238,7 @@
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
                   <title level="j" type="short-BP">BASP</title>
                   <author n="1">
@@ -262,7 +262,7 @@
                   <ptr target="http://papyri.info/biblio/10921"/>
                   <biblScope unit="number">102</biblScope>
                </bibl>
-               <bibl n="3" type="edition" subtype="principal">
+               <bibl n="3" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
                   <title level="j" type="short-BP">Eranos</title>
                   <author n="1">

--- a/DCLP/60/59847.xml
+++ b/DCLP/60/59847.xml
@@ -140,7 +140,7 @@ L. 14 separate square bracket and change to [.?]</change>
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/45454"/>
                </bibl>
-               <bibl n="2" type="edition" subtype="principal">
+               <bibl n="2" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/6821"/>

--- a/DCLP/60/59953.xml
+++ b/DCLP/60/59953.xml
@@ -157,7 +157,7 @@
                   <biblScope n="2" unit="chapter"/>
                   <biblScope n="3" unit="page"/>
                </bibl>
-               <bibl n="5" type="edition" subtype="principal">
+               <bibl n="5" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/95207"/>

--- a/DCLP/61/60296.xml
+++ b/DCLP/61/60296.xml
@@ -161,7 +161,7 @@
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/10921"/>

--- a/DCLP/61/60539.xml
+++ b/DCLP/61/60539.xml
@@ -170,7 +170,7 @@
                   <biblScope n="2" unit="number">3</biblScope>
                   <biblScope n="3" unit="page">258</biblScope>
                </bibl>
-               <bibl n="2" type="edition" subtype="principal">
+               <bibl n="2" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/11957"/>

--- a/DCLP/61/60614.xml
+++ b/DCLP/61/60614.xml
@@ -211,7 +211,7 @@
                   <ptr target="http://papyri.info/biblio/95463"/>
                   <biblScope unit="number">148a</biblScope>
                </bibl>
-               <bibl n="3" type="edition" subtype="principal">
+               <bibl n="3" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/9306"/>

--- a/DCLP/61/60668.xml
+++ b/DCLP/61/60668.xml
@@ -335,7 +335,7 @@
       </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/49388"/>

--- a/DCLP/61/60698.xml
+++ b/DCLP/61/60698.xml
@@ -146,7 +146,7 @@
                   <ptr target="http://papyri.info/biblio/16711"/>
                   <biblScope unit="number">455b</biblScope>
                </bibl>
-               <bibl n="2" type="edition" subtype="principal">
+               <bibl n="2" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/48278"/>

--- a/DCLP/62/61246.xml
+++ b/DCLP/62/61246.xml
@@ -175,7 +175,7 @@
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/14433"/>

--- a/DCLP/62/61311.xml
+++ b/DCLP/62/61311.xml
@@ -204,7 +204,7 @@
                   <biblScope n="1" unit="page" from="139" to="143">139-143</biblScope>
                   <biblScope n="2" unit="number">MS 12</biblScope>
                </bibl>
-               <bibl n="5" type="edition" subtype="principal">
+               <bibl n="5" type="publication" subtype="principal">
                   <title level="s" type="short-Checklist" n="1">P.Iand. 5</title>
                   <author n="1">
                      <forename>Josef</forename>

--- a/DCLP/62/61608.xml
+++ b/DCLP/62/61608.xml
@@ -217,7 +217,7 @@ As far as the metadata, I updated the following details: bibliographycal referen
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/72978"/>

--- a/DCLP/62/61800.xml
+++ b/DCLP/62/61800.xml
@@ -140,7 +140,7 @@ Metadata: Biblio 56829 would be the previous edition, 82132 is the principal. Ad
                   <ptr target="http://papyri.info/biblio/56829"/>
                   <biblScope unit="page">145</biblScope>
                </bibl>
-               <bibl n="2" type="edition" subtype="principal">
+               <bibl n="2" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/82132"/>

--- a/DCLP/63/62151.xml
+++ b/DCLP/63/62151.xml
@@ -211,7 +211,7 @@
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/14433"/>

--- a/DCLP/63/62492.xml
+++ b/DCLP/63/62492.xml
@@ -227,7 +227,7 @@
 </ab></div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl type="edition" subtype="principal">
+               <bibl type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/83723"/>

--- a/DCLP/63/62505.xml
+++ b/DCLP/63/62505.xml
@@ -167,7 +167,7 @@ Thanks, Max</change>
 </ab></div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/83357"/>

--- a/DCLP/63/62680.xml
+++ b/DCLP/63/62680.xml
@@ -358,7 +358,7 @@
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
                   <title level="a" type="main">Two Greek School Tablets</title>
                   <author n="1">

--- a/DCLP/63/62724.xml
+++ b/DCLP/63/62724.xml
@@ -130,7 +130,7 @@
 </ab></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/3559"/>

--- a/DCLP/64/63194.xml
+++ b/DCLP/64/63194.xml
@@ -512,25 +512,25 @@
 </ab></div></div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/10813"/>
                   <biblScope unit="number">7</biblScope>
                </bibl>
-               <bibl n="2" type="edition" subtype="principal">
+               <bibl n="2" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/10813"/>
                   <biblScope unit="number">8</biblScope>
                </bibl>
-               <bibl n="3" type="edition" subtype="principal">
+               <bibl n="3" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/10813"/>
                   <biblScope unit="number">10</biblScope>
                </bibl>
-               <bibl n="4" type="edition" subtype="principal">
+               <bibl n="4" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/10813"/>

--- a/DCLP/64/63602.xml
+++ b/DCLP/64/63602.xml
@@ -181,7 +181,7 @@
     </ab></div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
                   <title level="s" type="abbreviated">P. Oxy.</title>
                   <!-- ignore - start, i.e. SoSOL users may not edit this -->
                   <!-- ignore - stop -->

--- a/DCLP/64/63786.xml
+++ b/DCLP/64/63786.xml
@@ -116,7 +116,7 @@
 </ab></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
                   <title level="j" type="short-BP">EtPap</title>
                   <author n="1">

--- a/DCLP/65/64037.xml
+++ b/DCLP/65/64037.xml
@@ -204,7 +204,7 @@
                   <ptr target="http://papyri.info/biblio/95359"/>
                   <biblScope unit="page" from="460" to="463">460-463</biblScope>
                </bibl>
-               <bibl n="3" type="edition" subtype="principal">
+               <bibl n="3" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
                   <title level="a" type="main">Testi dei papiri di logica adespoti.</title>
                   <author n="1">

--- a/DCLP/65/64173.xml
+++ b/DCLP/65/64173.xml
@@ -139,7 +139,7 @@
 </ab></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/13946"/>

--- a/DCLP/65/64281.xml
+++ b/DCLP/65/64281.xml
@@ -155,7 +155,7 @@
                   <biblScope n="1" unit="page">207</biblScope>
                   <biblScope n="2" unit="number">142</biblScope>
                </bibl>
-               <bibl n="3" type="edition" subtype="principal">
+               <bibl n="3" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/95344"/>

--- a/DCLP/65/64327.xml
+++ b/DCLP/65/64327.xml
@@ -133,7 +133,7 @@
                   <ptr target="http://papyri.info/biblio/37482"/>
                   <biblScope unit="page">453</biblScope>
                </bibl>
-               <bibl n="3" type="edition" subtype="principal">
+               <bibl n="3" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/54586"/>

--- a/DCLP/65/64391.xml
+++ b/DCLP/65/64391.xml
@@ -213,7 +213,7 @@ Text a.folio: &lt;:[λ]ανθάνῃ|reg|[λ]α̣νθάνι:&gt; ; b.folio, line
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/12969"/>

--- a/DCLP/65/64612.xml
+++ b/DCLP/65/64612.xml
@@ -204,7 +204,7 @@
 </div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl type="edition" subtype="principal">
+               <bibl type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/10813"/>

--- a/DCLP/65/64846.xml
+++ b/DCLP/65/64846.xml
@@ -172,7 +172,7 @@
                   <ptr target="http://papyri.info/biblio/12016"/>
                   <biblScope unit="number">31</biblScope>
                </bibl>
-               <bibl n="2" type="edition" subtype="principal">
+               <bibl n="2" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/14433"/>

--- a/DCLP/66/65056.xml
+++ b/DCLP/66/65056.xml
@@ -157,7 +157,7 @@
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
                   <title level="a" type="main">Problèmes d'édition dans le corpus papyrologique des hymnes chrétiennes.</title>
                   <!-- ignore - start, i.e. SoSOL users may not edit this -->
                   <!-- ignore - stop -->

--- a/DCLP/66/65146.xml
+++ b/DCLP/66/65146.xml
@@ -116,7 +116,7 @@
 </ab></div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/54002"/>

--- a/DCLP/66/65367.xml
+++ b/DCLP/66/65367.xml
@@ -143,7 +143,7 @@
                   <ptr target="http://papyri.info/biblio/10813"/>
                   <biblScope unit="number">144</biblScope>
                </bibl>
-               <bibl n="2" type="edition" subtype="principal">
+               <bibl n="2" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/95614"/>

--- a/DCLP/66/65385.xml
+++ b/DCLP/66/65385.xml
@@ -124,7 +124,7 @@
                   <ptr target="http://papyri.info/biblio/10813"/>
                   <biblScope unit="number">170</biblScope>
                </bibl>
-               <bibl n="2" type="edition" subtype="principal">
+               <bibl n="2" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/95686"/>

--- a/DCLP/66/65612.xml
+++ b/DCLP/66/65612.xml
@@ -341,7 +341,7 @@
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/57270"/>
                </bibl>
-               <bibl n="3" type="edition" subtype="principal">
+               <bibl n="3" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/95039"/>

--- a/DCLP/67/66070.xml
+++ b/DCLP/67/66070.xml
@@ -153,7 +153,7 @@
                   <biblScope n="2" unit="number">62</biblScope>
                   <biblScope n="3" unit="page" from="640" to="641">640-641</biblScope>
                </bibl>
-               <bibl n="2" type="edition" subtype="principal">
+               <bibl n="2" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/69126"/>

--- a/DCLP/70/69036.xml
+++ b/DCLP/70/69036.xml
@@ -115,7 +115,7 @@
 </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="edition" subtype="principal">
+               <bibl n="1" type="publication" subtype="principal">
             <!-- ignore - start, i.e. SoSOL users may not edit this -->
             <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/53196"/>


### PR DESCRIPTION
This update corrects a fault in DCLP xml which is preventing principal editions to display correctly (see issue ticket [here](https://github.com/papyri/sosol/issues/290)). The underlying issue in the DCLP metadata mask that is responsible for the corruption will have to be addressed by the DC3 team.