### PR TITLE
Xwalk and idnos for APIS aggregation

### DIFF
--- a/APIS/columbia/xml/columbia.apis.109.xml
+++ b/APIS/columbia/xml/columbia.apis.109.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">columbia.apis.109</idno>
             <idno type="controlNo">(NNC)aaa0279</idno>
+            <idno type="TM">317014</idno>
+            <idno type="HGV">317014</idno>
+            <idno type="ddb-hybrid">basp;54;147_2</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/columbia/xml/columbia.apis.1102.xml
+++ b/APIS/columbia/xml/columbia.apis.1102.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">columbia.apis.1102</idno>
             <idno type="controlNo">(NNC)aaa1648</idno>
+            <idno type="TM">317029</idno>
+            <idno type="HGV">317029</idno>
+            <idno type="ddb-hybrid">basp;54;153_5</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/columbia/xml/columbia.apis.795.xml
+++ b/APIS/columbia/xml/columbia.apis.795.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">columbia.apis.795</idno>
             <idno type="controlNo">(NNC)aaa0963</idno>
+            <idno type="TM">320266</idno>
+            <idno type="HGV">320266</idno>
+            <idno type="ddb-hybrid">basp;54;149_3</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/columbia/xml/columbia.apis.82.xml
+++ b/APIS/columbia/xml/columbia.apis.82.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">columbia.apis.82</idno>
             <idno type="controlNo">(NNC)aaa0252</idno>
+            <idno type="TM">704978</idno>
+            <idno type="HGV">704978</idno>
+            <idno type="ddb-hybrid">basp;54;145_1</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/columbia/xml/columbia.apis.950.xml
+++ b/APIS/columbia/xml/columbia.apis.950.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">columbia.apis.950</idno>
             <idno type="controlNo">(NNC)aaa1118</idno>
+            <idno type="TM">320438</idno>
+            <idno type="HGV">320438</idno>
+            <idno type="ddb-hybrid">basp;54;151_4</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/columbia/xml/columbia.apis.p811.xml
+++ b/APIS/columbia/xml/columbia.apis.p811.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">columbia.apis.p811</idno>
             <idno type="controlNo">(NNC)aaa3985</idno>
+            <idno type="TM">244111</idno>
+            <idno type="HGV">244111</idno>
+            <idno type="ddb-hybrid">jjp;40;268</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/duke/xml/duke.apis.33150324.xml
+++ b/APIS/duke/xml/duke.apis.33150324.xml
@@ -11,6 +11,8 @@
             <idno type="apisid">duke.apis.33150324</idno>
             <idno type="controlNo">(NcD)33150324</idno>
             <idno type="TM">132916</idno>
+            <idno type="HGV">132916</idno>
+            <idno type="ddb-hybrid">basp;49;172_2r</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/michigan/xml/michigan.apis.5606.xml
+++ b/APIS/michigan/xml/michigan.apis.5606.xml
@@ -11,6 +11,9 @@
             <authority>APIS</authority>
             <idno type="apisid">michigan.apis.5606</idno>
             <idno type="controlNo">(MiU)5606</idno>
+            <idno type="TM">832287</idno>
+            <idno type="HGV">832287</idno>
+            <idno type="ddb-hybrid">basp;56;120</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/michigan/xml/michigan.apis.5607.xml
+++ b/APIS/michigan/xml/michigan.apis.5607.xml
@@ -11,6 +11,9 @@
             <authority>APIS</authority>
             <idno type="apisid">michigan.apis.5607</idno>
             <idno type="controlNo">(MiU)5607</idno>
+            <idno type="TM">832339</idno>
+            <idno type="HGV">832339</idno>
+            <idno type="ddb-hybrid">basp;56;122</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/upenn/xml/upenn.apis.48.xml
+++ b/APIS/upenn/xml/upenn.apis.48.xml
@@ -10,7 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">upenn.apis.48</idno>
             <idno type="controlNo">(PU) 48</idno>
-            <idno type="ddbdp">p.oxy.3.652</idno>
+            <idno type="ddb-hybrid">jjp;42;104</idno>
+            <idno type="HGV">28397</idno>
+            <idno type="TM">28397</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0007600000.xml
+++ b/APIS/yale/xml/yale.apis.0007600000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0007600000</idno>
             <idno type="controlNo">(CtY)760</idno>
+            <idno type="TM">768440</idno>
+            <idno type="HGV">768440</idno>
+            <idno type="ddb-hybrid">jjp;47;32</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/HGV_meta_EpiDoc/HGV11/10834.xml
+++ b/HGV_meta_EpiDoc/HGV11/10834.xml
@@ -87,6 +87,13 @@
                </bibl>
             </listBibl>
          </div>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="https://compass.fivecolleges.edu/object/mtholyoke:39640"/>
+             </figure>
+           </p>
+         </div>
          <div type="bibliography" subtype="illustrations">
             <p>keine</p>
          </div>

--- a/HGV_meta_EpiDoc/HGV133/132916.xml
+++ b/HGV_meta_EpiDoc/HGV133/132916.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Durham (NC)</settlement>
+              <settlement>Durham (NC)</settlement>
             </placeName>
             <collection>Duke University </collection>
             <idno type="invNo">P.Duke inv. 1053 recto</idno>
@@ -57,11 +57,11 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Protokoll</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Protokoll</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -90,10 +90,13 @@
       </div>
       <div type="figure">
         <p>
-         <figure n="1">
-             <graphic url="https://papyri.info/apis/duke.apis.33150324"/>
+          <figure n="1">
+            <graphic url="https://papyri.info/apis/duke.apis.33150324"/>
           </figure>
         </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite: BASP 49 (2012) S. 173.</p>
       </div>
     </body>
   </text>

--- a/HGV_meta_EpiDoc/HGV133/132916.xml
+++ b/HGV_meta_EpiDoc/HGV133/132916.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Protocole bilingue grec et arabe </title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">132916</idno>
+        <idno type="TM">132916</idno>
+        <idno type="ddb-filename">basp.49.172_2r</idno>
+        <idno type="ddb-hybrid">basp;49;172_2r</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Durham (NC)</settlement>
+            </placeName>
+            <collection>Duke University </collection>
+            <idno type="invNo">P.Duke inv. 1053 recto</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Egypt</origPlace>
+              <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Protokoll</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">49</biblScope>
+            <biblScope type="fascicle">(2012)</biblScope>
+            <biblScope type="pages">S. 172</biblScope>
+            <biblScope type="number">Nr. 2r</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 174</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Descr.</p>
+      </div>
+      <div type="figure">
+        <p>
+         <figure n="1">
+             <graphic url="https://papyri.info/apis/duke.apis.33150324"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV133/132920.xml
+++ b/HGV_meta_EpiDoc/HGV133/132920.xml
@@ -2,67 +2,67 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>
-      <fileDesc>
-         <titleStmt>
-            <title>Ordre de paiement de légumes et d'encens</title>
-         </titleStmt>
-         <publicationStmt>
-            <idno type="filename">132920</idno>
-            <idno type="TM">132920</idno>
-            <idno type="ddb-filename">basp.49.173_2</idno>
-            <idno type="ddb-hybrid">basp;49;173_2</idno>
-         </publicationStmt>
-         <sourceDesc>
-            <msDesc>
-               <msIdentifier>
-                  <placeName>
-                     <settlement>Durham (NC)</settlement>
-                  </placeName>
-                  <collection>Duke University</collection>
-                  <idno type="invNo">P.Duke inv. 1053 vo</idno>
-               </msIdentifier>
-               <physDesc>
-                  <objectDesc>
-                     <supportDesc>
-                        <support>
-                           <material>Papyrus</material>
-                        </support>
-                     </supportDesc>
-                  </objectDesc>
-               </physDesc>
-               <history>
-                  <origin>
-                     <origPlace>Abba Apollotos Monasterion (= Bawit) (Hermopolites, Egypt)</origPlace>
-                     <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
-                  </origin>
-                  <provenance type="located">
-                     <p xml:id="geoHEB477">
-                        <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
-                        <placeName n="2"
-                                   type="ancient"
-                                   subtype="nome"
-                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
-                        <placeName n="3"
-                                   type="ancient"
-                                   ref="https://www.trismegistos.org/place/10454 https://pleiades.stoa.org/places/756663">Abba Apollotos Monasterion</placeName>
-                        <placeName n="4" type="modern">Bawit</placeName>
-                     </p>
-                  </provenance>
-               </history>
+    <fileDesc>
+      <titleStmt>
+        <title>Ordre de paiement de légumes et d'encens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">132920</idno>
+        <idno type="TM">132920</idno>
+        <idno type="ddb-filename">basp.49.173_2</idno>
+        <idno type="ddb-hybrid">basp;49;173_2</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Durham (NC)</settlement>
+            </placeName>
+            <collection>Duke University</collection>
+            <idno type="invNo">P.Duke inv. 1053 verso</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Abba Apollotos Monasterion (= Bawit) (Hermopolites, Egypt)</origPlace>
+              <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+            </origin>
+            <provenance type="located">
+              <p xml:id="geoHEB477">
+                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2"
+                  type="ancient"
+                  subtype="nome"
+                  ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                  <placeName n="3"
+                    type="ancient"
+                    ref="https://www.trismegistos.org/place/10454 https://pleiades.stoa.org/places/756663">Abba Apollotos Monasterion</placeName>
+                    <placeName n="4" type="modern">Bawit</placeName>
+                  </p>
+                </provenance>
+              </history>
             </msDesc>
             <listBibl>
-               <bibl type="SB">
-                  <ptr target="http://papyri.info/biblio/86476"/>
-                  <biblScope type="pp">173</biblScope>
-               </bibl>
+              <bibl type="SB">
+                <ptr target="http://papyri.info/biblio/86476"/>
+                <biblScope type="pp">173</biblScope>
+              </bibl>
             </listBibl>
-         </sourceDesc>
-      </fileDesc>
-      <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
-      </encodingDesc>
-      <profileDesc>
-         <langUsage>
+          </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+          <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+          <langUsage>
             <language ident="fr">Französisch</language>
             <language ident="en">Englisch</language>
             <language ident="de">Deutsch</language>
@@ -70,62 +70,65 @@
             <language ident="es">Spanisch</language>
             <language ident="la">Latein</language>
             <language ident="el">Griechisch</language>
-         </langUsage>
-         <textClass>
+          </langUsage>
+          <textClass>
             <keywords scheme="hgv">
-               <term n="1">Bestellung</term>
-               <term n="2">Zahlung</term>
-               <term n="3">Weihrauch</term>
-               <term n="4">Gemüse</term>
+              <term n="1">Bestellung</term>
+              <term n="2">Zahlung</term>
+              <term n="3">Weihrauch</term>
+              <term n="4">Gemüse</term>
             </keywords>
-         </textClass>
-      </profileDesc>
-      <revisionDesc>
-         <change when="2020-06-06T10:49:40-04:00"
-                 who="http://papyri.info/users/Mike%20Sampson">Finalized - This is ready.</change>
-         <change when="2020-06-06T10:33:43-04:00"
-                 who="http://papyri.info/users/Mike%20Sampson">Vote - HGVAccept - Some tidying needed throughout.</change>
-         <change when="2020-06-05T04:41:35-04:00"
-                 who="http://papyri.info/users/So%20Miyagawa">Submit - This is BASP 49 (2012) 173 no. 2 (Delattre), made in the Heidelberg Digital Papyrology.</change>
-         <change when="2020-05-26T23:24:43-04:00" who="http://papyri.info/editor">Automated creation from template</change>
-      </revisionDesc>
-  </teiHeader>
-  <text>
-      <body>
-         <div type="bibliography" subtype="principalEdition">
-            <listBibl>
-               <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">BASP</title>
-                  <!-- provide meaningful data -->
-                  <!-- provide meaningful data -->
-                  <!-- provide meaningful data -->
-                  <biblScope n="1" type="volume">49</biblScope>
-                  <biblScope n="2" type="fascicle">(2012)</biblScope>
-                  <biblScope n="3" type="pages">S. 173</biblScope>
-                  <biblScope n="4" type="number">Nr. 2</biblScope>
-               </bibl>
-            </listBibl>
-         </div>
-         <div type="bibliography" subtype="illustrations">
-            <p>
-               <bibl type="illustration">S. 173</bibl>
-            </p>
-         </div>
-         <div type="bibliography" subtype="translations">
-            <listBibl xml:lang="fr">
-               <bibl type="translations">S. 173</bibl>
-            </listBibl>
-         </div>
-         <div type="figure">
-            <p>
-               <figure n="1">
-                  <graphic url="https://quod.lib.umich.edu/b/basp/0599796.0049.001/173"/>
-               </figure>
-               <figure n="2">
-                  <graphic url="https://library.duke.edu/rubenstein/scriptorium/papyrus/records/1053v.html"/>
-               </figure>
-            </p>
-         </div>
-      </body>
-  </text>
-</TEI>
+          </textClass>
+        </profileDesc>
+        <revisionDesc>
+          <change when="2020-06-06T10:49:40-04:00"
+            who="http://papyri.info/users/Mike%20Sampson">Finalized - This is ready.</change>
+            <change when="2020-06-06T10:33:43-04:00"
+              who="http://papyri.info/users/Mike%20Sampson">Vote - HGVAccept - Some tidying needed throughout.</change>
+              <change when="2020-06-05T04:41:35-04:00"
+                who="http://papyri.info/users/So%20Miyagawa">Submit - This is BASP 49 (2012) 173 no. 2 (Delattre), made in the Heidelberg Digital Papyrology.</change>
+                <change when="2020-05-26T23:24:43-04:00" who="http://papyri.info/editor">Automated creation from template</change>
+              </revisionDesc>
+            </teiHeader>
+            <text>
+              <body>
+                <div type="bibliography" subtype="principalEdition">
+                  <listBibl>
+                    <bibl type="publication" subtype="principal">
+                      <title level="s" type="abbreviated">BASP</title>
+                      <!-- provide meaningful data -->
+                      <!-- provide meaningful data -->
+                      <!-- provide meaningful data -->
+                      <biblScope n="1" type="volume">49</biblScope>
+                      <biblScope n="2" type="fascicle">(2012)</biblScope>
+                      <biblScope n="3" type="pages">S. 173</biblScope>
+                      <biblScope n="4" type="number">Nr. 2</biblScope>
+                    </bibl>
+                  </listBibl>
+                </div>
+                <div type="bibliography" subtype="illustrations">
+                  <p>
+                    <bibl type="illustration">S. 173</bibl>
+                  </p>
+                </div>
+                <div type="bibliography" subtype="translations">
+                  <listBibl xml:lang="fr">
+                    <bibl type="translations">S. 173</bibl>
+                  </listBibl>
+                </div>
+                <div type="figure">
+                  <p>
+                    <figure n="1">
+                      <graphic url="https://quod.lib.umich.edu/b/basp/0599796.0049.001/173"/>
+                    </figure>
+                    <figure n="2">
+                      <graphic url="https://library.duke.edu/rubenstein/scriptorium/papyrus/records/1053v.html"/>
+                    </figure>
+                  </p>
+                </div>
+                <div type="commentary" subtype="general">
+                  <p>Rückseite: BASP 49 (2012) S. 172-173.</p>
+                </div>
+              </body>
+            </text>
+          </TEI>

--- a/HGV_meta_EpiDoc/HGV134/133268.xml
+++ b/HGV_meta_EpiDoc/HGV134/133268.xml
@@ -91,6 +91,9 @@
                </bibl>
             </listBibl>
          </div>
+         <div type="commentary" subtype="general">
+           <p>Descr.</p>
+         </div>
          <div type="bibliography" subtype="illustrations">
             <p>keine</p>
          </div>

--- a/HGV_meta_EpiDoc/HGV141/140211.xml
+++ b/HGV_meta_EpiDoc/HGV141/140211.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Ein Neurömer aus Alexandria</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">140211</idno>
+        <idno type="TM">140211</idno>
+        <idno type="ddb-filename">jjp.40.137</idno>
+        <idno type="ddb-hybrid">jjp;40;137</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Paris</settlement>
+            </placeName>
+            <collection>Louvre</collection>
+            <idno type="invNo">E 11083 f / 52</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Egypt</origPlace>
+              <origDate notBefore="0219-02-25" notAfter="0220-02-25">25 Febr. 219 - 220</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Vertrag</term>
+        <term n="2">Darlehen</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">40</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 137</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 139</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV141/140211.xml
+++ b/HGV_meta_EpiDoc/HGV141/140211.xml
@@ -86,6 +86,13 @@
           <bibl type="illustration">S. 139</bibl>
         </p>
       </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2010-t40/The_Journal_of_Juristic_Papyrology-r2010-t40-s135-144/The_Journal_of_Juristic_Papyrology-r2010-t40-s135-144.pdf"/>
+          </figure>
+        </p>
+      </div>
     </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV245/244050.xml
+++ b/HGV_meta_EpiDoc/HGV245/244050.xml
@@ -32,15 +32,15 @@
           </physDesc>
           <history>
             <origin>
-                     <origPlace>Arsinoites, Egypt</origPlace>
-                     <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
-                  </origin>
-                  <provenance type="located">
-                     <p xml:id="geoBHFIDG">
-                        <placeName n="1" type="ancient" subtype="nome" ref="http://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
-                     </p>
-                  </provenance>
+              <origPlace>Arsinoites, Egypt</origPlace>
+              <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
+            </origin>
+            <provenance type="located">
+              <p xml:id="geoBHFIDG">
+                <placeName n="1" type="ancient" subtype="nome" ref="http://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
           </history>
         </msDesc>
       </sourceDesc>
@@ -81,6 +81,9 @@
             <biblScope n="3" type="pages">S. 31</biblScope>
           </bibl>
         </listBibl>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Descr.</p>
       </div>
       <div type="bibliography" subtype="illustrations">
         <p>keine

--- a/HGV_meta_EpiDoc/HGV245/244111.xml
+++ b/HGV_meta_EpiDoc/HGV245/244111.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A loan contract with 'paramonê' provision from mid-first-century CE Theadelphia</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">244111</idno>
+        <idno type="TM">244111</idno>
+        <idno type="ddb-filename">jjp.40.268</idno>
+        <idno type="ddb-hybrid">jjp;40;268</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New York</settlement>
+            </placeName>
+            <collection>Columbia University</collection>
+            <idno type="invNo">P.Col. inv. 131</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Theadelpheia (Arsinoites, Egypt)</origPlace>
+              <origDate when="0058-08-20">20. Aug. 58</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2349 https://pleiades.stoa.org/places/737081">Theadelpheia</placeName>
+                <placeName type="ancient" subtype="nome">Arsinoites</placeName>
+                <placeName type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Vertrag</term>
+        <term n="2">Darlehen</term>
+        <term n="3">Geld</term>
+        <term n="4">Paramone</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">40</biblScope>
+            <biblScope type="fascicle">(2010)</biblScope>
+            <biblScope type="pages">S. 268</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 269</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="https://papyri.info/apis/columbia.apis.p811/images"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV245/244111.xml
+++ b/HGV_meta_EpiDoc/HGV245/244111.xml
@@ -94,6 +94,9 @@
           <figure n="1">
             <graphic url="https://papyri.info/apis/columbia.apis.p811/images"/>
           </figure>
+          <figure n="2">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2010-t40/The_Journal_of_Juristic_Papyrology-r2010-t40-s267-282/The_Journal_of_Juristic_Papyrology-r2010-t40-s267-282.pdf"/>
+          </figure>
         </p>
       </div>
     </body>

--- a/HGV_meta_EpiDoc/HGV31/30681.xml
+++ b/HGV_meta_EpiDoc/HGV31/30681.xml
@@ -88,6 +88,9 @@
          <div type="bibliography" subtype="illustrations">
             <p>keine</p>
          </div>
+         <div type="commentary" subtype="general">
+           <p>Rückseite: Tyche 33 (2018) S. 46.</p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV317/316320.xml
+++ b/HGV_meta_EpiDoc/HGV317/316320.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Ein spätantiker Papyrusbrief an den magnificentissimus comes Menas</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">316320</idno>
+        <idno type="TM">316320</idno>
+        <idno type="ddb-filename">tyche.28.128</idno>
+        <idno type="ddb-hybrid">tyche;28;128</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Vienna</settlement>
+            </placeName>
+            <collection>Nationalbibliothek</collection>
+            <idno type="invNo">P.Vindob. G 15798</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hermopolites (oder Arsinoites)</origPlace>
+              <origDate notBefore="0676" notAfter="0700" precision="low">Ende VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p n="1" xml:id="geog_1" exclude="#geog_2">
+                <placeName type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+              </p>
+              <p n="2" xml:id="geog_2" exclude="#geog_1">
+                <placeName type="ancient" subtype="nome" ref="https://pleiades.stoa.org/places/736893 https://www.trismegistos.org/place/332">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">N.N. an Menas</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">28</biblScope>
+            <biblScope type="fascicle">(2013)</biblScope>
+            <biblScope type="pages">S. 128</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 10, 11</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://data.onb.ac.at/rec/RZ00008370"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV318/317014.xml
+++ b/HGV_meta_EpiDoc/HGV318/317014.xml
@@ -94,10 +94,17 @@
                </bibl>
             </listBibl>
          </div>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="https://papyri.info/apis/columbia.apis.109/images"/>
+             </figure>
+           </p>
+         </div>
          <div type="bibliography" subtype="illustrations">
-            <p>
-               <bibl type="illustration">S. 149</bibl>
-            </p>
+           <p>
+             <bibl type="illustration">S. 149</bibl>
+           </p>
          </div>
       </body>
   </text>

--- a/HGV_meta_EpiDoc/HGV321/320266.xml
+++ b/HGV_meta_EpiDoc/HGV321/320266.xml
@@ -90,6 +90,13 @@
                </bibl>
             </listBibl>
          </div>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="https://papyri.info/apis/columbia.apis.795/images"/>
+             </figure>
+           </p>
+         </div>
          <div type="bibliography" subtype="illustrations">
             <p>
                <bibl type="illustration">S. 150</bibl>

--- a/HGV_meta_EpiDoc/HGV321/320438.xml
+++ b/HGV_meta_EpiDoc/HGV321/320438.xml
@@ -90,6 +90,13 @@
                </bibl>
             </listBibl>
          </div>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="https://papyri.info/apis/columbia.apis.950/images"/>
+             </figure>
+           </p>
+         </div>
          <div type="bibliography" subtype="illustrations">
             <p>
                <bibl type="illustration">S. 152</bibl>

--- a/HGV_meta_EpiDoc/HGV383/382520.xml
+++ b/HGV_meta_EpiDoc/HGV383/382520.xml
@@ -109,6 +109,12 @@
                <bibl type="illustration">S. 131</bibl>
             </p>
          </div>
+         <div type="bibliography" subtype="otherPublications">
+           <head>Andere Publikation</head>
+           <listBibl>
+             <bibl type="publication" subtype="other">BASP 50 (2013), S. 54, Nr. 1</bibl>
+           </listBibl>
+         </div>
       </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV389/388511.xml
+++ b/HGV_meta_EpiDoc/HGV389/388511.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Ein Mietvertrag über ein Haus aus dem byzantinischen Hermopolites</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">388511</idno>
+        <idno type="TM">388511</idno>
+        <idno type="ddb-filename">tyche.29.101</idno>
+        <idno type="ddb-hybrid">tyche;29;101</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Vienna</settlement>
+            </placeName>
+            <collection>Nationalbibliothek</collection>
+            <idno type="invNo">P.Vindob. G 13458</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hermopolis (Hermopolites, Egypt)</origPlace>
+              <origDate notBefore="0501" notAfter="0600">VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/816 https://pleiades.stoa.org/places/756574">Hermopolis</placeName>
+                <placeName n="2" type="ancient" subtype="nome">Hermopolites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Mietvertrag</term>
+        <term n="2">Haus</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">29</biblScope>
+            <biblScope type="fascicle">(2014)</biblScope>
+            <biblScope type="pages">S. 101</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 4, 5</bibl>
+        </p>
+      </div>
+	  </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV700/699703.xml
+++ b/HGV_meta_EpiDoc/HGV700/699703.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Eine Nachtragsforderung bezüglich Datteln</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">699703</idno>
+        <idno type="TM">699703</idno>
+        <idno type="ddb-filename">tyche.30.28</idno>
+        <idno type="ddb-hybrid">tyche;30;28</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Vienna</settlement>
+            </placeName>
+            <collection>Nationalbibliothek</collection>
+            <idno type="invNo">P.Vindob. K 4712</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hermopolites</origPlace>
+              <origDate notBefore="0626" notAfter="0675" precision="low">Mitte VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2720 ">Hermopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">Aufteilung der Datteln</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">30</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 28</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 7, 8</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://data.onb.ac.at/rec/RZ00003985"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV700/699704.xml
+++ b/HGV_meta_EpiDoc/HGV700/699704.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Enteuxis Concerning Illegal Sale of Cedria</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">699704</idno>
+        <idno type="TM">699704</idno>
+        <idno type="ddb-filename">tyche.30.82</idno>
+        <idno type="ddb-hybrid">tyche;30;82</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Vienna</settlement>
+            </placeName>
+            <collection>Nationalbibliothek</collection>
+            <idno type="invNo">P.Vindob. G 60501</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhyncha ? (Arsinoites, Egypt)</origPlace>
+              <origDate notBefore="-0175" notAfter="-0126" precision="low">Mitte II v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1523 https://pleiades.stoa.org/places/741540">Oxyrhyncha</placeName>
+                <placeName n="2" type="ancient" subtype="nome">Arsinoites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Eingabe an den König</term>
+        <term n="2">Monopol</term>
+        <term n="3">Enteuxis</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">30</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 82</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 30</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV701/700731.xml
+++ b/HGV_meta_EpiDoc/HGV701/700731.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>An addendum to the fourth-century bishops of Oxyrhynchus?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">700731</idno>
+        <idno type="TM">700731</idno>
+        <idno type="ddb-filename">jjp.44.88</idno>
+        <idno type="ddb-hybrid">jjp;44;88</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Birmingham</settlement>
+            </placeName>
+            <collection>Cadbury Research Library</collection>
+            <idno type="invNo">P.Harris 317</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchus (Oxyrhynchites, Egypt)</origPlace>
+              <origDate notBefore="0351" notAfter="0400" precision="low">2. Hälfte IV</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchus</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="3" type="ancient" subtype="nome">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Bischof Dorotheus</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">44</biblScope>
+            <biblScope type="fascicle">(2014)</biblScope>
+            <biblScope type="pages">S. 88</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 89</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV701/700731.xml
+++ b/HGV_meta_EpiDoc/HGV701/700731.xml
@@ -86,6 +86,13 @@
           <bibl type="illustration">S. 89</bibl>
         </p>
       </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2014-t44/The_Journal_of_Juristic_Papyrology-r2014-t44-s83-91/The_Journal_of_Juristic_Papyrology-r2014-t44-s83-91.pdf"/>
+          </figure>
+        </p>
+      </div>
     </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV701/700732.xml
+++ b/HGV_meta_EpiDoc/HGV701/700732.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Address label for a parcel</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">700732</idno>
+        <idno type="TM">700732</idno>
+        <idno type="ddb-filename">jjp.44.119</idno>
+        <idno type="ddb-hybrid">jjp;44;119</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Naqlun</settlement>
+            </placeName>
+            <collection>Polish excavations </collection>
+            <idno type="invNo">no. Nd. 11.255</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Naqlun (Arsinoites, Egypt)</origPlace>
+              <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1418 https://pleiades.stoa.org/places/736975">Naqlun</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="3" type="ancient" subtype="nome">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Etickett</term>
+        <term n="2">Sansneus an Nikolaos</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">44</biblScope>
+            <biblScope type="fascicle">(2014)</biblScope>
+            <biblScope type="pages">S. 119</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 119</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV701/700732.xml
+++ b/HGV_meta_EpiDoc/HGV701/700732.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Naqlun</settlement>
+              <settlement>Naqlun</settlement>
             </placeName>
             <collection>Polish excavations </collection>
             <idno type="invNo">no. Nd. 11.255</idno>
@@ -59,12 +59,12 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Etickett</term>
-        <term n="2">Sansneus an Nikolaos</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Etickett</term>
+          <term n="2">Sansneus an Nikolaos</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -85,6 +85,13 @@
       <div type="bibliography" subtype="illustrations">
         <p>
           <bibl type="illustration">S. 119</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2014-t44/The_Journal_of_Juristic_Papyrology-r2014-t44-s117-131/The_Journal_of_Juristic_Papyrology-r2014-t44-s117-131.pdf"/>
+          </figure>
         </p>
       </div>
     </body>

--- a/HGV_meta_EpiDoc/HGV701/700733.xml
+++ b/HGV_meta_EpiDoc/HGV701/700733.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Naqlun</settlement>
+              <settlement>Naqlun</settlement>
             </placeName>
             <collection>Polish excavations </collection>
             <idno type="invNo">no. Nd. 11.375</idno>
@@ -59,12 +59,12 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Liste</term>
-        <term n="2">Namen</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+          <term n="2">Namen</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -85,6 +85,13 @@
       <div type="bibliography" subtype="illustrations">
         <p>
           <bibl type="illustration">S. 123</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2014-t44/The_Journal_of_Juristic_Papyrology-r2014-t44-s117-131/The_Journal_of_Juristic_Papyrology-r2014-t44-s117-131.pdf"/>
+          </figure>
         </p>
       </div>
     </body>

--- a/HGV_meta_EpiDoc/HGV701/700733.xml
+++ b/HGV_meta_EpiDoc/HGV701/700733.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of names</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">700733</idno>
+        <idno type="TM">700733</idno>
+        <idno type="ddb-filename">jjp.44.121</idno>
+        <idno type="ddb-hybrid">jjp;44;121</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Naqlun</settlement>
+            </placeName>
+            <collection>Polish excavations </collection>
+            <idno type="invNo">no. Nd. 11.375</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Naqlun (Arsinoites, Egypt)</origPlace>
+              <origDate notBefore="0501" notAfter="0600" cert="low" precision="low">VI (?)</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1418 https://pleiades.stoa.org/places/736975">Naqlun</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="3" type="ancient" subtype="nome">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Liste</term>
+        <term n="2">Namen</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">44</biblScope>
+            <biblScope type="fascicle">(2014)</biblScope>
+            <biblScope type="pages">S. 121</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 123</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV701/700734.xml
+++ b/HGV_meta_EpiDoc/HGV701/700734.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Left side of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">700734</idno>
+        <idno type="TM">700734</idno>
+        <idno type="ddb-filename">jjp.44.127</idno>
+        <idno type="ddb-hybrid">jjp;44;127</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Naqlun</settlement>
+            </placeName>
+            <collection>Polish excavations </collection>
+            <idno type="invNo">no. Nd. 11.379</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Naqlun (Arsinoites, Egypt)</origPlace>
+              <origDate notBefore="0501" notAfter="0600" cert="low" precision="low">VI (?)</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1418 https://pleiades.stoa.org/places/736975">Naqlun</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="3" type="ancient" subtype="nome">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">Fragment</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">44</biblScope>
+            <biblScope type="fascicle">(2014)</biblScope>
+            <biblScope type="pages">S. 127</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 128</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV701/700734.xml
+++ b/HGV_meta_EpiDoc/HGV701/700734.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Naqlun</settlement>
+              <settlement>Naqlun</settlement>
             </placeName>
             <collection>Polish excavations </collection>
             <idno type="invNo">no. Nd. 11.379</idno>
@@ -59,12 +59,12 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Brief</term>
-        <term n="2">Fragment</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -85,6 +85,13 @@
       <div type="bibliography" subtype="illustrations">
         <p>
           <bibl type="illustration">S. 128</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2014-t44/The_Journal_of_Juristic_Papyrology-r2014-t44-s117-131/The_Journal_of_Juristic_Papyrology-r2014-t44-s117-131.pdf"/>
+          </figure>
         </p>
       </div>
     </body>

--- a/HGV_meta_EpiDoc/HGV701/700735.xml
+++ b/HGV_meta_EpiDoc/HGV701/700735.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Naqlun</settlement>
+              <settlement>Naqlun</settlement>
             </placeName>
             <collection>Polish excavations </collection>
             <idno type="invNo">no. Nd. 11.384</idno>
@@ -59,15 +59,15 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Brief</term>
-        <term n="2">Fragment</term>
-        <term n="3">N.N. an apa Paulos</term>
-        <term n="4">Darlehen (?)</term>
-        <term n="5">Geld (?)</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+          <term n="3">N.N. an apa Paulos</term>
+          <term n="4">Darlehen (?)</term>
+          <term n="5">Geld (?)</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -88,6 +88,13 @@
       <div type="bibliography" subtype="illustrations">
         <p>
           <bibl type="illustration">S. 129</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2014-t44/The_Journal_of_Juristic_Papyrology-r2014-t44-s117-131/The_Journal_of_Juristic_Papyrology-r2014-t44-s117-131.pdf"/>
+          </figure>
         </p>
       </div>
     </body>

--- a/HGV_meta_EpiDoc/HGV701/700735.xml
+++ b/HGV_meta_EpiDoc/HGV701/700735.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter to apa Paulos regarding a loan?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">700735</idno>
+        <idno type="TM">700735</idno>
+        <idno type="ddb-filename">jjp.44.129</idno>
+        <idno type="ddb-hybrid">jjp;44;129</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Naqlun</settlement>
+            </placeName>
+            <collection>Polish excavations </collection>
+            <idno type="invNo">no. Nd. 11.384</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Naqlun (Arsinoites, Egypt)</origPlace>
+              <origDate notBefore="0501" notAfter="0600" cert="low" precision="low">VI (?)</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1418 https://pleiades.stoa.org/places/736975">Naqlun</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="3" type="ancient" subtype="nome">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">Fragment</term>
+        <term n="3">N.N. an apa Paulos</term>
+        <term n="4">Darlehen (?)</term>
+        <term n="5">Geld (?)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">44</biblScope>
+            <biblScope type="fascicle">(2014)</biblScope>
+            <biblScope type="pages">S. 129</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 129</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV704/703150.xml
+++ b/HGV_meta_EpiDoc/HGV704/703150.xml
@@ -104,6 +104,13 @@
                <bibl type="illustration">S. 186</bibl>
             </p>
          </div>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2015-t45/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227.pdf"/>
+             </figure>
+           </p>
+         </div>
       </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV704/703151.xml
+++ b/HGV_meta_EpiDoc/HGV704/703151.xml
@@ -121,6 +121,13 @@
                <bibl type="illustration">S. 189</bibl>
             </p>
          </div>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2015-t45/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227.pdf"/>
+             </figure>
+           </p>
+         </div>
       </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV704/703152.xml
+++ b/HGV_meta_EpiDoc/HGV704/703152.xml
@@ -104,6 +104,13 @@
                <bibl type="illustration">S. 191</bibl>
             </p>
          </div>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2015-t45/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227.pdf"/>
+             </figure>
+           </p>
+         </div>
       </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV704/703153.xml
+++ b/HGV_meta_EpiDoc/HGV704/703153.xml
@@ -112,7 +112,13 @@
                <bibl type="translations">S. 192</bibl>
             </listBibl>
          </div>
-         <div type="commentary" subtype="mentionedDates"/>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2015-t45/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227.pdf"/>
+             </figure>
+           </p>
+         </div>
       </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV704/703154.xml
+++ b/HGV_meta_EpiDoc/HGV704/703154.xml
@@ -107,6 +107,13 @@
                <bibl type="illustration">S. 195</bibl>
             </p>
          </div>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2015-t45/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227.pdf"/>
+             </figure>
+           </p>
+         </div>
       </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV704/703155.xml
+++ b/HGV_meta_EpiDoc/HGV704/703155.xml
@@ -109,6 +109,13 @@
                <bibl type="illustration">S. 197</bibl>
             </p>
          </div>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2015-t45/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227.pdf"/>
+             </figure>
+           </p>
+         </div>
       </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV704/703156.xml
+++ b/HGV_meta_EpiDoc/HGV704/703156.xml
@@ -107,6 +107,13 @@
                <bibl type="illustration">S. 199</bibl>
             </p>
          </div>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2015-t45/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227.pdf"/>
+             </figure>
+           </p>
+         </div>
       </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV704/703157.xml
+++ b/HGV_meta_EpiDoc/HGV704/703157.xml
@@ -125,6 +125,13 @@
                <bibl type="illustration">S. 201</bibl>
             </p>
          </div>
+         <div type="figure">
+           <p>
+             <figure n="1">
+               <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2015-t45/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227.pdf"/>
+             </figure>
+           </p>
+         </div>
       </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV704/703158.xml
+++ b/HGV_meta_EpiDoc/HGV704/703158.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Zahlungsanweisung des γραμματεὺς γεωργῶν Zoilos an den σιτολόγος Akousilaos</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">703158</idno>
+        <idno type="TM">703158</idno>
+        <idno type="ddb-filename">jjp.45.204</idno>
+        <idno type="ddb-hybrid">jjp;45;204</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Berkeley</settlement>
+            </placeName>
+            <collection>Bancroft Library</collection>
+            <idno type="invNo">Frag. Inv. 21412 j</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Bakhias (Arsinoites, Egypt)</origPlace>
+              <origDate when="-0011-11-11" cert="low">11. Nov. 11 v.Chr. (?)</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="http://www.trismegistos.org/place/392 https://pleiades.stoa.org/places/736896">Bakhias</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="3" type="ancient" subtype="nome">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Anweisung</term>
+        <term n="2">Zahlung</term>
+        <term n="3">Weizen</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">45</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 204</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 203</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV704/703158.xml
+++ b/HGV_meta_EpiDoc/HGV704/703158.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Berkeley</settlement>
+              <settlement>Berkeley</settlement>
             </placeName>
             <collection>Bancroft Library</collection>
             <idno type="invNo">Frag. Inv. 21412 j</idno>
@@ -59,13 +59,13 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Anweisung</term>
-        <term n="2">Zahlung</term>
-        <term n="3">Weizen</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Anweisung</term>
+          <term n="2">Zahlung</term>
+          <term n="3">Weizen</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -86,6 +86,13 @@
       <div type="bibliography" subtype="illustrations">
         <p>
           <bibl type="illustration">S. 203</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2015-t45/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227.pdf"/>
+          </figure>
         </p>
       </div>
     </body>

--- a/HGV_meta_EpiDoc/HGV704/703159.xml
+++ b/HGV_meta_EpiDoc/HGV704/703159.xml
@@ -88,6 +88,13 @@
           <bibl type="illustration">S. 206</bibl>
         </p>
       </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2015-t45/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227.pdf"/>
+          </figure>
+        </p>
+      </div>
     </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV704/703159.xml
+++ b/HGV_meta_EpiDoc/HGV704/703159.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Zahlungsanweisung des γραμματεὺς γεωργῶν Zoilos an den σιτολόγος Akousilaos</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">703159</idno>
+        <idno type="TM">703159</idno>
+        <idno type="ddb-filename">jjp.45.205</idno>
+        <idno type="ddb-hybrid">jjp;45;205</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Berkeley</settlement>
+            </placeName>
+            <collection>Bancroft Library</collection>
+            <idno type="invNo">Frag. Inv. 21412 k</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Bakhias (Arsinoites, Egypt)</origPlace>
+              <origDate when="-0011-11-11" cert="low">11. Nov. 11 v.Chr. (?)</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="http://www.trismegistos.org/place/392 https://pleiades.stoa.org/places/736896">Bakhias</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="3" type="ancient" subtype="nome">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Anweisung</term>
+        <term n="2">Zahlung</term>
+        <term n="3">Weizen</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">45</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 205</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 206</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV704/703160.xml
+++ b/HGV_meta_EpiDoc/HGV704/703160.xml
@@ -88,6 +88,13 @@
           <bibl type="illustration">S. 208</bibl>
         </p>
       </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2015-t45/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227/The_Journal_of_Juristic_Papyrology-r2015-t45-s165-227.pdf"/>
+          </figure>
+        </p>
+      </div>
     </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV704/703160.xml
+++ b/HGV_meta_EpiDoc/HGV704/703160.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Zahlungsanweisung des γραμματεὺς γεωργῶν Zoilos an den σιτολόγος Akousilaos</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">703160</idno>
+        <idno type="TM">703160</idno>
+        <idno type="ddb-filename">jjp.45.207</idno>
+        <idno type="ddb-hybrid">jjp;45;207</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Berkeley</settlement>
+            </placeName>
+            <collection>Bancroft Library</collection>
+            <idno type="invNo">Frag. Inv. 21412 l</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Bakhias (Arsinoites, Egypt)</origPlace>
+              <origDate when="-0011-11-12" cert="low">12. Nov. 11 v.Chr. (?)</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="http://www.trismegistos.org/place/392 https://pleiades.stoa.org/places/736896">Bakhias</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="3" type="ancient" subtype="nome">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Anweisung</term>
+        <term n="2">Zahlung</term>
+        <term n="3">Weizen</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">45</biblScope>
+            <biblScope type="fascicle">(2015)</biblScope>
+            <biblScope type="pages">S. 207</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 208</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV704/703288.xml
+++ b/HGV_meta_EpiDoc/HGV704/703288.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Un nouveau sauf-conduit du monastère d'Apa Jeremias à Saqqara?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">703288</idno>
+        <idno type="TM">703288</idno>
+        <idno type="ddb-filename">basp.53.236</idno>
+        <idno type="ddb-hybrid">basp;53;236</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New York</settlement>
+            </placeName>
+            <collection>Pierpont Morgan Library</collection>
+            <idno type="invNo">M 662 B 35e</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Saqqara ?</origPlace>
+              <origDate notBefore="0729-02" notAfter="0729-03">Febr. - März 729</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" cert="low" ref="http://www.trismegistos.org/place/1344 https://pleiades.stoa.org/places/796289136">Saqqara</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Bitte um Geleit</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">53</biblScope>
+            <biblScope type="fascicle">(2016)</biblScope>
+            <biblScope type="pages">S. 236</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 236</bibl>
+        </p>
+      </div>
+	<div type="figure">
+	  <p>
+         <figure n="1">
+             <graphic url="https://www.themorgan.org/manuscript/351280"/>
+          </figure>
+	  </p>
+	</div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV704/703289.xml
+++ b/HGV_meta_EpiDoc/HGV704/703289.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Sale with Postponed Delivery of Four irdabbs of Wheat</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">703289</idno>
+        <idno type="TM">703289</idno>
+        <idno type="ddb-filename">basp.53.244_1</idno>
+        <idno type="ddb-hybrid">basp;53;244_1</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Cambridge</settlement>
+            </placeName>
+            <collection>Cambridge University Library</collection>
+            <idno type="invNo">P.Cam.Michaelides B 718</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Egypt</origPlace>
+              <origDate notBefore="0801" notAfter="0900" precision="low">IX</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Lieferung</term>
+        <term n="2">Weizen</term>
+        <term n="3">Zahlung</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">53</biblScope>
+            <biblScope type="fascicle">(2016)</biblScope>
+            <biblScope type="pages">S. 244</biblScope>
+            <biblScope type="number">Nr. 1</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 245</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV704/703290.xml
+++ b/HGV_meta_EpiDoc/HGV704/703290.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Payment of One Thousand and Three Hundred Baskets of Trefoil as Rent</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">703290</idno>
+        <idno type="TM">703290</idno>
+        <idno type="ddb-filename">basp.53.247_2</idno>
+        <idno type="ddb-hybrid">basp;53;247_2</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Cambridge</settlement>
+            </placeName>
+            <collection>Cambridge University Library</collection>
+            <idno type="invNo">P.Cam.Michaelides B 118</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Egypt</origPlace>
+              <origDate when="0875">875</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Zahlung</term>
+        <term n="2">Miete</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">53</biblScope>
+            <biblScope type="fascicle">(2016)</biblScope>
+            <biblScope type="pages">S. 247</biblScope>
+            <biblScope type="number">Nr. 2</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 249</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV705/704979.xml
+++ b/HGV_meta_EpiDoc/HGV705/704979.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Paris</settlement>
+              <settlement>Paris</settlement>
             </placeName>
             <collection>Sorbonne</collection>
             <idno type="invNo">P.Sorb. inv. 2712 verso</idno>
@@ -57,13 +57,13 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Quittung</term>
-        <term n="2">Zahlung</term>
-        <term n="3">Miete</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Zahlung</term>
+          <term n="3">Miete</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -86,6 +86,9 @@
         <p>
           <bibl type="illustration">S. 161</bibl>
         </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite: BASP 54 (2017) S. 160 Nr. 1 recto.</p>
       </div>
     </body>
   </text>

--- a/HGV_meta_EpiDoc/HGV705/704979.xml
+++ b/HGV_meta_EpiDoc/HGV705/704979.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Reçu pour le règlement de quatre mois de loyer</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">704979</idno>
+        <idno type="TM">704979</idno>
+        <idno type="ddb-filename">basp.54.160_1v</idno>
+        <idno type="ddb-hybrid">basp;54;160_1v</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Paris</settlement>
+            </placeName>
+            <collection>Sorbonne</collection>
+            <idno type="invNo">P.Sorb. inv. 2712 verso</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Egypt</origPlace>
+              <origDate notBefore="0901" notAfter="1000" precision="low">X</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Zahlung</term>
+        <term n="3">Miete</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">54</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 160</biblScope>
+            <biblScope type="number">Nr. 1v</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 161</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV705/704980.xml
+++ b/HGV_meta_EpiDoc/HGV705/704980.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Compte</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">704980</idno>
+        <idno type="TM">704980</idno>
+        <idno type="ddb-filename">basp.54.160_1r</idno>
+        <idno type="ddb-hybrid">basp;54;160_1r</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Paris</settlement>
+            </placeName>
+            <collection>Sorbonne</collection>
+            <idno type="invNo">P.Sorb. inv. 2712 recto</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Egypt</origPlace>
+              <origDate notBefore="0901" notAfter="1000" precision="low">X</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Rechnung</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">54</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 160</biblScope>
+            <biblScope type="number">Nr. 1r</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 161</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV705/704980.xml
+++ b/HGV_meta_EpiDoc/HGV705/704980.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Paris</settlement>
+              <settlement>Paris</settlement>
             </placeName>
             <collection>Sorbonne</collection>
             <idno type="invNo">P.Sorb. inv. 2712 recto</idno>
@@ -57,11 +57,11 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Rechnung</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Rechnung</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -84,6 +84,9 @@
         <p>
           <bibl type="illustration">S. 161</bibl>
         </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite: BASP 54 (2017) S. 160 Nr. 1 verso.</p>
       </div>
     </body>
   </text>

--- a/HGV_meta_EpiDoc/HGV705/704981.xml
+++ b/HGV_meta_EpiDoc/HGV705/704981.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Paris</settlement>
+              <settlement>Paris</settlement>
             </placeName>
             <collection>Sorbonne</collection>
             <idno type="invNo">P.Sorb. inv. 2706 verso</idno>
@@ -57,13 +57,13 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Quittung</term>
-        <term n="2">Zahlung</term>
-        <term n="3">Miete</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Zahlung</term>
+          <term n="3">Miete</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -86,6 +86,9 @@
         <p>
           <bibl type="illustration">S. 165</bibl>
         </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite: BASP 54 (2017) S. 163 Nr. 2 recto.</p>
       </div>
     </body>
   </text>

--- a/HGV_meta_EpiDoc/HGV705/704981.xml
+++ b/HGV_meta_EpiDoc/HGV705/704981.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Reçu pour le règlement de trois mois de loyer</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">704981</idno>
+        <idno type="TM">704981</idno>
+        <idno type="ddb-filename">basp.54.163_2v</idno>
+        <idno type="ddb-hybrid">basp;54;163_2v</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Paris</settlement>
+            </placeName>
+            <collection>Sorbonne</collection>
+            <idno type="invNo">P.Sorb. inv. 2706 verso</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Egypt</origPlace>
+              <origDate notBefore="0908" notAfter="0909">908 - 909</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Quittung</term>
+        <term n="2">Zahlung</term>
+        <term n="3">Miete</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">54</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 163</biblScope>
+            <biblScope type="number">Nr. 2v</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 165</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV705/704982.xml
+++ b/HGV_meta_EpiDoc/HGV705/704982.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Contrat (?)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">704982</idno>
+        <idno type="TM">704982</idno>
+        <idno type="ddb-filename">basp.54.163_2r</idno>
+        <idno type="ddb-hybrid">basp;54;163_2r</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Paris</settlement>
+            </placeName>
+            <collection>Sorbonne</collection>
+            <idno type="invNo">P.Sorb. inv. 2706 recto</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Egypt</origPlace>
+              <origDate notAfter="0909">
+                <offset n="1" type="before">vor</offset>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Vertrag?</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">54</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 163</biblScope>
+            <biblScope type="number">Nr. 2r</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 163</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV705/704982.xml
+++ b/HGV_meta_EpiDoc/HGV705/704982.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Paris</settlement>
+              <settlement>Paris</settlement>
             </placeName>
             <collection>Sorbonne</collection>
             <idno type="invNo">P.Sorb. inv. 2706 recto</idno>
@@ -33,8 +33,7 @@
           <history>
             <origin>
               <origPlace>Egypt</origPlace>
-              <origDate notAfter="0909">
-                <offset n="1" type="before">vor</offset>
+              <origDate notBefore="0908" notAfter="0909">908 - 909</origDate>
             </origin>
             <provenance type="located">
               <p>
@@ -58,11 +57,11 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Vertrag?</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag?</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -85,6 +84,9 @@
         <p>
           <bibl type="illustration">S. 163</bibl>
         </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite: BASP 54 (2017) S. 163 Nr. 2 verso.</p>
       </div>
     </body>
   </text>

--- a/HGV_meta_EpiDoc/HGV769/768440.xml
+++ b/HGV_meta_EpiDoc/HGV769/768440.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>The Jews of Oxyrhynchus Address the Strategos of the Nome</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">768440</idno>
+        <idno type="TM">768440</idno>
+        <idno type="ddb-filename">jjp.47.32</idno>
+        <idno type="ddb-hybrid">jjp;47;32</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. 760</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchus (Oxyrhynchites, Egypt)</origPlace>
+              <origDate when="0309-08-17">17. Aug. 309</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchus</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="3" type="ancient" subtype="nome">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">Strategos (Aurelius Dioskourides alias Ioulianos)</term>
+        <term n="3">Steuer</term>
+        <term n="4">Juden</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 32</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 33</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2757477"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV769/768440.xml
+++ b/HGV_meta_EpiDoc/HGV769/768440.xml
@@ -94,6 +94,9 @@
           <figure n="1">
             <graphic url="http://hdl.handle.net/10079/digcoll/2757477"/>
           </figure>
+          <figure n="2">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s27-43/The_Journal_of_Juristic_Papyrology-r2017-t47-s27-43.pdf"/>
+          </figure>
         </p>
       </div>
     </body>

--- a/HGV_meta_EpiDoc/HGV784/783347.xml
+++ b/HGV_meta_EpiDoc/HGV784/783347.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Dispute about tax payment</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783347</idno>
+        <idno type="TM">783347</idno>
+        <idno type="ddb-filename">jjp.47.49_12</idno>
+        <idno type="ddb-hybrid">jjp;47;49_12</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 266</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">N.N. an N.N.</term>
+        <term n="3">Steuer</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 49</biblScope>
+            <biblScope type="number">Nr. 12</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 49</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783348.xml
+++ b/HGV_meta_EpiDoc/HGV784/783348.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Request for help from Koïre to apa Paulos</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783348</idno>
+        <idno type="TM">783348</idno>
+        <idno type="ddb-filename">jjp.47.53_13</idno>
+        <idno type="ddb-hybrid">jjp;47;53_13</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 300</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">Koïre an apa Paulos</term>
+        <term n="3">Schlichtung</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 53</biblScope>
+            <biblScope type="number">Nr. 13</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 53, 54</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783349.xml
+++ b/HGV_meta_EpiDoc/HGV784/783349.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Request for intercession</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783349</idno>
+        <idno type="TM">783349</idno>
+        <idno type="ddb-filename">jjp.47.56_14</idno>
+        <idno type="ddb-hybrid">jjp;47;56_14</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 034</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">N.N. an N.N.</term>
+        <term n="3">Bitte um Fürbitte</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 56</biblScope>
+            <biblScope type="number">Nr. 14</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 56</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783350.xml
+++ b/HGV_meta_EpiDoc/HGV784/783350.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Request for clothing for poor people</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783350</idno>
+        <idno type="TM">783350</idno>
+        <idno type="ddb-filename">jjp.47.58_15</idno>
+        <idno type="ddb-hybrid">jjp;47;58_15</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 041</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">N.N. an N.N.</term>
+        <term n="3">Schutz der Mutter und ihrer Kinder</term>
+        <term n="4">Kleidung</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 58</biblScope>
+            <biblScope type="number">Nr. 15</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 58</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783351.xml
+++ b/HGV_meta_EpiDoc/HGV784/783351.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter about books</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783351</idno>
+        <idno type="TM">783351</idno>
+        <idno type="ddb-filename">jjp.47.61_16</idno>
+        <idno type="ddb-hybrid">jjp;47;61_16</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 042</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">Isak an N.N.</term>
+        <term n="3">ein Buch kopieren</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 61</biblScope>
+            <biblScope type="number">Nr. 16</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 61</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783352.xml
+++ b/HGV_meta_EpiDoc/HGV784/783352.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter mentioning a book</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783352</idno>
+        <idno type="TM">783352</idno>
+        <idno type="ddb-filename">jjp.47.62_17</idno>
+        <idno type="ddb-hybrid">jjp;47;62_17</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (?)</term>
+          <term n="2">Buch</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 62</biblScope>
+            <biblScope type="number">Nr. 17</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 62</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783353.xml
+++ b/HGV_meta_EpiDoc/HGV784/783353.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragmentary letter about books</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783353</idno>
+        <idno type="TM">783353</idno>
+        <idno type="ddb-filename">jjp.47.62_18</idno>
+        <idno type="ddb-hybrid">jjp;47;62_18</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 308</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (?)</term>
+          <term n="2">Buch</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 62</biblScope>
+            <biblScope type="number">Nr. 18</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 62</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783354.xml
+++ b/HGV_meta_EpiDoc/HGV784/783354.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter about books</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783354</idno>
+        <idno type="TM">783354</idno>
+        <idno type="ddb-filename">jjp.47.63_19</idno>
+        <idno type="ddb-hybrid">jjp;47;63_19</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 004</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">N.N. an N.N.</term>
+          <term n="3">Schäfer</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 63</biblScope>
+            <biblScope type="number">Nr. 19</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 63</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783355.xml
+++ b/HGV_meta_EpiDoc/HGV784/783355.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter to a priest</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783355</idno>
+        <idno type="TM">783355</idno>
+        <idno type="ddb-filename">jjp.47.64_20</idno>
+        <idno type="ddb-hybrid">jjp;47;64_20</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 002</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">N.N. an N.N.</term>
+          <term n="3">Priester</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 64</biblScope>
+            <biblScope type="number">Nr. 20</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 64, 65</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783356.xml
+++ b/HGV_meta_EpiDoc/HGV784/783356.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783356</idno>
+        <idno type="TM">783356</idno>
+        <idno type="ddb-filename">jjp.47.66_21</idno>
+        <idno type="ddb-hybrid">jjp;47;66_21</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 294</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 66</biblScope>
+            <biblScope type="number">Nr. 21</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 66, 67</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783357.xml
+++ b/HGV_meta_EpiDoc/HGV784/783357.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter to an anchorite</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783357</idno>
+        <idno type="TM">783357</idno>
+        <idno type="ddb-filename">jjp.47.68_22</idno>
+        <idno type="ddb-hybrid">jjp;47;68_22</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 028</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Bitte um Gebet</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 68</biblScope>
+            <biblScope type="number">Nr. 22</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 68</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783358.xml
+++ b/HGV_meta_EpiDoc/HGV784/783358.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Request for prayer</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783358</idno>
+        <idno type="TM">783358</idno>
+        <idno type="ddb-filename">jjp.47.69_23</idno>
+        <idno type="ddb-hybrid">jjp;47;69_23</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 067</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Bitte um Gebet</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 69</biblScope>
+            <biblScope type="number">Nr. 23</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 69</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783359.xml
+++ b/HGV_meta_EpiDoc/HGV784/783359.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Request for mercy and prayer</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783359</idno>
+        <idno type="TM">783359</idno>
+        <idno type="ddb-filename">jjp.47.70_24</idno>
+        <idno type="ddb-hybrid">jjp;47;70_24</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 123</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Bitte um Gebet</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 70</biblScope>
+            <biblScope type="number">Nr. 24</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 70</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783360.xml
+++ b/HGV_meta_EpiDoc/HGV784/783360.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter with a request for prayer</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783360</idno>
+        <idno type="TM">783360</idno>
+        <idno type="ddb-filename">jjp.47.71_25</idno>
+        <idno type="ddb-hybrid">jjp;47;71_25</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 064</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Bitte um Gebet</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 71</biblScope>
+            <biblScope type="number">Nr. 25</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 71</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783361.xml
+++ b/HGV_meta_EpiDoc/HGV784/783361.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Request for incense and grapes</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783361</idno>
+        <idno type="TM">783361</idno>
+        <idno type="ddb-filename">jjp.47.72_26</idno>
+        <idno type="ddb-hybrid">jjp;47;72_26</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 107</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Bitte um Weihrauch und Trauben</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 72</biblScope>
+            <biblScope type="number">Nr. 26</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 72</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783362.xml
+++ b/HGV_meta_EpiDoc/HGV784/783362.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter mentioning corn</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783362</idno>
+        <idno type="TM">783362</idno>
+        <idno type="ddb-filename">jjp.47.73_27</idno>
+        <idno type="ddb-hybrid">jjp;47;73_27</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 069</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 73</biblScope>
+            <biblScope type="number">Nr. 27</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 73</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783363.xml
+++ b/HGV_meta_EpiDoc/HGV784/783363.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Request for a knife</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783363</idno>
+        <idno type="TM">783363</idno>
+        <idno type="ddb-filename">jjp.47.74_28</idno>
+        <idno type="ddb-hybrid">jjp;47;74_28</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 147</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Messer</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 74</biblScope>
+            <biblScope type="number">Nr. 28</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 74</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783364.xml
+++ b/HGV_meta_EpiDoc/HGV784/783364.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter about ropes?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783364</idno>
+        <idno type="TM">783364</idno>
+        <idno type="ddb-filename">jjp.47.75_29</idno>
+        <idno type="ddb-hybrid">jjp;47;75_29</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 337</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Seil (?)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 75</biblScope>
+            <biblScope type="number">Nr. 29</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 75</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783365.xml
+++ b/HGV_meta_EpiDoc/HGV784/783365.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter requesting people or goods</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783365</idno>
+        <idno type="TM">783365</idno>
+        <idno type="ddb-filename">jjp.47.76_30</idno>
+        <idno type="ddb-hybrid">jjp;47;76_30</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 022d</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Anfrage</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 76</biblScope>
+            <biblScope type="number">Nr. 30</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 76</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783366.xml
+++ b/HGV_meta_EpiDoc/HGV784/783366.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Request for a personal meeting</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783366</idno>
+        <idno type="TM">783366</idno>
+        <idno type="ddb-filename">jjp.47.77_31</idno>
+        <idno type="ddb-hybrid">jjp;47;77_31</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 222 + 252</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Anfrage</term>
+          <term n="3">Treffen</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 77</biblScope>
+            <biblScope type="number">Nr. 31</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 77</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783367.xml
+++ b/HGV_meta_EpiDoc/HGV784/783367.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Beginning of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783367</idno>
+        <idno type="TM">783367</idno>
+        <idno type="ddb-filename">jjp.47.77_32</idno>
+        <idno type="ddb-hybrid">jjp;47;77_32</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 119 + 254</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 77</biblScope>
+            <biblScope type="number">Nr. 32</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 77</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783368.xml
+++ b/HGV_meta_EpiDoc/HGV784/783368.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Beginning of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783368</idno>
+        <idno type="TM">783368</idno>
+        <idno type="ddb-filename">jjp.47.78_33</idno>
+        <idno type="ddb-hybrid">jjp;47;78_33</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 275 + 299</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 78</biblScope>
+            <biblScope type="number">Nr. 33</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 78</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783369.xml
+++ b/HGV_meta_EpiDoc/HGV784/783369.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Beginning of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783369</idno>
+        <idno type="TM">783369</idno>
+        <idno type="ddb-filename">jjp.47.79_34</idno>
+        <idno type="ddb-hybrid">jjp;47;79_34</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 062</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 79</biblScope>
+            <biblScope type="number">Nr. 34</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 79</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783370.xml
+++ b/HGV_meta_EpiDoc/HGV784/783370.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Beginning of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783370</idno>
+        <idno type="TM">783370</idno>
+        <idno type="ddb-filename">jjp.47.79_35</idno>
+        <idno type="ddb-hybrid">jjp;47;79_35</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 071y</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 79</biblScope>
+            <biblScope type="number">Nr. 35</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 79</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783371.xml
+++ b/HGV_meta_EpiDoc/HGV784/783371.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Beginning of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783371</idno>
+        <idno type="TM">783371</idno>
+        <idno type="ddb-filename">jjp.47.80_36</idno>
+        <idno type="ddb-hybrid">jjp;47;80_36</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 087</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 80</biblScope>
+            <biblScope type="number">Nr. 36</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 80</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783372.xml
+++ b/HGV_meta_EpiDoc/HGV784/783372.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Beginning of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783372</idno>
+        <idno type="TM">783372</idno>
+        <idno type="ddb-filename">jjp.47.80_37</idno>
+        <idno type="ddb-hybrid">jjp;47;80_37</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 225</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 80</biblScope>
+            <biblScope type="number">Nr. 37</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 80</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783373.xml
+++ b/HGV_meta_EpiDoc/HGV784/783373.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Beginning of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783373</idno>
+        <idno type="TM">783373</idno>
+        <idno type="ddb-filename">jjp.47.81_38</idno>
+        <idno type="ddb-hybrid">jjp;47;81_38</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 271</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 81</biblScope>
+            <biblScope type="number">Nr. 38</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 81</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783374.xml
+++ b/HGV_meta_EpiDoc/HGV784/783374.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Beginning of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783374</idno>
+        <idno type="TM">783374</idno>
+        <idno type="ddb-filename">jjp.47.82_39</idno>
+        <idno type="ddb-hybrid">jjp;47;82_39</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 279</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 82</biblScope>
+            <biblScope type="number">Nr. 39</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 82</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783375.xml
+++ b/HGV_meta_EpiDoc/HGV784/783375.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783375</idno>
+        <idno type="TM">783375</idno>
+        <idno type="ddb-filename">jjp.47.83_40</idno>
+        <idno type="ddb-hybrid">jjp;47;83_40</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 021</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Vieh</term>
+          <term n="3">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 83</biblScope>
+            <biblScope type="number">Nr. 40</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 83</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783376.xml
+++ b/HGV_meta_EpiDoc/HGV784/783376.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783376</idno>
+        <idno type="TM">783376</idno>
+        <idno type="ddb-filename">jjp.47.83_41</idno>
+        <idno type="ddb-hybrid">jjp;47;83_41</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 045</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 83</biblScope>
+            <biblScope type="number">Nr. 41</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 83</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783377.xml
+++ b/HGV_meta_EpiDoc/HGV784/783377.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783377</idno>
+        <idno type="TM">783377</idno>
+        <idno type="ddb-filename">jjp.47.84_42</idno>
+        <idno type="ddb-hybrid">jjp;47;84_42</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 047</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 84</biblScope>
+            <biblScope type="number">Nr. 42</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 84</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783378.xml
+++ b/HGV_meta_EpiDoc/HGV784/783378.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783378</idno>
+        <idno type="TM">783378</idno>
+        <idno type="ddb-filename">jjp.47.85_43</idno>
+        <idno type="ddb-hybrid">jjp;47;85_43</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 055</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 85</biblScope>
+            <biblScope type="number">Nr. 43</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 85</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783379.xml
+++ b/HGV_meta_EpiDoc/HGV784/783379.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783379</idno>
+        <idno type="TM">783379</idno>
+        <idno type="ddb-filename">jjp.47.85_44</idno>
+        <idno type="ddb-hybrid">jjp;47;85_44</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 065</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 85</biblScope>
+            <biblScope type="number">Nr. 44</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 85</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783380.xml
+++ b/HGV_meta_EpiDoc/HGV784/783380.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783380</idno>
+        <idno type="TM">783380</idno>
+        <idno type="ddb-filename">jjp.47.86_45</idno>
+        <idno type="ddb-hybrid">jjp;47;86_45</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 156</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 86</biblScope>
+            <biblScope type="number">Nr. 45</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 86</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783381.xml
+++ b/HGV_meta_EpiDoc/HGV784/783381.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783381</idno>
+        <idno type="TM">783381</idno>
+        <idno type="ddb-filename">jjp.47.86_46</idno>
+        <idno type="ddb-hybrid">jjp;47;86_46</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 255</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 86</biblScope>
+            <biblScope type="number">Nr. 46</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 86</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783382.xml
+++ b/HGV_meta_EpiDoc/HGV784/783382.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783382</idno>
+        <idno type="TM">783382</idno>
+        <idno type="ddb-filename">jjp.47.87_47</idno>
+        <idno type="ddb-hybrid">jjp;47;87_47</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 259</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 87</biblScope>
+            <biblScope type="number">Nr. 47</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 87</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783383.xml
+++ b/HGV_meta_EpiDoc/HGV784/783383.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter to Markos</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783383</idno>
+        <idno type="TM">783383</idno>
+        <idno type="ddb-filename">jjp.47.88_48</idno>
+        <idno type="ddb-hybrid">jjp;47;88_48</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 262 + 285</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">N.N. an Markos</term>
+          <term n="3">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 88</biblScope>
+            <biblScope type="number">Nr. 48</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 88</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783384.xml
+++ b/HGV_meta_EpiDoc/HGV784/783384.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783384</idno>
+        <idno type="TM">783384</idno>
+        <idno type="ddb-filename">jjp.47.88_49</idno>
+        <idno type="ddb-hybrid">jjp;47;88_49</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 284</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 88</biblScope>
+            <biblScope type="number">Nr. 49</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 88</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783385.xml
+++ b/HGV_meta_EpiDoc/HGV784/783385.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783385</idno>
+        <idno type="TM">783385</idno>
+        <idno type="ddb-filename">jjp.47.89_50</idno>
+        <idno type="ddb-hybrid">jjp;47;89_50</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 044</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 89</biblScope>
+            <biblScope type="number">Nr. 50</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 89</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783386.xml
+++ b/HGV_meta_EpiDoc/HGV784/783386.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783386</idno>
+        <idno type="TM">783386</idno>
+        <idno type="ddb-filename">jjp.47.90_51</idno>
+        <idno type="ddb-hybrid">jjp;47;90_51</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 046</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Entwurf (?)</term>
+          <term n="3">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 90</biblScope>
+            <biblScope type="number">Nr. 51</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 90</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783387.xml
+++ b/HGV_meta_EpiDoc/HGV784/783387.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783387</idno>
+        <idno type="TM">783387</idno>
+        <idno type="ddb-filename">jjp.47.91_52</idno>
+        <idno type="ddb-hybrid">jjp;47;91_52</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 195</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 91</biblScope>
+            <biblScope type="number">Nr. 52</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 91</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783388.xml
+++ b/HGV_meta_EpiDoc/HGV784/783388.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragmentary letter </title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783388</idno>
+        <idno type="TM">783388</idno>
+        <idno type="ddb-filename">jjp.47.91_53</idno>
+        <idno type="ddb-hybrid">jjp;47;91_53</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 126</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 91</biblScope>
+            <biblScope type="number">Nr. 53</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 91</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783389.xml
+++ b/HGV_meta_EpiDoc/HGV784/783389.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783389</idno>
+        <idno type="TM">783389</idno>
+        <idno type="ddb-filename">jjp.47.92_54</idno>
+        <idno type="ddb-hybrid">jjp;47;92_54</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 036</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 92</biblScope>
+            <biblScope type="number">Nr. 54</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 92</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783390.xml
+++ b/HGV_meta_EpiDoc/HGV784/783390.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783390</idno>
+        <idno type="TM">783390</idno>
+        <idno type="ddb-filename">jjp.47.92_55</idno>
+        <idno type="ddb-hybrid">jjp;47;92_55</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 040</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Anfrage (?)</term>
+          <term n="3">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 92</biblScope>
+            <biblScope type="number">Nr. 55</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 92</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783391.xml
+++ b/HGV_meta_EpiDoc/HGV784/783391.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragmentary letter </title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783391</idno>
+        <idno type="TM">783391</idno>
+        <idno type="ddb-filename">jjp.47.93_56</idno>
+        <idno type="ddb-hybrid">jjp;47;93_56</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 061</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 93</biblScope>
+            <biblScope type="number">Nr. 56</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 93</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783392.xml
+++ b/HGV_meta_EpiDoc/HGV784/783392.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783392</idno>
+        <idno type="TM">783392</idno>
+        <idno type="ddb-filename">jjp.47.93_57</idno>
+        <idno type="ddb-hybrid">jjp;47;93_57</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 071x</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 93</biblScope>
+            <biblScope type="number">Nr. 57</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 93</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783393.xml
+++ b/HGV_meta_EpiDoc/HGV784/783393.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783393</idno>
+        <idno type="TM">783393</idno>
+        <idno type="ddb-filename">jjp.47.94_58</idno>
+        <idno type="ddb-hybrid">jjp;47;94_58</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 089</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 94</biblScope>
+            <biblScope type="number">Nr. 58</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 94</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783394.xml
+++ b/HGV_meta_EpiDoc/HGV784/783394.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragmentary letter </title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783394</idno>
+        <idno type="TM">783394</idno>
+        <idno type="ddb-filename">jjp.47.94_59</idno>
+        <idno type="ddb-hybrid">jjp;47;94_59</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 129</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 94</biblScope>
+            <biblScope type="number">Nr. 59</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 94</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783395.xml
+++ b/HGV_meta_EpiDoc/HGV784/783395.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783395</idno>
+        <idno type="TM">783395</idno>
+        <idno type="ddb-filename">jjp.47.95_60</idno>
+        <idno type="ddb-hybrid">jjp;47;95_60</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 165</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Flachs</term>
+          <term n="3">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 95</biblScope>
+            <biblScope type="number">Nr. 60</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 95</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783396.xml
+++ b/HGV_meta_EpiDoc/HGV784/783396.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783396</idno>
+        <idno type="TM">783396</idno>
+        <idno type="ddb-filename">jjp.47.95_61</idno>
+        <idno type="ddb-hybrid">jjp;47;95_61</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 173</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 95</biblScope>
+            <biblScope type="number">Nr. 61</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 95</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783397.xml
+++ b/HGV_meta_EpiDoc/HGV784/783397.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783397</idno>
+        <idno type="TM">783397</idno>
+        <idno type="ddb-filename">jjp.47.96_62</idno>
+        <idno type="ddb-hybrid">jjp;47;96_62</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 181</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 96</biblScope>
+            <biblScope type="number">Nr. 62</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 96</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783398.xml
+++ b/HGV_meta_EpiDoc/HGV784/783398.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783398</idno>
+        <idno type="TM">783398</idno>
+        <idno type="ddb-filename">jjp.47.96_63</idno>
+        <idno type="ddb-hybrid">jjp;47;96_63</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 184</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 96</biblScope>
+            <biblScope type="number">Nr. 63</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 96</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783399.xml
+++ b/HGV_meta_EpiDoc/HGV784/783399.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragmentary letter?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783399</idno>
+        <idno type="TM">783399</idno>
+        <idno type="ddb-filename">jjp.47.97_64</idno>
+        <idno type="ddb-hybrid">jjp;47;97_64</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 242</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 97</biblScope>
+            <biblScope type="number">Nr. 64</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 97</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783400.xml
+++ b/HGV_meta_EpiDoc/HGV784/783400.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragmentary letter?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783400</idno>
+        <idno type="TM">783400</idno>
+        <idno type="ddb-filename">jjp.47.97_65</idno>
+        <idno type="ddb-hybrid">jjp;47;97_65</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 280</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 97</biblScope>
+            <biblScope type="number">Nr. 65</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 97</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783401.xml
+++ b/HGV_meta_EpiDoc/HGV784/783401.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragmentary letter?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783401</idno>
+        <idno type="TM">783401</idno>
+        <idno type="ddb-filename">jjp.47.98_66</idno>
+        <idno type="ddb-hybrid">jjp;47;98_66</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 281</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 98</biblScope>
+            <biblScope type="number">Nr. 66</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 98</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783402.xml
+++ b/HGV_meta_EpiDoc/HGV784/783402.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783402</idno>
+        <idno type="TM">783402</idno>
+        <idno type="ddb-filename">jjp.47.98_67</idno>
+        <idno type="ddb-hybrid">jjp;47;98_67</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 295</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 98</biblScope>
+            <biblScope type="number">Nr. 67</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 98</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783403.xml
+++ b/HGV_meta_EpiDoc/HGV784/783403.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783403</idno>
+        <idno type="TM">783403</idno>
+        <idno type="ddb-filename">jjp.47.99_68</idno>
+        <idno type="ddb-hybrid">jjp;47;99_68</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Luxor</settlement>
+            </placeName>
+            <collection>MMA 1152</collection>
+            <idno type="invNo">Polish excavations 2003-2013, inv. no. C.O. 315</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Ta Memnoneia (Hermonthites)</origPlace>
+              <origPlace>Ta Memnoneia (Egypt)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0501" notAfter="0550" precision="low">1. Hälfte VI</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0701" notAfter="0750" precision="low">1. Hälfte VIII</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 http://pleiades.stoa.org/places/786067">Ta Memnoneia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2981">Hermonthites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-10-03" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 99</biblScope>
+            <biblScope type="number">Nr. 68</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 99</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100/The_Journal_of_Juristic_Papyrology-r2017-t47-s45-100.pdf"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783404.xml
+++ b/HGV_meta_EpiDoc/HGV784/783404.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter to Elias from Samuel</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783404</idno>
+        <idno type="TM">783404</idno>
+        <idno type="ddb-filename">jjp.47.104_1</idno>
+        <idno type="ddb-hybrid">jjp;47;104_1</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">O.Uppsala VM 1085</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oberägypten ? (Egypt)</origPlace>
+              <origDate notBefore="0601" notAfter="0625" precision="low">Anfang VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2766 ">Oberägypten</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">Elias an Samuel</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 104</biblScope>
+            <biblScope type="number">Nr. 1</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 104</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783404.xml
+++ b/HGV_meta_EpiDoc/HGV784/783404.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Uppsala</settlement>
+              <settlement>Uppsala</settlement>
             </placeName>
             <collection>Victoria Museum</collection>
             <idno type="invNo">O.Uppsala VM 1085</idno>
@@ -58,12 +58,12 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Brief</term>
-        <term n="2">Elias an Samuel</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Elias an Samuel</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -85,6 +85,13 @@
       <div type="bibliography" subtype="illustrations">
         <p>
           <bibl type="illustration">S. 104</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s101-115/The_Journal_of_Juristic_Papyrology-r2017-t47-s101-115.pdf"/>
+          </figure>
         </p>
       </div>
     </body>

--- a/HGV_meta_EpiDoc/HGV784/783405.xml
+++ b/HGV_meta_EpiDoc/HGV784/783405.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter about the appointment of a shepherd</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783405</idno>
+        <idno type="TM">783405</idno>
+        <idno type="ddb-filename">jjp.47.108_2</idno>
+        <idno type="ddb-hybrid">jjp;47;108_2</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">O.Uppsala VM 1487</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oberägypten ? (Egypt)</origPlace>
+              <origDate notBefore="0601" notAfter="0625" precision="low">Anfang VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2766 ">Oberägypten</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">Schäfer</term>
+        <term n="3">Geld</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 108</biblScope>
+            <biblScope type="number">Nr. 2</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 108</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783405.xml
+++ b/HGV_meta_EpiDoc/HGV784/783405.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Uppsala</settlement>
+              <settlement>Uppsala</settlement>
             </placeName>
             <collection>Victoria Museum</collection>
             <idno type="invNo">O.Uppsala VM 1487</idno>
@@ -58,13 +58,13 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Brief</term>
-        <term n="2">Schäfer</term>
-        <term n="3">Geld</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Schäfer</term>
+          <term n="3">Geld</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -86,6 +86,13 @@
       <div type="bibliography" subtype="illustrations">
         <p>
           <bibl type="illustration">S. 108</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s101-115/The_Journal_of_Juristic_Papyrology-r2017-t47-s101-115.pdf"/>
+          </figure>
         </p>
       </div>
     </body>

--- a/HGV_meta_EpiDoc/HGV784/783406.xml
+++ b/HGV_meta_EpiDoc/HGV784/783406.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter about a delivery</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">783406</idno>
+        <idno type="TM">783406</idno>
+        <idno type="ddb-filename">jjp.47.113_3</idno>
+        <idno type="ddb-hybrid">jjp;47;113_3</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Uppsala</settlement>
+            </placeName>
+            <collection>Victoria Museum</collection>
+            <idno type="invNo">O.Uppsala VM 2397</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oberägypten ? (Egypt)</origPlace>
+              <origDate notBefore="0501" notAfter="0800" precision="low">VI - VIII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2766 ">Oberägypten</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Brief</term>
+        <term n="2">Lieferung von Getriede (?)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">47</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 113</biblScope>
+            <biblScope type="number">Nr. 3</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 113</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV784/783406.xml
+++ b/HGV_meta_EpiDoc/HGV784/783406.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Uppsala</settlement>
+              <settlement>Uppsala</settlement>
             </placeName>
             <collection>Victoria Museum</collection>
             <idno type="invNo">O.Uppsala VM 2397</idno>
@@ -58,12 +58,12 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Brief</term>
-        <term n="2">Lieferung von Getriede (?)</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Lieferung von Getriede (?)</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -85,6 +85,13 @@
       <div type="bibliography" subtype="illustrations">
         <p>
           <bibl type="illustration">S. 113</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2017-t47/The_Journal_of_Juristic_Papyrology-r2017-t47-s101-115/The_Journal_of_Juristic_Papyrology-r2017-t47-s101-115.pdf"/>
+          </figure>
         </p>
       </div>
     </body>

--- a/HGV_meta_EpiDoc/HGV829/828778.xml
+++ b/HGV_meta_EpiDoc/HGV829/828778.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Tbilisi</settlement>
+              <settlement>Tbilisi</settlement>
             </placeName>
             <collection>Kekelidze Institut</collection>
             <idno type="invNo">P.Tbilisi inv. 344 Vo</idno>
@@ -59,13 +59,13 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Grundbuch</term>
-        <term n="2">Register</term>
-        <term n="3">Parzellen</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Grundbuch</term>
+          <term n="2">Register</term>
+          <term n="3">Parzellen</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -87,6 +87,9 @@
         <p>
           <bibl type="illustration">Pl. 2</bibl>
         </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite: P.Ross.Georg. V 25.</p>
       </div>
     </body>
   </text>

--- a/HGV_meta_EpiDoc/HGV829/828778.xml
+++ b/HGV_meta_EpiDoc/HGV829/828778.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Extract from Memphite Land Register</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">828778</idno>
+        <idno type="TM">828778</idno>
+        <idno type="ddb-filename">tyche.33.46</idno>
+        <idno type="ddb-hybrid">tyche;33;46</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Tbilisi</settlement>
+            </placeName>
+            <collection>Kekelidze Institut</collection>
+            <idno type="invNo">P.Tbilisi inv. 344 Vo</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Taie (Memphites, Egypt)</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2227 ">Taie</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="3" type="ancient" subtype="nome">Memphites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Grundbuch</term>
+        <term n="2">Register</term>
+        <term n="3">Parzellen</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">33</biblScope>
+            <biblScope type="fascicle">(2018)</biblScope>
+            <biblScope type="pages">S. 46</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 2</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832104.xml
+++ b/HGV_meta_EpiDoc/HGV833/832104.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Ein griechischer Lieferungskauf über Schilfrohr aus dem spätantiken Hermopolites</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832104</idno>
+        <idno type="TM">832104</idno>
+        <idno type="ddb-filename">tyche.32.76</idno>
+        <idno type="ddb-hybrid">tyche;32;76</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Vienna</settlement>
+            </placeName>
+            <collection>Nationalbibliothek</collection>
+            <idno type="invNo">P.Vindob. G 20657</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hermopolis (Hermopolites, Egypt)</origPlace>
+              <origDate notBefore="0601" notAfter="0650" precision="low">1. Hälfte VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/816 https://pleiades.stoa.org/places/756574">Hermopolis</placeName>
+                <placeName n="2" type="ancient" subtype="nome">Hermopolites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Vertrag</term>
+        <term n="2">Lieferungskauf</term>
+        <term n="3">Kauf</term>
+        <term n="4">Schilfrohr</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">32</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 76</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 78, Pl. 15</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://data.onb.ac.at/rec/RZ00016564"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832105.xml
+++ b/HGV_meta_EpiDoc/HGV833/832105.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Gestellungsbürgschaft </title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832105</idno>
+        <idno type="TM">832105</idno>
+        <idno type="ddb-filename">tyche.32.87_1</idno>
+        <idno type="ddb-hybrid">tyche;32;87_1</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Vienna</settlement>
+            </placeName>
+            <collection>Nationalbibliothek</collection>
+            <idno type="invNo">P.Vindob. G 25640</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolites, Egypt</origPlace>
+              <origDate notBefore="0551" notAfter="0600" precision="low">2. Hälfte VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Vertrag</term>
+        <term n="2">Unterschrift (Notar)</term>
+        <term n="3">Bürgschaft</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">32</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 87</biblScope>
+            <biblScope type="number">Nr. 1</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 84, 85, Pl. 16</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://data.onb.ac.at/rec/RZ00009739"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832106.xml
+++ b/HGV_meta_EpiDoc/HGV833/832106.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Notarsunterschrift des Elias</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832106</idno>
+        <idno type="TM">832106</idno>
+        <idno type="ddb-filename">tyche.32.91_2</idno>
+        <idno type="ddb-hybrid">tyche;32;91_2</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Vienna</settlement>
+            </placeName>
+            <collection>Nationalbibliothek</collection>
+            <idno type="invNo">P.Vindob. G 41128</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolites, Egypt</origPlace>
+              <origDate notBefore="0551" notAfter="0600" precision="low">2. Hälfte VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Unterschrift (Notar)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">32</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 91</biblScope>
+            <biblScope type="number">Nr. 2</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 85, Pl. 17</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://data.onb.ac.at/rec/RZ00016569"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832107.xml
+++ b/HGV_meta_EpiDoc/HGV833/832107.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Notarsunterschrift des Pseeios</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832107</idno>
+        <idno type="TM">832107</idno>
+	 <idno type="ddb-filename">tyche.32.92_3</idno>
+        <idno type="ddb-hybrid">tyche;32;92_3</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Vienna</settlement>
+            </placeName>
+            <collection>Nationalbibliothek</collection>
+            <idno type="invNo">P.Vindob. G 16535</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolites, Egypt</origPlace>
+              <origDate notBefore="0551" notAfter="0600" precision="low">2. Hälfte VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Unterschrift (Notar)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">32</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 92</biblScope>
+            <biblScope type="number">Nr. 3</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 85, Pl. 17</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://data.onb.ac.at/rec/RZ00016109"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832108.xml
+++ b/HGV_meta_EpiDoc/HGV833/832108.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Eine griechische Gestellungsbürgschaft aus dem spätantiken Herakleopolis</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832108</idno>
+        <idno type="TM">832108</idno>
+        <idno type="ddb-filename">tyche.32.94</idno>
+        <idno type="ddb-hybrid">tyche;32;94</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Vienna</settlement>
+            </placeName>
+            <collection>Nationalbibliothek</collection>
+            <idno type="invNo">P.Vindob. G 20649</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolis ? (Egypt)</origPlace>
+              <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" cert="low" ref="https://www.trismegistos.org/place/801 https://pleiades.stoa.org/places/736920">Herakleopolis</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Vertrag</term>
+        <term n="2">Unterschrift (Notar)</term>
+        <term n="3">Bürgschaft</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">32</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 94</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 18</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://data.onb.ac.at/rec/RZ00009631"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832109.xml
+++ b/HGV_meta_EpiDoc/HGV833/832109.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Befehlsschreiben des Pagarchen Apa Kyros</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832109</idno>
+        <idno type="TM">832109</idno>
+        <idno type="ddb-filename">tyche.32.120</idno>
+        <idno type="ddb-hybrid">tyche;32;120</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Vienna</settlement>
+            </placeName>
+            <collection>Nationalbibliothek</collection>
+            <idno type="invNo">P.Vindob. G 39718</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolites, Egypt</origPlace>
+              <origDate notBefore="0640" notAfter="0725">640 - 725</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Entagion</term>
+        <term n="2">Arbeiter</term>
+        <term n="3">Aufforderung zur Zahlung </term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">32</biblScope>
+            <biblScope type="fascicle">(2017)</biblScope>
+            <biblScope type="pages">S. 120</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 19, 20</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://data.onb.ac.at/rec/RZ00010238"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832287.xml
+++ b/HGV_meta_EpiDoc/HGV833/832287.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Ann Arbor</settlement>
+              <settlement>Ann Arbor</settlement>
             </placeName>
             <collection>University of Michigan Library</collection>
             <idno type="invNo">P.Mich. inv. 975 recto</idno>
@@ -57,13 +57,13 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Dokument</term>
-        <term n="2">Gymnasium</term>
-        <term n="3">Bautätigkeit (?)</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Dokument</term>
+          <term n="2">Gymnasium</term>
+          <term n="3">Bautätigkeit (?)</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -92,6 +92,9 @@
             <graphic url="https://quod.lib.umich.edu/a/apis/x-5606"/>
           </figure>
         </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite: BASP 56 (2019) S. 122.</p>
       </div>
     </body>
   </text>

--- a/HGV_meta_EpiDoc/HGV833/832287.xml
+++ b/HGV_meta_EpiDoc/HGV833/832287.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>New Evidence for the Circular Gymnasium and the City Fund in Antinoopolis</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832287</idno>
+        <idno type="TM">832287</idno>
+        <idno type="ddb-filename">basp.56.120</idno>
+        <idno type="ddb-hybrid">basp;56;120</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Ann Arbor</settlement>
+            </placeName>
+            <collection>University of Michigan Library</collection>
+            <idno type="invNo">P.Mich. inv. 975 recto</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Antinoopolis</origPlace>
+              <origDate when="0263" precision="medium">ca. 263</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="http://www.trismegistos.org/place/2774 https://pleiades.stoa.org/places/756518">Antinoopolis</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Dokument</term>
+        <term n="2">Gymnasium</term>
+        <term n="3">Bautätigkeit (?)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 120</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 121</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="https://quod.lib.umich.edu/a/apis/x-5606"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832321.xml
+++ b/HGV_meta_EpiDoc/HGV833/832321.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Roster?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832321</idno>
+        <idno type="TM">832321</idno>
+        <idno type="ddb-filename">basp.56.100</idno>
+        <idno type="ddb-hybrid">basp;56;100</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. DP 121</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+        <term n="2">Dienstplan (?)</term>
+        <term n="3">Militär (?)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 100</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 98, 99</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+         <figure n="1">
+             <graphic url="http://hdl.handle.net/10079/digcoll/2771868"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832325.xml
+++ b/HGV_meta_EpiDoc/HGV833/832325.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Roster?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832325</idno>
+        <idno type="TM">832325</idno>
+        <idno type="ddb-filename">basp.56.103_4</idno>
+        <idno type="ddb-hybrid">basp;56;103_4</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. DP 16 fr. 2 recto</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+        <term n="2">Dienstplan (?)</term>
+        <term n="3">Militär (?)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 103</biblScope>
+            <biblScope type="number">Nr. 4</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 104</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832326.xml
+++ b/HGV_meta_EpiDoc/HGV833/832326.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>keiner</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832326</idno>
+        <idno type="TM">832326</idno>
+        <idno type="ddb-filename">basp.56.103_5</idno>
+        <idno type="ddb-hybrid">basp;56;103_5</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. DP 16 fr. 3 recto</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0212" notAfter="0230">212 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 103</biblScope>
+            <biblScope type="number">Nr. 5</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 104</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832327.xml
+++ b/HGV_meta_EpiDoc/HGV833/832327.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>keiner</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832327</idno>
+        <idno type="TM">832327</idno>
+        <idno type="ddb-filename">basp.56.103_6</idno>
+        <idno type="ddb-hybrid">basp;56;103_6</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. DP 16 fr. 1 verso</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 103</biblScope>
+            <biblScope type="number">Nr. 6</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 104</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832328.xml
+++ b/HGV_meta_EpiDoc/HGV833/832328.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>keiner</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832328</idno>
+        <idno type="TM">832328</idno>
+        <idno type="ddb-filename">basp.56.104_7</idno>
+        <idno type="ddb-hybrid">basp;56;104_7</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. s.n. (box 3, folder 1)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 104</biblScope>
+            <biblScope type="number">Nr. 7</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 105</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832329.xml
+++ b/HGV_meta_EpiDoc/HGV833/832329.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>keiner</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832329</idno>
+        <idno type="TM">832329</idno>
+        <idno type="ddb-filename">basp.56.105_8</idno>
+        <idno type="ddb-hybrid">basp;56;105_8</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. s.n. (box 3, folder 2)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 105</biblScope>
+            <biblScope type="number">Nr. 8</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 106</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832330.xml
+++ b/HGV_meta_EpiDoc/HGV833/832330.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Acta diurna?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832330</idno>
+        <idno type="TM">832330</idno>
+        <idno type="ddb-filename">basp.56.107_9</idno>
+        <idno type="ddb-hybrid">basp;56;107_9</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. s.n. (box 3, folder 3)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+        <term n="2">Truppentagebuch</term>
+        <term n="3">Militär (?)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 107</biblScope>
+            <biblScope type="number">Nr. 9</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 107</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832331.xml
+++ b/HGV_meta_EpiDoc/HGV833/832331.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>keiner</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832331</idno>
+        <idno type="TM">832331</idno>
+        <idno type="ddb-filename">basp.56.108_10</idno>
+        <idno type="ddb-hybrid">basp;56;108_10</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. s.n. (box 3, folder 4, fr. 1)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0225">200 - 225</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 108</biblScope>
+            <biblScope type="number">Nr. 10</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 108</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832332.xml
+++ b/HGV_meta_EpiDoc/HGV833/832332.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>keiner</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832332</idno>
+        <idno type="TM">832332</idno>
+        <idno type="ddb-filename">basp.56.108_11</idno>
+        <idno type="ddb-hybrid">basp;56;108_11</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. s.n. (box 3, folder 4, fr. 2)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 108</biblScope>
+            <biblScope type="number">Nr. 11</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 108</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832333.xml
+++ b/HGV_meta_EpiDoc/HGV833/832333.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>keiner</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832333</idno>
+        <idno type="TM">832333</idno>
+        <idno type="ddb-filename">basp.56.109_12</idno>
+        <idno type="ddb-hybrid">basp;56;109_12</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. s.n. (box 3, folder 5, fr. 4)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 109</biblScope>
+            <biblScope type="number">Nr. 12</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 109</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832334.xml
+++ b/HGV_meta_EpiDoc/HGV833/832334.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>keiner</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832334</idno>
+        <idno type="TM">832334</idno>
+        <idno type="ddb-filename">basp.56.109_13</idno>
+        <idno type="ddb-hybrid">basp;56;109_13</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. s.n. (box 3, folder 6, fr. 3)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 109</biblScope>
+            <biblScope type="number">Nr. 13</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 109</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832335.xml
+++ b/HGV_meta_EpiDoc/HGV833/832335.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>keiner</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832335</idno>
+        <idno type="TM">832335</idno>
+        <idno type="ddb-filename">basp.56.110_14</idno>
+        <idno type="ddb-hybrid">basp;56;110_14</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. s.n. (box 3, folder 6, fr. 4)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+        <term n="2">Militär (?)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 110</biblScope>
+            <biblScope type="number">Nr. 14</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 110</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832336.xml
+++ b/HGV_meta_EpiDoc/HGV833/832336.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Roster?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832336</idno>
+        <idno type="TM">832336</idno>
+        <idno type="ddb-filename">basp.56.111_15</idno>
+        <idno type="ddb-hybrid">basp;56;111_15</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. s.n. (box 3, folder 6, fr. 10)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+        <term n="2">Dienstplan (?)</term>
+        <term n="3">Militär (?)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 111</biblScope>
+            <biblScope type="number">Nr. 15</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 111, 112</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832337.xml
+++ b/HGV_meta_EpiDoc/HGV833/832337.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Roster?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832337</idno>
+        <idno type="TM">832337</idno>
+        <idno type="ddb-filename">basp.56.113_16</idno>
+        <idno type="ddb-hybrid">basp;56;113_16</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. s.n. (box 3, folder 7, fr. 1)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0220" notAfter="0256">220 - 256</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+        <term n="2">Dienstplan (?)</term>
+        <term n="3">Militär (?)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 113</biblScope>
+            <biblScope type="number">Nr. 16</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 113, 114</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832338.xml
+++ b/HGV_meta_EpiDoc/HGV833/832338.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Acta diurna?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832338</idno>
+        <idno type="TM">832338</idno>
+        <idno type="ddb-filename">basp.56.114_17</idno>
+        <idno type="ddb-hybrid">basp;56;114_17</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR inv. s.n. (box 3, folder 7, fr. 8)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Dura - Europos</origPlace>
+              <origDate notBefore="0200" notAfter="0230">200 - 230</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/604 https://pleiades.stoa.org/places/893990">Dura - Europos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Fragment</term>
+        <term n="2">Truppentagebuch</term>
+        <term n="3">Militär (?)</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 114</biblScope>
+            <biblScope type="number">Nr. 17</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 114</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832339.xml
+++ b/HGV_meta_EpiDoc/HGV833/832339.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of measures of grain</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832339</idno>
+        <idno type="TM">832339</idno>
+        <idno type="ddb-filename">basp.56.122</idno>
+        <idno type="ddb-hybrid">basp;56;122</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Ann Arbor</settlement>
+            </placeName>
+            <collection>University of Michigan Library</collection>
+            <idno type="invNo">P.Mich. inv. 975 verso</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Antinoopolis</origPlace>
+              <origDate when="0263" precision="medium">ca. 263</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="http://www.trismegistos.org/place/2774 https://pleiades.stoa.org/places/756518">Antinoopolis</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Rechnung</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 122</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 122</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="https://quod.lib.umich.edu/a/apis/x-5607"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV833/832339.xml
+++ b/HGV_meta_EpiDoc/HGV833/832339.xml
@@ -91,6 +91,9 @@
           </figure>
         </p>
       </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite: BASP 56 (2019) S. 120.</p>
+      </div>
     </body>
   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV833/832342.xml
+++ b/HGV_meta_EpiDoc/HGV833/832342.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Order from the Comes Phoibammon for Payment to a Locksmith</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">832342</idno>
+        <idno type="TM">832342</idno>
+        <idno type="ddb-filename">basp.56.142</idno>
+        <idno type="ddb-hybrid">basp;56;142</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>St. Louis</settlement>
+            </placeName>
+            <collection>Washington University</collection>
+            <idno type="invNo">P.Wash.Univ. inv. 385</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchus (Oxyrhynchites, Egypt)</origPlace>
+              <origDate when="0495-05-27">27. Mai 495</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchus</placeName>
+                <placeName n="2" type="ancient" subtype="nome">Oxyrhynchites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Auftrag</term>
+        <term n="2">Schlosser</term>
+        <term n="3">Zahlungsaufforderung</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">56</biblScope>
+            <biblScope type="fascicle">(2019)</biblScope>
+            <biblScope type="pages">S. 142</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 142</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV84/83729.xml
+++ b/HGV_meta_EpiDoc/HGV84/83729.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Die christusliebende Thebais</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">87349</idno>
+        <idno type="TM">87349</idno>
+        <idno type="ddb-filename">tyche.29.27_2</idno>
+        <idno type="ddb-hybrid">tyche;29;27_2</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Manchester</settlement>
+            </placeName>
+            <collection>John Rylands Library</collection>
+            <idno type="invNo">P.Ryl.Copt. 175</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hermopolis (Hermopolites, Egypt)</origPlace>
+              <origDate notBefore="0787" notAfter="0788">787 - 788</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/816 https://pleiades.stoa.org/places/756574">Hermopolis</placeName>
+                <placeName n="2" type="ancient" subtype="nome">Hermopolites</placeName>
+                <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Mietvertrag</term>
+        <term n="2">Nachlass</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-29" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Tyche</title>
+            <biblScope type="volume">29</biblScope>
+            <biblScope type="fascicle">(2014)</biblScope>
+            <biblScope type="pages">S. 27</biblScope>
+            <biblScope type="number">Nr. 2</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration"></bibl>
+        </p>
+      </div>
+      <div type="bibliography" subtype="otherPublications">
+        <head>Andere Publikation</head>
+        <listBibl>
+          <bibl type="publication" subtype="other">P.Ryl.Copt. 175</bibl>
+        </listBibl>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="https://luna.manchester.ac.uk/luna/servlet/detail/ManchesterDev~93~3~55199~203137"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV873/872950.xml
+++ b/HGV_meta_EpiDoc/HGV873/872950.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A name tag on a piece of Late Roman Amphora</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">872950</idno>
+        <idno type="TM">872950</idno>
+        <idno type="ddb-filename">jjp.46.6</idno>
+        <idno type="ddb-hybrid">jjp;46;6</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Gießen</settlement>
+            </placeName>
+            <collection>Universitätsbibliothek</collection>
+            <idno type="invNo">O.Giss. Inv. 537</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Thebes ? (Egypt)</origPlace>
+              <origDate notBefore="0376" notAfter="0700" precision="low">Ende IV - VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" cert="low" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Thebes</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Etickett</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">JJP</title>
+            <biblScope type="volume">46</biblScope>
+            <biblScope type="fascicle">(2016)</biblScope>
+            <biblScope type="pages">S. 6</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 3</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="https://www.papyrusportal.de/receive/GiePapyri_schrift_00012090"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV873/872950.xml
+++ b/HGV_meta_EpiDoc/HGV873/872950.xml
@@ -16,7 +16,7 @@
         <msDesc>
           <msIdentifier>
             <placeName>
-               <settlement>Gießen</settlement>
+              <settlement>Gießen</settlement>
             </placeName>
             <collection>Universitätsbibliothek</collection>
             <idno type="invNo">O.Giss. Inv. 537</idno>
@@ -58,11 +58,11 @@
         <language ident="la">Latein</language>
         <language ident="el">Griechisch</language>
       </langUsage>
-    <textClass>
-      <keywords scheme="hgv">
-        <term n="1">Etickett</term>
-      </keywords>
-    </textClass>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Etickett</term>
+        </keywords>
+      </textClass>
     </profileDesc>
     <revisionDesc>
       <change when="2021-09-30" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
@@ -89,6 +89,9 @@
         <p>
           <figure n="1">
             <graphic url="https://www.papyrusportal.de/receive/GiePapyri_schrift_00012090"/>
+          </figure>
+          <figure n="2">
+            <graphic url="http://bazhum.muzhp.pl/media/files/The_Journal_of_Juristic_Papyrology/The_Journal_of_Juristic_Papyrology-r2016-t46/The_Journal_of_Juristic_Papyrology-r2016-t46-s1-7/The_Journal_of_Juristic_Papyrology-r2016-t46-s1-7.pdf"/>
           </figure>
         </p>
       </div>

--- a/HGV_meta_EpiDoc/HGV99/98008.xml
+++ b/HGV_meta_EpiDoc/HGV99/98008.xml
@@ -98,7 +98,7 @@
       <div type="figure">
         <p>
          <figure n="1">
-             <graphic url="https://dpg.lib.berkeley.edu/webdb/apis/apis2?invno=&ucinvno=1053&sort=Author_Title&item=2"/>
+             <graphic url="https://dpg.lib.berkeley.edu/webdb/apis/apis2?invno=&amp;ucinvno=1053&amp;sort=Author_Title&amp;item=2"/>
           </figure>
         </p>
       </div>

--- a/HGV_meta_EpiDoc/HGV99/98008.xml
+++ b/HGV_meta_EpiDoc/HGV99/98008.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Register with Measurements of Land</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">98008</idno>
+        <idno type="TM">98008</idno>
+        <idno type="ddb-filename">basp.51.7</idno>
+        <idno type="ddb-hybrid">basp;51;7</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Berkeley</settlement>
+            </placeName>
+            <collection>Bancroft Library</collection>
+            <idno type="invNo">P.Tebt.UC. inv. 1053 + 1055 + 2063 + 2077</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fundort: Tebtunis (Arsinoites, Egypt)</origPlace>
+              <origDate notBefore="-0125" notAfter="-0101" precision="low">Ende II v.Chr.</origDate>
+            </origin>
+            <provenance type="found">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome">Arsinoites</placeName>
+                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="3" type="ancient" ref="http://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">Tebtunis</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Landvermessungen</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2021-09-27" who="http://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">51</biblScope>
+            <biblScope type="fascicle">(2014)</biblScope>
+            <biblScope type="pages">S. 7</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration"></bibl>
+        </p>
+      </div>
+      <div type="bibliography" subtype="otherPublications">
+        <head>Andere Publikation</head>
+        <listBibl>
+          <bibl type="publication" subtype="other">P.Tebt. 3.2 899 descr.</bibl>
+        </listBibl>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Descr.</p>
+      </div>
+      <div type="figure">
+        <p>
+         <figure n="1">
+             <graphic url="https://dpg.lib.berkeley.edu/webdb/apis/apis2?invno=&ucinvno=1053&sort=Author_Title&item=2"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
This series of commits Xwalks metadata to HGV for various BASP, Tyche, and JJP volumes. I've been careful to add HGV commentary re: Rückseite and descr., have updated APIS entries with the new idnos where applicable, and have included links to open access articles in JJP.

It may be wise to wait until PN sync is fully functioning again before merging the pull. 