### PR TITLE
Princeton APIS images

### DIFF
--- a/APIS/princeton/xml/princeton.apis.p1.xml
+++ b/APIS/princeton/xml/princeton.apis.p1.xml
@@ -80,6 +80,9 @@
          <div type="figure">
             <p>
                <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/sb397c77k"/>
+               </figure>
+               <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p1"/>
                </figure>
             </p>

--- a/APIS/princeton/xml/princeton.apis.p10.xml
+++ b/APIS/princeton/xml/princeton.apis.p10.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+           <p>
+             <figure>
+               <graphic url="https://dpul.princeton.edu/papyri/catalog/5t34sp071"/>
+             </figure>
+           </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p103.xml
+++ b/APIS/princeton/xml/princeton.apis.p103.xml
@@ -81,11 +81,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/s7526g009"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/v405sd890"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p103"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p104.xml
+++ b/APIS/princeton/xml/princeton.apis.p104.xml
@@ -67,6 +67,13 @@
                <bibl>Unpublished</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/7m01bq20w"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p105.xml
+++ b/APIS/princeton/xml/princeton.apis.p105.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/g732dc58n"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k643b4691"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p106.xml
+++ b/APIS/princeton/xml/princeton.apis.p106.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8049g856j"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p109.xml
+++ b/APIS/princeton/xml/princeton.apis.p109.xml
@@ -71,8 +71,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p109"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/fj236559n"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p109"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p11.xml
+++ b/APIS/princeton/xml/princeton.apis.p11.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/05741v29d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/5d86p3730"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p111.xml
+++ b/APIS/princeton/xml/princeton.apis.p111.xml
@@ -80,11 +80,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/9880vt57d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/gt54kr53p"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p111"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p113.xml
+++ b/APIS/princeton/xml/princeton.apis.p113.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/x059c9913"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/m039k842d"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p114.xml
+++ b/APIS/princeton/xml/princeton.apis.p114.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/x059c9913"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/qn59q734m"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p115.xml
+++ b/APIS/princeton/xml/princeton.apis.p115.xml
@@ -68,8 +68,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p115"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/4t64gr69s"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p115"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p116.xml
+++ b/APIS/princeton/xml/princeton.apis.p116.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/g158bk878"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1r66j463m"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p118.xml
+++ b/APIS/princeton/xml/princeton.apis.p118.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/t435gj456"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p123.xml
+++ b/APIS/princeton/xml/princeton.apis.p123.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/bn999b070"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/qz20sw84x"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p124.xml
+++ b/APIS/princeton/xml/princeton.apis.p124.xml
@@ -76,11 +76,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/zw12z788d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1831cp46c"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p124"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p126.xml
+++ b/APIS/princeton/xml/princeton.apis.p126.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/pc289m666"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/h702q989c"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p127.xml
+++ b/APIS/princeton/xml/princeton.apis.p127.xml
@@ -79,11 +79,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/sb397b845"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/vd66w324q"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p127"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p129.xml
+++ b/APIS/princeton/xml/princeton.apis.p129.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/jh343x746"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p13.xml
+++ b/APIS/princeton/xml/princeton.apis.p13.xml
@@ -83,6 +83,13 @@
                <bibl type="ddbdp">P.Oxy.:11:1371</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+           <p>
+             <figure>
+               <graphic url="https://dpul.princeton.edu/papyri/catalog/ht24wn94f"/>
+             </figure>
+           </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p130.xml
+++ b/APIS/princeton/xml/princeton.apis.p130.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/gx41mm45d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/nc580r16w"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p134.xml
+++ b/APIS/princeton/xml/princeton.apis.p134.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/tx31qp154"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p136.xml
+++ b/APIS/princeton/xml/princeton.apis.p136.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hq37vs09m"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p138.xml
+++ b/APIS/princeton/xml/princeton.apis.p138.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/bc386m81f"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/fj236560r"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p14.xml
+++ b/APIS/princeton/xml/princeton.apis.p14.xml
@@ -84,8 +84,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p14"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ks65hg724"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p14"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p141.xml
+++ b/APIS/princeton/xml/princeton.apis.p141.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/f7623g17w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/vt150n763"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p142.xml
+++ b/APIS/princeton/xml/princeton.apis.p142.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/b2773z272"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bg257j571"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p145.xml
+++ b/APIS/princeton/xml/princeton.apis.p145.xml
@@ -86,7 +86,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/5m60qv503"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8910jz08r"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p146.xml
+++ b/APIS/princeton/xml/princeton.apis.p146.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/h989r5793"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8910jz08r"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p147.xml
+++ b/APIS/princeton/xml/princeton.apis.p147.xml
@@ -82,51 +82,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <head>Recto :: 0 :: 12 kb image</head>
-                  <figDesc> </figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=12&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=12&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=12&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=12&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=12&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Recto :: 0 :: 12 kb image</head>
-                  <figDesc> 12</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=12&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Recto :: 0 :: 768 kb image</head>
-                  <figDesc> </figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=150&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=150&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=150&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=150&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=150&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Recto :: 0 :: 768 kb image</head>
-                  <figDesc> 150</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=150&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Recto :: 0 :: 2728 kb image</head>
-                  <figDesc> </figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=300&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=300&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=300&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=300&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=300&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Recto :: 0 :: 2728 kb image</head>
-                  <figDesc> 300</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=300&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Recto :: 0 :: 220 kb image</head>
-                  <figDesc> </figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=75&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=75&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=75&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=75&amp;face=f&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=75&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Recto :: 0 :: 220 kb image</head>
-                  <figDesc> 75</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147&amp;size=75&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/hh63sz49m"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/qv33s115f"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p147"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p148.xml
+++ b/APIS/princeton/xml/princeton.apis.p148.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ws859k17m"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p149.xml
+++ b/APIS/princeton/xml/princeton.apis.p149.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/c247dw598"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p15.xml
+++ b/APIS/princeton/xml/princeton.apis.p15.xml
@@ -82,8 +82,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p15"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/rb68xg36g"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p15"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p150.xml
+++ b/APIS/princeton/xml/princeton.apis.p150.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/xp68kk72r"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p151.xml
+++ b/APIS/princeton/xml/princeton.apis.p151.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2f75rc532"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p153.xml
+++ b/APIS/princeton/xml/princeton.apis.p153.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/dn39x504x"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p157.xml
+++ b/APIS/princeton/xml/princeton.apis.p157.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/h128nk16c"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p159.xml
+++ b/APIS/princeton/xml/princeton.apis.p159.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ms35tf09p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p16.xml
+++ b/APIS/princeton/xml/princeton.apis.p16.xml
@@ -83,8 +83,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p16"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2j62s8367"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p16"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p166.xml
+++ b/APIS/princeton/xml/princeton.apis.p166.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/w9505494b"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p17.xml
+++ b/APIS/princeton/xml/princeton.apis.p17.xml
@@ -78,8 +78,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p17"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/x346d7685"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p17"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p172.xml
+++ b/APIS/princeton/xml/princeton.apis.p172.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/12579x73f"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p173.xml
+++ b/APIS/princeton/xml/princeton.apis.p173.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/z316q605b"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p176.xml
+++ b/APIS/princeton/xml/princeton.apis.p176.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/4t64gs64s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p177.xml
+++ b/APIS/princeton/xml/princeton.apis.p177.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/h128nk16c"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p179.xml
+++ b/APIS/princeton/xml/princeton.apis.p179.xml
@@ -68,8 +68,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p179"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1g05fg10h"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p179"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p18.xml
+++ b/APIS/princeton/xml/princeton.apis.p18.xml
@@ -79,8 +79,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p18"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/00000352z"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p18"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p180.xml
+++ b/APIS/princeton/xml/princeton.apis.p180.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/fx719q974"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p184.xml
+++ b/APIS/princeton/xml/princeton.apis.p184.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/nc580r16w"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p189.xml
+++ b/APIS/princeton/xml/princeton.apis.p189.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/wh246w652"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p19.xml
+++ b/APIS/princeton/xml/princeton.apis.p19.xml
@@ -82,8 +82,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p19"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/b8515r89z"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p19"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p190.xml
+++ b/APIS/princeton/xml/princeton.apis.p190.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/xp68km66n"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p194.xml
+++ b/APIS/princeton/xml/princeton.apis.p194.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/xp68km66n"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p2.xml
+++ b/APIS/princeton/xml/princeton.apis.p2.xml
@@ -1,77 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
-      <fileDesc>
-         <titleStmt>
-            <title>Biblical Text</title>
-            <author>St James</author>
-         </titleStmt>
-         <publicationStmt>
-            <authority>APIS</authority>
-            <idno type="apisid">princeton.apis.p2</idno>
-            <idno type="controlNo">(NjP)apis.p0002</idno>
-            <idno type="dclp">61622</idno>
-            <idno type="TM">61622</idno>
-            <idno type="dclp-hybrid">p.princ;2;15</idno>
-         </publicationStmt>
-         <sourceDesc>
-            <msDesc>
-               <msIdentifier>
-                  <idno type="invNo">GD 7742</idno>
-               </msIdentifier>
-               <msContents>
-                  <summary>Epistle of St. James, ii.16-18, 22, 24-25, iii.2-4</summary>
-                  <msItemStruct>
-                     <note type="general">Written on both sides of the papyrus</note>
-                     <note type="general">Frag. (a) 8 lines recto, 7 lines verso; frag. (b) 7 lines recto, 7 lines verso; broken except at top</note>
-                     <note type="general">Written in a good-sized uncial hand</note>
-                     <textLang mainLang="grc">In Greek</textLang>
-                  </msItemStruct>
-               </msContents>
-               <physDesc>
-                  <objectDesc>
-                     <supportDesc>
-                        <support>2 papyrus fragments; (a) 8.7 x 6.5; (b) 6 x 6.5 cm</support>
-                     </supportDesc>
-                  </objectDesc>
-               </physDesc>
-               <history>
-                  <origin>
-                     <origDate notBefore="0400" notAfter="0499">Vth c. AD</origDate>
-                     <origPlace>From Oxyrhynchus</origPlace>
-                  </origin>
-               </history>
-            </msDesc>
-         </sourceDesc>
-      </fileDesc>
-      <encodingDesc>
-         <classDecl>
-            <taxonomy xml:id="apis">
-               <desc>APIS keywords are controlled locally at the institution level. They are not necessarily consistent.</desc>
-            </taxonomy>
-         </classDecl>
-      </encodingDesc>
-      <profileDesc>
-         <langUsage>
-            <language ident="en">English</language>
-            <language ident="grc">In Greek</language>
-         </langUsage>
-         <textClass>
-            <keywords scheme="#apis">
-               <term type="genre_form">Papyri</term>
-               <term type="genre_form">Papyri</term>
-            </keywords>
-         </textClass>
-      </profileDesc>
-   </teiHeader>
-   <text>
-      <body>
-         <div type="bibliography" subtype="citations">
-            <listBibl>
-               <bibl>P.Princ. II 15</bibl>
-            </listBibl>
-         </div>
-      </body>
-   </text>
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Biblical Text</title>
+        <author>St James</author>
+      </titleStmt>
+      <publicationStmt>
+        <authority>APIS</authority>
+        <idno type="apisid">princeton.apis.p2</idno>
+        <idno type="controlNo">(NjP)apis.p0002</idno>
+        <idno type="dclp">61622</idno>
+        <idno type="TM">61622</idno>
+        <idno type="dclp-hybrid">p.princ;2;15</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <idno type="invNo">GD 7742</idno>
+          </msIdentifier>
+          <msContents>
+            <summary>Epistle of St. James, ii.16-18, 22, 24-25, iii.2-4</summary>
+            <msItemStruct>
+              <note type="general">Written on both sides of the papyrus</note>
+              <note type="general">Frag. (a) 8 lines recto, 7 lines verso; frag. (b) 7 lines recto, 7 lines verso; broken except at top</note>
+              <note type="general">Written in a good-sized uncial hand</note>
+              <textLang mainLang="grc">In Greek</textLang>
+            </msItemStruct>
+          </msContents>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>2 papyrus fragments; (a) 8.7 x 6.5; (b) 6 x 6.5 cm</support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origDate notBefore="0400" notAfter="0499">Vth c. AD</origDate>
+              <origPlace>From Oxyrhynchus</origPlace>
+            </origin>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy xml:id="apis">
+          <desc>APIS keywords are controlled locally at the institution level. They are not necessarily consistent.</desc>
+        </taxonomy>
+      </classDecl>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="en">English</language>
+        <language ident="grc">In Greek</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="#apis">
+          <term type="genre_form">Papyri</term>
+          <term type="genre_form">Papyri</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="citations">
+        <listBibl>
+          <bibl>P.Princ. II 15</bibl>
+        </listBibl>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://dpul.princeton.edu/papyri/catalog/qv33s116x"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p20.xml
+++ b/APIS/princeton/xml/princeton.apis.p20.xml
@@ -78,6 +78,13 @@
                <bibl type="ddbdp">P.Oxy.:6:876</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+           <p>
+             <figure>
+               <graphic url="https://dpul.princeton.edu/papyri/catalog/v692t972m"/>
+             </figure>
+           </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p201.xml
+++ b/APIS/princeton/xml/princeton.apis.p201.xml
@@ -12,6 +12,7 @@
             <idno type="controlNo">(NjP)apis.p0201</idno>
             <idno type="HGV">14032</idno>
             <idno type="TM">14032</idno>
+            <idno type="ddb-hybrid">p.princ.roll;;2nded</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
@@ -74,7 +75,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/1v53k0579"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6969z428f"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p202.xml
+++ b/APIS/princeton/xml/princeton.apis.p202.xml
@@ -69,8 +69,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p202"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cz30px17d"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p202"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p205.xml
+++ b/APIS/princeton/xml/princeton.apis.p205.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/p5547t965"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/xg94ht053"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p206.xml
+++ b/APIS/princeton/xml/princeton.apis.p206.xml
@@ -76,11 +76,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/c821gn377"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/tt44pr36g"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p206"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p207.xml
+++ b/APIS/princeton/xml/princeton.apis.p207.xml
@@ -84,7 +84,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/s4655k180"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/qf85nf80j"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p208.xml
+++ b/APIS/princeton/xml/princeton.apis.p208.xml
@@ -79,11 +79,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/r494vn76g"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/qz20sx019"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p208"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p209.xml
+++ b/APIS/princeton/xml/princeton.apis.p209.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/z029p730t"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/js956k32v"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p21.xml
+++ b/APIS/princeton/xml/princeton.apis.p21.xml
@@ -80,8 +80,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p21"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cc08hk11m"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p21"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p210.xml
+++ b/APIS/princeton/xml/princeton.apis.p210.xml
@@ -1,93 +1,93 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
-      <fileDesc>
-         <titleStmt>
-            <title>Embankment Certificate</title>
-         </titleStmt>
-         <publicationStmt>
-            <authority>APIS</authority>
-            <idno type="apisid">princeton.apis.p210</idno>
-            <idno type="controlNo">(NjP)apis.p0210</idno>
-            <idno type="ddbdp">p.princ.2.40</idno>
-            <idno type="ddb-perseus-style">0192;2;40</idno>
-            <idno type="ddb-hybrid">p.princ;2;40</idno>
-            <idno type="HGV">12833</idno>
-            <idno type="TM">12833</idno>
-         </publicationStmt>
-         <sourceDesc>
-            <msDesc>
-               <msIdentifier>
-                  <idno type="invNo">AM 8911</idno>
-               </msIdentifier>
-               <msContents>
-                  <summary>Certificate for embankment work (penthemeros)</summary>
-                  <msItemStruct>
-                     <note type="general">Written along the fibers; back blank</note>
-                     <note type="general">4 lines; complete</note>
-                     <note type="general">Three hands: two are tiny, rapid cursives; the third is a large fluent cursive</note>
-                     <textLang mainLang="grc">In Greek</textLang>
-                  </msItemStruct>
-               </msContents>
-               <physDesc>
-                  <objectDesc>
-                     <supportDesc>
-                        <support>1 papyrus fragment; 4.5 x 13 cm</support>
-                     </supportDesc>
-                  </objectDesc>
-               </physDesc>
-               <history>
-                  <origin>
-                     <origDate when="0049">49 AD, July 16</origDate>
-                     <origPlace>From Theadelphia</origPlace>
-                  </origin>
-               </history>
-            </msDesc>
-         </sourceDesc>
-      </fileDesc>
-      <encodingDesc>
-         <classDecl>
-            <taxonomy xml:id="apis">
-               <desc>APIS keywords are controlled locally at the institution level. They are not necessarily consistent.</desc>
-            </taxonomy>
-         </classDecl>
-      </encodingDesc>
-      <profileDesc>
-         <langUsage>
-            <language ident="en">English</language>
-            <language ident="grc">In Greek</language>
-         </langUsage>
-         <textClass>
-            <keywords scheme="#apis">
-               <term type="genre_form">Papyri</term>
-               <term type="genre_form">Receipt</term>
-            </keywords>
-         </textClass>
-      </profileDesc>
-   </teiHeader>
-   <text>
-      <body>
-         <div type="translation">
-            <ab>The ninth year of Tiberius Claudius Caesar Augustus Germanicus the Emperor, on the 22nd of the month Epeiph, in Plot-, accomplished the five days of the labor on the embankments. [hand 2] Hathres son of Arthonios, police-officer from Theadelphia. [hand 3] I, Dionysos, have signed.</ab>
-         </div>
-         <div type="bibliography" subtype="citations">
-            <listBibl>
-               <bibl>P.Princ. II 40 <note>BL III, 149; V, 85; VI 118.</note>
-               </bibl>
-               <bibl type="ddbdp">P.Princ.:2:40</bibl>
-            </listBibl>
-         </div>
-         <div type="figure">
-            <p>
-               <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/xw42nb49m"/>
-               </figure>
-               <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p210"/>
-               </figure>
-            </p>
-         </div>
-      </body>
-   </text>
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Embankment Certificate</title>
+      </titleStmt>
+      <publicationStmt>
+        <authority>APIS</authority>
+        <idno type="apisid">princeton.apis.p210</idno>
+        <idno type="controlNo">(NjP)apis.p0210</idno>
+        <idno type="ddbdp">p.princ.2.40</idno>
+        <idno type="ddb-perseus-style">0192;2;40</idno>
+        <idno type="ddb-hybrid">p.princ;2;40</idno>
+        <idno type="HGV">12833</idno>
+        <idno type="TM">12833</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <idno type="invNo">AM 8911</idno>
+          </msIdentifier>
+          <msContents>
+            <summary>Certificate for embankment work (penthemeros)</summary>
+            <msItemStruct>
+              <note type="general">Written along the fibers; back blank</note>
+              <note type="general">4 lines; complete</note>
+              <note type="general">Three hands: two are tiny, rapid cursives; the third is a large fluent cursive</note>
+              <textLang mainLang="grc">In Greek</textLang>
+            </msItemStruct>
+          </msContents>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>1 papyrus fragment; 4.5 x 13 cm</support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origDate when="0049">49 AD, July 16</origDate>
+              <origPlace>From Theadelphia</origPlace>
+            </origin>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy xml:id="apis">
+          <desc>APIS keywords are controlled locally at the institution level. They are not necessarily consistent.</desc>
+        </taxonomy>
+      </classDecl>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="en">English</language>
+        <language ident="grc">In Greek</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="#apis">
+          <term type="genre_form">Papyri</term>
+          <term type="genre_form">Receipt</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="translation">
+        <ab>The ninth year of Tiberius Claudius Caesar Augustus Germanicus the Emperor, on the 22nd of the month Epeiph, in Plot-, accomplished the five days of the labor on the embankments. [hand 2] Hathres son of Arthonios, police-officer from Theadelphia. [hand 3] I, Dionysos, have signed.</ab>
+      </div>
+      <div type="bibliography" subtype="citations">
+        <listBibl>
+          <bibl>P.Princ. II 40 <note>BL III, 149; V, 85; VI 118.</note>
+        </bibl>
+        <bibl type="ddbdp">P.Princ.:2:40</bibl>
+      </listBibl>
+    </div>
+    <div type="figure">
+      <p>
+        <figure>
+          <graphic url="https://dpul.princeton.edu/papyri/catalog/6395wb59w"/>
+        </figure>
+        <figure>
+           <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p210"/>
+         </figure>
+      </p>
+    </div>
+  </body>
+</text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p211.xml
+++ b/APIS/princeton/xml/princeton.apis.p211.xml
@@ -73,8 +73,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p211"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/d504rp83t"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p211"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p212.xml
+++ b/APIS/princeton/xml/princeton.apis.p212.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/x346d8635"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p214.xml
+++ b/APIS/princeton/xml/princeton.apis.p214.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/br86b615p"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/7m01bq20w"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p215.xml
+++ b/APIS/princeton/xml/princeton.apis.p215.xml
@@ -82,48 +82,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <head>Verso :: 0 :: 12 kb image</head>
-                  <figDesc> </figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=12&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=12&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=12&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=12&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=12&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=12&amp;face=b&amp;tile=0"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/x346d767p"/>
                </figure>
                <figure>
-                  <head>Verso :: 0 :: 12 kb image</head>
-                  <figDesc> 12</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=12&amp;face=b&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Verso :: 0 :: 860 kb image</head>
-                  <figDesc> </figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=150&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=150&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=150&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=150&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=150&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=150&amp;face=b&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Verso :: 0 :: 860 kb image</head>
-                  <figDesc> 150</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=150&amp;face=b&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Verso :: 0 :: 3020 kb image</head>
-                  <figDesc> </figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=300&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=300&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=300&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=300&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=300&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=300&amp;face=b&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Verso :: 0 :: 3020 kb image</head>
-                  <figDesc> 300</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=300&amp;face=b&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Verso :: 0 :: 244 kb image</head>
-                  <figDesc> </figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=75&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=75&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=75&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=75&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=75&amp;face=b&amp;tile=0http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=75&amp;face=b&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Verso :: 0 :: 244 kb image</head>
-                  <figDesc> 75</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215&amp;size=75&amp;face=b&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/6m311r89m"/>
-               </figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p215"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p22.xml
+++ b/APIS/princeton/xml/princeton.apis.p22.xml
@@ -78,8 +78,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p22"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9c67wr33r"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p22"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p221.xml
+++ b/APIS/princeton/xml/princeton.apis.p221.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/kp78gj96x"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/7w62fc72h"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p223.xml
+++ b/APIS/princeton/xml/princeton.apis.p223.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/kp78gk88v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p225.xml
+++ b/APIS/princeton/xml/princeton.apis.p225.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/c821gp308"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p226.xml
+++ b/APIS/princeton/xml/princeton.apis.p226.xml
@@ -78,7 +78,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2v23vw995"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/kw52jc41x"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p229.xml
+++ b/APIS/princeton/xml/princeton.apis.p229.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/0z709094s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p23.xml
+++ b/APIS/princeton/xml/princeton.apis.p23.xml
@@ -79,8 +79,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p23"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8910jz097"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p23"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p230.xml
+++ b/APIS/princeton/xml/princeton.apis.p230.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/0g354h80b"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/qr46r414b"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p231.xml
+++ b/APIS/princeton/xml/princeton.apis.p231.xml
@@ -67,8 +67,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p231"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k643b468j"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p231"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p232.xml
+++ b/APIS/princeton/xml/princeton.apis.p232.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/fq977z294"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p234.xml
+++ b/APIS/princeton/xml/princeton.apis.p234.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/w66347125"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p236.xml
+++ b/APIS/princeton/xml/princeton.apis.p236.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/vm40xx043"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p237.xml
+++ b/APIS/princeton/xml/princeton.apis.p237.xml
@@ -66,8 +66,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p237"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8k71nm600"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p237"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p238.xml
+++ b/APIS/princeton/xml/princeton.apis.p238.xml
@@ -67,8 +67,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p238"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/kw52jc578"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p238"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p239.xml
+++ b/APIS/princeton/xml/princeton.apis.p239.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ns064b50d"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p24.xml
+++ b/APIS/princeton/xml/princeton.apis.p24.xml
@@ -80,8 +80,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p24"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/w3763b27d"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p24"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p240.xml
+++ b/APIS/princeton/xml/princeton.apis.p240.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/4f16c7288"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p241.xml
+++ b/APIS/princeton/xml/princeton.apis.p241.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8336h6375"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p242.xml
+++ b/APIS/princeton/xml/princeton.apis.p242.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8623j319v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p244.xml
+++ b/APIS/princeton/xml/princeton.apis.p244.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2v23vz85m"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p247.xml
+++ b/APIS/princeton/xml/princeton.apis.p247.xml
@@ -80,11 +80,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2z10ws800"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/gx41mn35c"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p247"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p249.xml
+++ b/APIS/princeton/xml/princeton.apis.p249.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/d504rn92c"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3x816r129"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p250.xml
+++ b/APIS/princeton/xml/princeton.apis.p250.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/bn999b070"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6w924g15s"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p251.xml
+++ b/APIS/princeton/xml/princeton.apis.p251.xml
@@ -79,11 +79,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/9g54xm240"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/b5644w057"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p251"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p253.xml
+++ b/APIS/princeton/xml/princeton.apis.p253.xml
@@ -84,11 +84,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/8g84mp858"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/vh53x006d"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p253"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p254.xml
+++ b/APIS/princeton/xml/princeton.apis.p254.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/r207tr920"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cf95jf98m"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p258.xml
+++ b/APIS/princeton/xml/princeton.apis.p258.xml
@@ -80,6 +80,13 @@
                <bibl type="ddbdp">P.Princ.:2:82</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/dv140258x"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p259.xml
+++ b/APIS/princeton/xml/princeton.apis.p259.xml
@@ -77,7 +77,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2r36v111w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/n583xz48g"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p26.xml
+++ b/APIS/princeton/xml/princeton.apis.p26.xml
@@ -78,8 +78,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p26"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/tb09j9169"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p26"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p260.xml
+++ b/APIS/princeton/xml/princeton.apis.p260.xml
@@ -82,11 +82,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/3t945t37k"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/tx31qn20r"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p260"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p27.xml
+++ b/APIS/princeton/xml/princeton.apis.p27.xml
@@ -74,6 +74,13 @@
                </bibl>
             </listBibl>
          </div>
+         <div type="figure">
+           <p>
+             <figure>
+               <graphic url="https://dpul.princeton.edu/papyri/catalog/b5644w04r"/>
+             </figure>
+           </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p276.xml
+++ b/APIS/princeton/xml/princeton.apis.p276.xml
@@ -72,8 +72,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p276"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/p8418r72c"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p276"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p278.xml
+++ b/APIS/princeton/xml/princeton.apis.p278.xml
@@ -69,6 +69,13 @@
                <bibl>Unpublished</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/r494vp68d"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p28.xml
+++ b/APIS/princeton/xml/princeton.apis.p28.xml
@@ -75,6 +75,13 @@
                <bibl type="ddbdp">P.Princ.:3:108</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+           <p>
+             <figure>
+               <graphic url="https://dpul.princeton.edu/papyri/catalog/pz50h0600"/>
+             </figure>
+           </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p280.xml
+++ b/APIS/princeton/xml/princeton.apis.p280.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/j098zg57z"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p282.xml
+++ b/APIS/princeton/xml/princeton.apis.p282.xml
@@ -73,7 +73,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/gm80hx926"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/w3763b28w"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p284.xml
+++ b/APIS/princeton/xml/princeton.apis.p284.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ns064b50d"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p285.xml
+++ b/APIS/princeton/xml/princeton.apis.p285.xml
@@ -73,8 +73,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p285"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2r36v203t"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p285"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p29.xml
+++ b/APIS/princeton/xml/princeton.apis.p29.xml
@@ -79,8 +79,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p29"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/kk91fq06z"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p29"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p291.xml
+++ b/APIS/princeton/xml/princeton.apis.p291.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bc386p678"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p292.xml
+++ b/APIS/princeton/xml/princeton.apis.p292.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/g158bn75p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p293.xml
+++ b/APIS/princeton/xml/princeton.apis.p293.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/g158bn75p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p294.xml
+++ b/APIS/princeton/xml/princeton.apis.p294.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2f75rd48f"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p296.xml
+++ b/APIS/princeton/xml/princeton.apis.p296.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6682x841m"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p297.xml
+++ b/APIS/princeton/xml/princeton.apis.p297.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/x920g2313"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p299.xml
+++ b/APIS/princeton/xml/princeton.apis.p299.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/td96k603v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p30.xml
+++ b/APIS/princeton/xml/princeton.apis.p30.xml
@@ -76,6 +76,13 @@
                <bibl>P.Princ. III 111</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+           <p>
+             <figure>
+               <graphic url="https://dpul.princeton.edu/papyri/catalog/hd76s356s"/>
+             </figure>
+           </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p300.xml
+++ b/APIS/princeton/xml/princeton.apis.p300.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/v979v754v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p301.xml
+++ b/APIS/princeton/xml/princeton.apis.p301.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2227mv106"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p304.xml
+++ b/APIS/princeton/xml/princeton.apis.p304.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hm50tx19q"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p306.xml
+++ b/APIS/princeton/xml/princeton.apis.p306.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/n870zw28m"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p307.xml
+++ b/APIS/princeton/xml/princeton.apis.p307.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hm50tx19q"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p309.xml
+++ b/APIS/princeton/xml/princeton.apis.p309.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/x346d8635"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p31.xml
+++ b/APIS/princeton/xml/princeton.apis.p31.xml
@@ -83,8 +83,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p31"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/d791sk698"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p31"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p310.xml
+++ b/APIS/princeton/xml/princeton.apis.p310.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1v53k245q"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p311.xml
+++ b/APIS/princeton/xml/princeton.apis.p311.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cv43p2271"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p312.xml
+++ b/APIS/princeton/xml/princeton.apis.p312.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/70795d10s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p313.xml
+++ b/APIS/princeton/xml/princeton.apis.p313.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/w0892f45q"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p314.xml
+++ b/APIS/princeton/xml/princeton.apis.p314.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/mg74qq613"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p315.xml
+++ b/APIS/princeton/xml/princeton.apis.p315.xml
@@ -69,6 +69,13 @@
                </bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1c18dm24p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p316.xml
+++ b/APIS/princeton/xml/princeton.apis.p316.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8w32r912q"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p32.xml
+++ b/APIS/princeton/xml/princeton.apis.p32.xml
@@ -74,6 +74,13 @@
                <bibl type="ddbdp">P.Oxy.:6:951</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9z9033379"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p320.xml
+++ b/APIS/princeton/xml/princeton.apis.p320.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1c18dk29p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p323.xml
+++ b/APIS/princeton/xml/princeton.apis.p323.xml
@@ -67,9 +67,12 @@
          </div>
          <div type="figure">
             <p>
-               <figure>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/1544bs59n"/>
+              </figure>
+              <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p323"/>
-               </figure>
+               </figure> 
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p324.xml
+++ b/APIS/princeton/xml/princeton.apis.p324.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/br86b8033"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p325.xml
+++ b/APIS/princeton/xml/princeton.apis.p325.xml
@@ -67,6 +67,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/j3860b453"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p325"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p328.xml
+++ b/APIS/princeton/xml/princeton.apis.p328.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bz60d172k"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p329.xml
+++ b/APIS/princeton/xml/princeton.apis.p329.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/td96k603v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p33.xml
+++ b/APIS/princeton/xml/princeton.apis.p33.xml
@@ -74,6 +74,13 @@
                <bibl type="ddbdp">P.Princ.:3:109</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/sx61dq80j"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p330.xml
+++ b/APIS/princeton/xml/princeton.apis.p330.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/js956m277"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p332.xml
+++ b/APIS/princeton/xml/princeton.apis.p332.xml
@@ -67,7 +67,10 @@
          </div>
          <div type="figure">
             <p>
-               <figure>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/9s161967k"/>
+              </figure>
+              <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p332"/>
                </figure>
             </p>

--- a/APIS/princeton/xml/princeton.apis.p333.xml
+++ b/APIS/princeton/xml/princeton.apis.p333.xml
@@ -1,77 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
-      <fileDesc>
-         <titleStmt>
-            <title>Documentary Text [II/III AD]</title>
-         </titleStmt>
-         <publicationStmt>
-            <authority>APIS</authority>
-            <idno type="apisid">princeton.apis.p333</idno>
-            <idno type="controlNo">(NjP)apis.p0333</idno>
-         </publicationStmt>
-         <sourceDesc>
-            <msDesc>
-               <msIdentifier>
-                  <idno type="invNo">Princ. inv. AM 4428 A verso</idno>
-               </msIdentifier>
-               <msContents>
-                  <summary>Document: content uncertain; fragment (a) has a column or page number at the top</summary>
-                  <msItemStruct>
-                     <note type="general">Written across the fibers; on the recto, a document</note>
-                     <note type="general">Frag. (a) 25 lines; frag. (b) 8 lines; broken except at top</note>
-                     <note type="general">The hand is a large cursive</note>
-                     <note type="local_note">Frame 37</note>
-                     <textLang mainLang="grc">In Greek</textLang>
-                  </msItemStruct>
-               </msContents>
-               <physDesc>
-                  <objectDesc>
-                     <supportDesc>
-                        <support>1 papyrus fragment; (a) 15.6 x 10.7 cm. (b) 8.1 x 9 cm</support>
-                     </supportDesc>
-                  </objectDesc>
-               </physDesc>
-               <history>
-                  <origin>
-                     <origDate notBefore="0100" notAfter="0299">100 CE – 299 CE</origDate>
-                  </origin>
-               </history>
-            </msDesc>
-         </sourceDesc>
-      </fileDesc>
-      <encodingDesc>
-         <classDecl>
-            <taxonomy xml:id="apis">
-               <desc>APIS keywords are controlled locally at the institution level. They are not necessarily consistent.</desc>
-            </taxonomy>
-         </classDecl>
-      </encodingDesc>
-      <profileDesc>
-         <langUsage>
-            <language ident="en">English</language>
-            <language ident="grc">In Greek</language>
-         </langUsage>
-         <textClass>
-            <keywords scheme="#apis">
-               <term type="genre_form">Papyri</term>
-            </keywords>
-         </textClass>
-      </profileDesc>
-   </teiHeader>
-   <text>
-      <body>
-         <div type="bibliography" subtype="citations">
-            <p>No citations.</p>
-         </div>
-         <div type="figure">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Documentary Text [II/III AD]</title>
+      </titleStmt>
+      <publicationStmt>
+        <authority>APIS</authority>
+        <idno type="apisid">princeton.apis.p333</idno>
+        <idno type="controlNo">(NjP)apis.p0333</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <idno type="invNo">Princ. inv. AM 4428 A verso</idno>
+          </msIdentifier>
+          <msContents>
+            <summary>Document: content uncertain; fragment (a) has a column or page number at the top</summary>
+            <msItemStruct>
+              <note type="general">Written across the fibers; on the recto, a document</note>
+              <note type="general">Frag. (a) 25 lines; frag. (b) 8 lines; broken except at top</note>
+              <note type="general">The hand is a large cursive</note>
+              <note type="local_note">Frame 37</note>
+              <textLang mainLang="grc">In Greek</textLang>
+            </msItemStruct>
+          </msContents>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>1 papyrus fragment; (a) 15.6 x 10.7 cm. (b) 8.1 x 9 cm</support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origDate notBefore="0100" notAfter="0299">100 CE – 299 CE</origDate>
+            </origin>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy xml:id="apis">
+          <desc>APIS keywords are controlled locally at the institution level. They are not necessarily consistent.</desc>
+        </taxonomy>
+      </classDecl>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="en">English</language>
+        <language ident="grc">In Greek</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="#apis">
+          <term type="genre_form">Papyri</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="citations">
+        <p>No citations.</p>
+      </div>
+      <div type="figure">
+        <p>
+          <div type="figure">
             <p>
-               <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p333"/>
-               </figure>
+              <figure>
+                <graphic url="https://dpul.princeton.edu/papyri/catalog/9s161967k"/>
+              </figure>
+              <figure>
+                <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p333"/>
+              </figure>
             </p>
-         </div>
-      </body>
-   </text>
-</TEI>
+          </div>
+        </body>
+      </text>
+    </TEI>

--- a/APIS/princeton/xml/princeton.apis.p333.xml
+++ b/APIS/princeton/xml/princeton.apis.p333.xml
@@ -67,16 +67,14 @@
       </div>
       <div type="figure">
         <p>
-          <div type="figure">
-            <p>
-              <figure>
-                <graphic url="https://dpul.princeton.edu/papyri/catalog/9s161967k"/>
-              </figure>
-              <figure>
-                <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p333"/>
-              </figure>
-            </p>
-          </div>
-        </body>
-      </text>
-    </TEI>
+          <figure>
+            <graphic url="https://dpul.princeton.edu/papyri/catalog/9s161967k"/>
+          </figure>
+          <figure>
+            <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p333"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/APIS/princeton/xml/princeton.apis.p334.xml
+++ b/APIS/princeton/xml/princeton.apis.p334.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/5q47rt20b"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p335.xml
+++ b/APIS/princeton/xml/princeton.apis.p335.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hm50tx187"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p336.xml
+++ b/APIS/princeton/xml/princeton.apis.p336.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ms35td149"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p340.xml
+++ b/APIS/princeton/xml/princeton.apis.p340.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/nv935636f"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p341.xml
+++ b/APIS/princeton/xml/princeton.apis.p341.xml
@@ -67,7 +67,10 @@
          </div>
          <div type="figure">
             <p>
-               <figure>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/jh343w809"/>
+              </figure>
+              <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p341"/>
                </figure>
             </p>

--- a/APIS/princeton/xml/princeton.apis.p345.xml
+++ b/APIS/princeton/xml/princeton.apis.p345.xml
@@ -67,7 +67,10 @@
          </div>
          <div type="figure">
             <p>
-               <figure>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/t148fm64k"/>
+              </figure>
+              <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p345"/>
                </figure>
             </p>

--- a/APIS/princeton/xml/princeton.apis.p346.xml
+++ b/APIS/princeton/xml/princeton.apis.p346.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2b88qh64s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p348.xml
+++ b/APIS/princeton/xml/princeton.apis.p348.xml
@@ -67,6 +67,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/9g54xn16x"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p348"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p350.xml
+++ b/APIS/princeton/xml/princeton.apis.p350.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/n870zw28m"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p353.xml
+++ b/APIS/princeton/xml/princeton.apis.p353.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ww72bg97t"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p358.xml
+++ b/APIS/princeton/xml/princeton.apis.p358.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/r207ts85d"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p36.xml
+++ b/APIS/princeton/xml/princeton.apis.p36.xml
@@ -80,8 +80,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p36"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cv43p132n"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p36"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p360.xml
+++ b/APIS/princeton/xml/princeton.apis.p360.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/w3763c22d"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p363.xml
+++ b/APIS/princeton/xml/princeton.apis.p363.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/s1784q249"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p364.xml
+++ b/APIS/princeton/xml/princeton.apis.p364.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hm50tx19q"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p366.xml
+++ b/APIS/princeton/xml/princeton.apis.p366.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hh63t041j"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p369.xml
+++ b/APIS/princeton/xml/princeton.apis.p369.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1n79h8769"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p37.xml
+++ b/APIS/princeton/xml/princeton.apis.p37.xml
@@ -86,8 +86,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p37"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/mk61rm45r"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p37"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p370.xml
+++ b/APIS/princeton/xml/princeton.apis.p370.xml
@@ -67,6 +67,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/wp988p310"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p370"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p371.xml
+++ b/APIS/princeton/xml/princeton.apis.p371.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k930c2495"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p372.xml
+++ b/APIS/princeton/xml/princeton.apis.p372.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3b591d07c"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p374.xml
+++ b/APIS/princeton/xml/princeton.apis.p374.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1z40kx34m"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p375.xml
+++ b/APIS/princeton/xml/princeton.apis.p375.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/gh93h398p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p379.xml
+++ b/APIS/princeton/xml/princeton.apis.p379.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/5425kg16r"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p38.xml
+++ b/APIS/princeton/xml/princeton.apis.p38.xml
@@ -77,8 +77,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p38"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1r66j4643"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p38"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p381.xml
+++ b/APIS/princeton/xml/princeton.apis.p381.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9w032749p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p382.xml
+++ b/APIS/princeton/xml/princeton.apis.p382.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8w32rb073"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p383.xml
+++ b/APIS/princeton/xml/princeton.apis.p383.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/p2676z14d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/jm214s66x"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p384.xml
+++ b/APIS/princeton/xml/princeton.apis.p384.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/c821gn377"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/z029p822r"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p385.xml
+++ b/APIS/princeton/xml/princeton.apis.p385.xml
@@ -84,7 +84,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/f7623g17w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/gb19f931j"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p385"/>

--- a/APIS/princeton/xml/princeton.apis.p387.xml
+++ b/APIS/princeton/xml/princeton.apis.p387.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/v405sc972"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/wh246w652"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p388.xml
+++ b/APIS/princeton/xml/princeton.apis.p388.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/pg15bh47d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/jm214s65f"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p389.xml
+++ b/APIS/princeton/xml/princeton.apis.p389.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/f7623g17w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bk128f40t"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p389"/>

--- a/APIS/princeton/xml/princeton.apis.p39.xml
+++ b/APIS/princeton/xml/princeton.apis.p39.xml
@@ -78,6 +78,13 @@
                <bibl type="ddbdp">P.Princ.:3:113</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/47429d63v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p391.xml
+++ b/APIS/princeton/xml/princeton.apis.p391.xml
@@ -77,7 +77,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/tx31qm286"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/4b29b949m"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p393.xml
+++ b/APIS/princeton/xml/princeton.apis.p393.xml
@@ -73,6 +73,13 @@
                </bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/5999n7856"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p394.xml
+++ b/APIS/princeton/xml/princeton.apis.p394.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/5q47rr33d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/7s75dg887"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p394"/>

--- a/APIS/princeton/xml/princeton.apis.p395.xml
+++ b/APIS/princeton/xml/princeton.apis.p395.xml
@@ -73,7 +73,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/1544br67q"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/nk322h85c"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p395"/>

--- a/APIS/princeton/xml/princeton.apis.p396.xml
+++ b/APIS/princeton/xml/princeton.apis.p396.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/h989r5793"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/g445ch65f"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p398.xml
+++ b/APIS/princeton/xml/princeton.apis.p398.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/dz010s64m"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/0c483n90k"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p398"/>

--- a/APIS/princeton/xml/princeton.apis.p40.xml
+++ b/APIS/princeton/xml/princeton.apis.p40.xml
@@ -82,8 +82,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p40"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/qj72pb646"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p40"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p400.xml
+++ b/APIS/princeton/xml/princeton.apis.p400.xml
@@ -72,6 +72,13 @@
                </bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/m900nz892"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p403.xml
+++ b/APIS/princeton/xml/princeton.apis.p403.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/mc87ps83x"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/mg74qq62k"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p404.xml
+++ b/APIS/princeton/xml/princeton.apis.p404.xml
@@ -73,6 +73,13 @@
                </bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9306t376z"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p405.xml
+++ b/APIS/princeton/xml/princeton.apis.p405.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/vm40xv16p"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/028710372"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p406.xml
+++ b/APIS/princeton/xml/princeton.apis.p406.xml
@@ -63,6 +63,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hm50tw24b"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p408.xml
+++ b/APIS/princeton/xml/princeton.apis.p408.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/kp78gj96x"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cn69m7637"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p409.xml
+++ b/APIS/princeton/xml/princeton.apis.p409.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/q237hv54p"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/5d86p372h"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p409"/>

--- a/APIS/princeton/xml/princeton.apis.p411.xml
+++ b/APIS/princeton/xml/princeton.apis.p411.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/wm117s50t"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p412.xml
+++ b/APIS/princeton/xml/princeton.apis.p412.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/gm80hz83n"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p413.xml
+++ b/APIS/princeton/xml/princeton.apis.p413.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/h128nj22g"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p414.xml
+++ b/APIS/princeton/xml/princeton.apis.p414.xml
@@ -78,7 +78,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/gb19f8390"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/08612s03n"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p415.xml
+++ b/APIS/princeton/xml/princeton.apis.p415.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/r781wk54n"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p416.xml
+++ b/APIS/princeton/xml/princeton.apis.p416.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/qb98mj067"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k930c1539"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p417.xml
+++ b/APIS/princeton/xml/princeton.apis.p417.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/rf55zc20r"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p418.xml
+++ b/APIS/princeton/xml/princeton.apis.p418.xml
@@ -75,7 +75,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/w3763935g"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/np193d68p"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p418"/>

--- a/APIS/princeton/xml/princeton.apis.p42.xml
+++ b/APIS/princeton/xml/princeton.apis.p42.xml
@@ -80,8 +80,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p42"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9306t281k"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p42"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p420.xml
+++ b/APIS/princeton/xml/princeton.apis.p420.xml
@@ -67,6 +67,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/5999n690t"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p420"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p424.xml
+++ b/APIS/princeton/xml/princeton.apis.p424.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/zs25xd93n"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p425.xml
+++ b/APIS/princeton/xml/princeton.apis.p425.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/jh343x75p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p427.xml
+++ b/APIS/princeton/xml/princeton.apis.p427.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3j333672b"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p428.xml
+++ b/APIS/princeton/xml/princeton.apis.p428.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/8623j132j"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3x816r13s"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p428"/>

--- a/APIS/princeton/xml/princeton.apis.p43.xml
+++ b/APIS/princeton/xml/princeton.apis.p43.xml
@@ -78,8 +78,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p43"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/nz806319m"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p43"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p430.xml
+++ b/APIS/princeton/xml/princeton.apis.p430.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/4f16c633w"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p431.xml
+++ b/APIS/princeton/xml/princeton.apis.p431.xml
@@ -78,7 +78,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/1c18dj368"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/wh246w64k"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p431"/>

--- a/APIS/princeton/xml/princeton.apis.p432.xml
+++ b/APIS/princeton/xml/princeton.apis.p432.xml
@@ -77,7 +77,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2f75rb614"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/5q47rs25b"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p433.xml
+++ b/APIS/princeton/xml/princeton.apis.p433.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/5425kd27v"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/j67317288"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p434.xml
+++ b/APIS/princeton/xml/princeton.apis.p434.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/9c67wq41t"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9w032653t"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p434"/>

--- a/APIS/princeton/xml/princeton.apis.p435.xml
+++ b/APIS/princeton/xml/princeton.apis.p435.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/8p58pg53b"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/zs25xc975"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p438.xml
+++ b/APIS/princeton/xml/princeton.apis.p438.xml
@@ -77,7 +77,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/6108vd84z"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hm50tw24b"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p439.xml
+++ b/APIS/princeton/xml/princeton.apis.p439.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/v692t879k"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/g158bm809"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p439"/>

--- a/APIS/princeton/xml/princeton.apis.p44.xml
+++ b/APIS/princeton/xml/princeton.apis.p44.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Iliad [III AD]</title>
+            <title>Hellenica [IV AD]</title>
          </titleStmt>
          <publicationStmt>
             <authority>APIS</authority>
@@ -75,6 +75,13 @@
                </bibl>
                <bibl type="ddbdp">P.Princ.:3:112</bibl>
             </listBibl>
+         </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/4m90f0005"/>
+               </figure>
+            </p>
          </div>
       </body>
    </text>

--- a/APIS/princeton/xml/princeton.apis.p440.xml
+++ b/APIS/princeton/xml/princeton.apis.p440.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9g54xp11x"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p441.xml
+++ b/APIS/princeton/xml/princeton.apis.p441.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/xw42nb49m"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/s4655m10j"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p441"/>

--- a/APIS/princeton/xml/princeton.apis.p442.xml
+++ b/APIS/princeton/xml/princeton.apis.p442.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/5d86p279g"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bk128f23c"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p443.xml
+++ b/APIS/princeton/xml/princeton.apis.p443.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/ks65hf793"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/rr172173c"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p444.xml
+++ b/APIS/princeton/xml/princeton.apis.p444.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/qf85nd880"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/v692t9714"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p445.xml
+++ b/APIS/princeton/xml/princeton.apis.p445.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/v405sc972"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/wh246w652"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p446.xml
+++ b/APIS/princeton/xml/princeton.apis.p446.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/n296x359k"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p449.xml
+++ b/APIS/princeton/xml/princeton.apis.p449.xml
@@ -73,6 +73,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/fb494c939"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p449"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p450.xml
+++ b/APIS/princeton/xml/princeton.apis.p450.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/h128nh29f"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/m326m523m"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p450"/>

--- a/APIS/princeton/xml/princeton.apis.p451.xml
+++ b/APIS/princeton/xml/princeton.apis.p451.xml
@@ -75,7 +75,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/jw827f252"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2z10wt74w"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p452.xml
+++ b/APIS/princeton/xml/princeton.apis.p452.xml
@@ -77,7 +77,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/rf55zb286"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/zw12z880z"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p453.xml
+++ b/APIS/princeton/xml/princeton.apis.p453.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/jm214r73h"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/08612s044"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p453"/>

--- a/APIS/princeton/xml/princeton.apis.p454.xml
+++ b/APIS/princeton/xml/princeton.apis.p454.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/p8418s668"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p455.xml
+++ b/APIS/princeton/xml/princeton.apis.p455.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/x920g045n"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/4f16c633w"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p456.xml
+++ b/APIS/princeton/xml/princeton.apis.p456.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/t148fn59z"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p457.xml
+++ b/APIS/princeton/xml/princeton.apis.p457.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/6h440w05w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1544bs60r"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p458.xml
+++ b/APIS/princeton/xml/princeton.apis.p458.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ks65hh661"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p459.xml
+++ b/APIS/princeton/xml/princeton.apis.p459.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/gx41mm44x"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/70795c15s"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p461.xml
+++ b/APIS/princeton/xml/princeton.apis.p461.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/xd07gx191"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p462.xml
+++ b/APIS/princeton/xml/princeton.apis.p462.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/xd07gw273"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/rr172172w"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p462"/>

--- a/APIS/princeton/xml/princeton.apis.p463.xml
+++ b/APIS/princeton/xml/princeton.apis.p463.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/xp68kj79q"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6108vf76w"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p466.xml
+++ b/APIS/princeton/xml/princeton.apis.p466.xml
@@ -77,7 +77,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/m900nx016"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/vq27zr923"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p466"/>

--- a/APIS/princeton/xml/princeton.apis.p467.xml
+++ b/APIS/princeton/xml/princeton.apis.p467.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/c821gn377"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/z029p822r"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p467"/>

--- a/APIS/princeton/xml/princeton.apis.p468.xml
+++ b/APIS/princeton/xml/princeton.apis.p468.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/7p88ck132"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/r207ts85d"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p469.xml
+++ b/APIS/princeton/xml/princeton.apis.p469.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/70795b22c"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hd76s3578"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p47.xml
+++ b/APIS/princeton/xml/princeton.apis.p47.xml
@@ -74,7 +74,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/df65vb44x"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cc08hk123"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p470.xml
+++ b/APIS/princeton/xml/princeton.apis.p470.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/bn999b070"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bn999b070"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p471.xml
+++ b/APIS/princeton/xml/princeton.apis.p471.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/sn00b228p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p472.xml
+++ b/APIS/princeton/xml/princeton.apis.p472.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8s45qd29x"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p473.xml
+++ b/APIS/princeton/xml/princeton.apis.p473.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/xs55mh53c"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p476.xml
+++ b/APIS/princeton/xml/princeton.apis.p476.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/f7623j04t"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p478.xml
+++ b/APIS/princeton/xml/princeton.apis.p478.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ks65hh661"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p479.xml
+++ b/APIS/princeton/xml/princeton.apis.p479.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/wm117r588"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/c534fs441"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p48.xml
+++ b/APIS/princeton/xml/princeton.apis.p48.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/pc289p534"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p480.xml
+++ b/APIS/princeton/xml/princeton.apis.p480.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/tb09j825v"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2514nq01f"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p480"/>

--- a/APIS/princeton/xml/princeton.apis.p481.xml
+++ b/APIS/princeton/xml/princeton.apis.p481.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2z10ws81g"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/tq57nv539"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p481"/>

--- a/APIS/princeton/xml/princeton.apis.p482.xml
+++ b/APIS/princeton/xml/princeton.apis.p482.xml
@@ -74,7 +74,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/gx41mm45d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/kh04dt210"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p483.xml
+++ b/APIS/princeton/xml/princeton.apis.p483.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/vd66w250q"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/q811kp12k"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p483"/>

--- a/APIS/princeton/xml/princeton.apis.p484.xml
+++ b/APIS/princeton/xml/princeton.apis.p484.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/jd473194v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p485.xml
+++ b/APIS/princeton/xml/princeton.apis.p485.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/d791sj77b"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/0k225f55f"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p485"/>

--- a/APIS/princeton/xml/princeton.apis.p486.xml
+++ b/APIS/princeton/xml/princeton.apis.p486.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/cj82k988c"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/5138jj38k"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p486"/>

--- a/APIS/princeton/xml/princeton.apis.p487.xml
+++ b/APIS/princeton/xml/princeton.apis.p487.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/sf268768t"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6w924g346"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p487"/>

--- a/APIS/princeton/xml/princeton.apis.p488.xml
+++ b/APIS/princeton/xml/princeton.apis.p488.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9w032749p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p489.xml
+++ b/APIS/princeton/xml/princeton.apis.p489.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2514nq96w"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p490.xml
+++ b/APIS/princeton/xml/princeton.apis.p490.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/gh93h3018"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p491.xml
+++ b/APIS/princeton/xml/princeton.apis.p491.xml
@@ -77,7 +77,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/7d278w61h"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/79408167f"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p492.xml
+++ b/APIS/princeton/xml/princeton.apis.p492.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/zc77ss708"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/v118rj058"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p493.xml
+++ b/APIS/princeton/xml/princeton.apis.p493.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/sn00b1358"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/j96024131"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p493"/>

--- a/APIS/princeton/xml/princeton.apis.p494.xml
+++ b/APIS/princeton/xml/princeton.apis.p494.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2j62s932q"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p495.xml
+++ b/APIS/princeton/xml/princeton.apis.p495.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9s161b62k"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p497.xml
+++ b/APIS/princeton/xml/princeton.apis.p497.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/gb19f8390"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/vh53x024b"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p497"/>

--- a/APIS/princeton/xml/princeton.apis.p5.xml
+++ b/APIS/princeton/xml/princeton.apis.p5.xml
@@ -10,7 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">princeton.apis.p5</idno>
             <idno type="controlNo">(NjP)apis.p0005</idno>
-            <idno type="ddbdp">p.princ.2.107</idno>
+            <idno type="DCLP">64605</idno>
+            <idno type="TM">64605</idno>
+            <idno type="dclp-hybrid">tm;;64605</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
@@ -73,6 +75,12 @@
                <bibl type="ddbdp">P.Princ.:2:107</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+           <p>
+             <figure>
+               <graphic url="https://dpul.princeton.edu/papyri/catalog/rx913t395"/>
+             </figure>
+           </p>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p5.xml
+++ b/APIS/princeton/xml/princeton.apis.p5.xml
@@ -81,6 +81,7 @@
                <graphic url="https://dpul.princeton.edu/papyri/catalog/rx913t395"/>
              </figure>
            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p50.xml
+++ b/APIS/princeton/xml/princeton.apis.p50.xml
@@ -63,6 +63,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/05741x15v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p500.xml
+++ b/APIS/princeton/xml/princeton.apis.p500.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/gh93h209q"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3j333576v"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p502.xml
+++ b/APIS/princeton/xml/princeton.apis.p502.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/j96023213"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/kh04dt20h"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p504.xml
+++ b/APIS/princeton/xml/princeton.apis.p504.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6969z524x"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p505.xml
+++ b/APIS/princeton/xml/princeton.apis.p505.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/br86b7083"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p506.xml
+++ b/APIS/princeton/xml/princeton.apis.p506.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/7w62fd67w"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p507.xml
+++ b/APIS/princeton/xml/princeton.apis.p507.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/0k225f56x"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p508.xml
+++ b/APIS/princeton/xml/princeton.apis.p508.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bg257k53h"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p509.xml
+++ b/APIS/princeton/xml/princeton.apis.p509.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bg257k53h"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p51.xml
+++ b/APIS/princeton/xml/princeton.apis.p51.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/05741x15v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p512.xml
+++ b/APIS/princeton/xml/princeton.apis.p512.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/rv042x584"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p513.xml
+++ b/APIS/princeton/xml/princeton.apis.p513.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hm50tx19q"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p514.xml
+++ b/APIS/princeton/xml/princeton.apis.p514.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/b2774115v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p515.xml
+++ b/APIS/princeton/xml/princeton.apis.p515.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/n296x359k"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p516.xml
+++ b/APIS/princeton/xml/princeton.apis.p516.xml
@@ -68,6 +68,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/pn89db11s"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p516"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p517.xml
+++ b/APIS/princeton/xml/princeton.apis.p517.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/sx61dr76d"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p520.xml
+++ b/APIS/princeton/xml/princeton.apis.p520.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/xp68km674"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p521.xml
+++ b/APIS/princeton/xml/princeton.apis.p521.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/70795c168"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p522.xml
+++ b/APIS/princeton/xml/princeton.apis.p522.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/m900nx936"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p523.xml
+++ b/APIS/princeton/xml/princeton.apis.p523.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2b88qh64s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p524.xml
+++ b/APIS/princeton/xml/princeton.apis.p524.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6395wc55c"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p525.xml
+++ b/APIS/princeton/xml/princeton.apis.p525.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/9306t1891"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cj82kb80x"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p525"/>

--- a/APIS/princeton/xml/princeton.apis.p526.xml
+++ b/APIS/princeton/xml/princeton.apis.p526.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/mc87pv70v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p527.xml
+++ b/APIS/princeton/xml/princeton.apis.p527.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/fq977x36q"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1n79h781x"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p530.xml
+++ b/APIS/princeton/xml/princeton.apis.p530.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1g05fg110"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p532.xml
+++ b/APIS/princeton/xml/princeton.apis.p532.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/qn59q750k"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p534.xml
+++ b/APIS/princeton/xml/princeton.apis.p534.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/000002601"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/vd66w3415"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p535.xml
+++ b/APIS/princeton/xml/princeton.apis.p535.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1c18dm24p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p536.xml
+++ b/APIS/princeton/xml/princeton.apis.p536.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1c18dm24p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p537.xml
+++ b/APIS/princeton/xml/princeton.apis.p537.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/w3763c22d"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p538.xml
+++ b/APIS/princeton/xml/princeton.apis.p538.xml
@@ -70,6 +70,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/gq67jv69d"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p539.xml
+++ b/APIS/princeton/xml/princeton.apis.p539.xml
@@ -78,7 +78,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/794080741"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/rn301488g"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p541.xml
+++ b/APIS/princeton/xml/princeton.apis.p541.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/ms35tc22c"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8k71nm600"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p542.xml
+++ b/APIS/princeton/xml/princeton.apis.p542.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/1z40kw42p"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/sq87bz131"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p544.xml
+++ b/APIS/princeton/xml/princeton.apis.p544.xml
@@ -69,6 +69,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/4j03d3162"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p544"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p545.xml
+++ b/APIS/princeton/xml/princeton.apis.p545.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/02871133j"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p547.xml
+++ b/APIS/princeton/xml/princeton.apis.p547.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2514np08d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/zg64tq44w"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p547"/>

--- a/APIS/princeton/xml/princeton.apis.p549.xml
+++ b/APIS/princeton/xml/princeton.apis.p549.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/kk91fp141"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/7h149t38k"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p55.xml
+++ b/APIS/princeton/xml/princeton.apis.p55.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/7m01br158"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p550.xml
+++ b/APIS/princeton/xml/princeton.apis.p550.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/73666800j"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p551.xml
+++ b/APIS/princeton/xml/princeton.apis.p551.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/vt150n77k"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p552.xml
+++ b/APIS/princeton/xml/princeton.apis.p552.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cr56n450z"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p554.xml
+++ b/APIS/princeton/xml/princeton.apis.p554.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2227mt16p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p555.xml
+++ b/APIS/princeton/xml/princeton.apis.p555.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cj82kc759"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p559.xml
+++ b/APIS/princeton/xml/princeton.apis.p559.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/fq978024h"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p56.xml
+++ b/APIS/princeton/xml/princeton.apis.p56.xml
@@ -71,6 +71,13 @@
                <bibl type="ddbdp">P.Princ.:3:115</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/pg15bj39b"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p562.xml
+++ b/APIS/princeton/xml/princeton.apis.p562.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/tx31qp154"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p564.xml
+++ b/APIS/princeton/xml/princeton.apis.p564.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/765373949"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3b591d06w"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p564"/>

--- a/APIS/princeton/xml/princeton.apis.p565.xml
+++ b/APIS/princeton/xml/princeton.apis.p565.xml
@@ -75,7 +75,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/ww72bf10f"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/zw12z881f"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p565"/>

--- a/APIS/princeton/xml/princeton.apis.p566.xml
+++ b/APIS/princeton/xml/princeton.apis.p566.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/ww72bf10f"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/jw827g18g"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p566"/>

--- a/APIS/princeton/xml/princeton.apis.p567.xml
+++ b/APIS/princeton/xml/princeton.apis.p567.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/vq27zr01k"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/j098zf613"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p567"/>

--- a/APIS/princeton/xml/princeton.apis.p569.xml
+++ b/APIS/princeton/xml/princeton.apis.p569.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9w032749p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p570.xml
+++ b/APIS/princeton/xml/princeton.apis.p570.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/kd17cw449"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/s7526g929"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p572.xml
+++ b/APIS/princeton/xml/princeton.apis.p572.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/j098zd70n"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ng451n01n"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p573.xml
+++ b/APIS/princeton/xml/princeton.apis.p573.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/tt44pq44j"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/dv13zx731"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p575.xml
+++ b/APIS/princeton/xml/princeton.apis.p575.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/3n204168k"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/df65vc36v"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p575"/>

--- a/APIS/princeton/xml/princeton.apis.p576.xml
+++ b/APIS/princeton/xml/princeton.apis.p576.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/5712m912m"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8p58ph458"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p576"/>

--- a/APIS/princeton/xml/princeton.apis.p577.xml
+++ b/APIS/princeton/xml/princeton.apis.p577.xml
@@ -78,7 +78,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/0z7090038"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/41687m97w"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p577"/>

--- a/APIS/princeton/xml/princeton.apis.p578.xml
+++ b/APIS/princeton/xml/princeton.apis.p578.xml
@@ -77,7 +77,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/3f462803n"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/h415pf05n"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p578"/>

--- a/APIS/princeton/xml/princeton.apis.p579.xml
+++ b/APIS/princeton/xml/princeton.apis.p579.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/f7623g17w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/r494vp67x"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p579"/>

--- a/APIS/princeton/xml/princeton.apis.p58.xml
+++ b/APIS/princeton/xml/princeton.apis.p58.xml
@@ -78,11 +78,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/js956j41d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2n49t5214"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p58"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p581.xml
+++ b/APIS/princeton/xml/princeton.apis.p581.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/vq27zr01k"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6h440w97w"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p581"/>

--- a/APIS/princeton/xml/princeton.apis.p583.xml
+++ b/APIS/princeton/xml/princeton.apis.p583.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/gm80hx926"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/tx31qn217"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p584.xml
+++ b/APIS/princeton/xml/princeton.apis.p584.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/bc386m80z"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/5m60qw41j"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p584"/>

--- a/APIS/princeton/xml/princeton.apis.p585.xml
+++ b/APIS/princeton/xml/princeton.apis.p585.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/7h149s46n"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/tm70mz69w"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p585"/>

--- a/APIS/princeton/xml/princeton.apis.p586.xml
+++ b/APIS/princeton/xml/princeton.apis.p586.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/df65vb44x"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/g732dd33r"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p587.xml
+++ b/APIS/princeton/xml/princeton.apis.p587.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/fx719q06m"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/f1881q401"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p587"/>

--- a/APIS/princeton/xml/princeton.apis.p588.xml
+++ b/APIS/princeton/xml/princeton.apis.p588.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/0c483m97j"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/f7623h08b"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p589.xml
+++ b/APIS/princeton/xml/princeton.apis.p589.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/nc580q24z"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/q524js289"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p589"/>

--- a/APIS/princeton/xml/princeton.apis.p591.xml
+++ b/APIS/princeton/xml/princeton.apis.p591.xml
@@ -85,7 +85,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/sx61dp87h"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/h128nj210"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p591"/>

--- a/APIS/princeton/xml/princeton.apis.p592.xml
+++ b/APIS/princeton/xml/princeton.apis.p592.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/kd17cw449"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bz60d0782"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p595.xml
+++ b/APIS/princeton/xml/princeton.apis.p595.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/n296x359k"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p596.xml
+++ b/APIS/princeton/xml/princeton.apis.p596.xml
@@ -22,7 +22,7 @@
                   <idno type="invNo">GD 7534</idno>
                </msIdentifier>
                <msContents>
-                  <summary>Petition.  Mentions the name Zoilos.  PrÃ©aux identifies this text as a letter rather than as a petition [CE 23 (1948), 199]</summary>
+                  <summary>Petition.  Mentions the name Zoilos.  Préaux identifies this text as a letter rather than as a petition [CE 23 (1948), 199]</summary>
                   <msItemStruct>
                      <note type="general">Written along the fibers; back blank</note>
                      <note type="general">13 lines; complete, but many holes, some of which are along horizontal fold lines</note>
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/zs25xc055"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/gf06g6175"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p597.xml
+++ b/APIS/princeton/xml/princeton.apis.p597.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/4f16c541z"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/m613n2097"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p598.xml
+++ b/APIS/princeton/xml/princeton.apis.p598.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/pc289m666"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/n009w5816"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p6.xml
+++ b/APIS/princeton/xml/princeton.apis.p6.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/nv935544h"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/wd3760809"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p60.xml
+++ b/APIS/princeton/xml/princeton.apis.p60.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/j9602414h"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p601.xml
+++ b/APIS/princeton/xml/princeton.apis.p601.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/7m01bp28b"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/g732dd506"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p601"/>

--- a/APIS/princeton/xml/princeton.apis.p602.xml
+++ b/APIS/princeton/xml/princeton.apis.p602.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/xw42nd36j"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p603.xml
+++ b/APIS/princeton/xml/princeton.apis.p603.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/9g54xm240"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/fx719q81s"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p603"/>

--- a/APIS/princeton/xml/princeton.apis.p604.xml
+++ b/APIS/princeton/xml/princeton.apis.p604.xml
@@ -77,7 +77,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/6q182n72j"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/pk02cf243"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p605.xml
+++ b/APIS/princeton/xml/princeton.apis.p605.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/c821gn38q"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/pz50h061g"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p606.xml
+++ b/APIS/princeton/xml/princeton.apis.p606.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/h989r5793"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/028710207"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p607.xml
+++ b/APIS/princeton/xml/princeton.apis.p607.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/1g05ff19f"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cn69m764q"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p61.xml
+++ b/APIS/princeton/xml/princeton.apis.p61.xml
@@ -76,8 +76,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p61"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bn999b26d"/>
                </figure>
+               <figure>
+                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p61"/>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p610.xml
+++ b/APIS/princeton/xml/princeton.apis.p610.xml
@@ -78,7 +78,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/zw12z788d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/n296x2646"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p610"/>

--- a/APIS/princeton/xml/princeton.apis.p611.xml
+++ b/APIS/princeton/xml/princeton.apis.p611.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/f1881p49z"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/vh53x025t"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p611"/>

--- a/APIS/princeton/xml/princeton.apis.p612.xml
+++ b/APIS/princeton/xml/princeton.apis.p612.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/7m01bp28b"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bg257j58h"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p612"/>

--- a/APIS/princeton/xml/princeton.apis.p613.xml
+++ b/APIS/princeton/xml/princeton.apis.p613.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/ks65hf793"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/n296x265p"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p614.xml
+++ b/APIS/princeton/xml/princeton.apis.p614.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/0r967632w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/x633f454d"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p615.xml
+++ b/APIS/princeton/xml/princeton.apis.p615.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/d504rn91w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1z40kx34m"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p615"/>

--- a/APIS/princeton/xml/princeton.apis.p616.xml
+++ b/APIS/princeton/xml/princeton.apis.p616.xml
@@ -72,6 +72,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/3r074z46h"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p616"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p617.xml
+++ b/APIS/princeton/xml/princeton.apis.p617.xml
@@ -73,6 +73,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/hq37vs084"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p617"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p619.xml
+++ b/APIS/princeton/xml/princeton.apis.p619.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/t722hc39g"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/st74ct97r"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p62.xml
+++ b/APIS/princeton/xml/princeton.apis.p62.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/v405sc972"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/4x51hn52k"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p620.xml
+++ b/APIS/princeton/xml/princeton.apis.p620.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/37720g31n"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6395wb600"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p621.xml
+++ b/APIS/princeton/xml/princeton.apis.p621.xml
@@ -72,6 +72,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/g445ch480"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p621"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p622.xml
+++ b/APIS/princeton/xml/princeton.apis.p622.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/bn999b070"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/gf06g5999"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p623.xml
+++ b/APIS/princeton/xml/princeton.apis.p623.xml
@@ -75,7 +75,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/w3763935g"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/0v8384070"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p623"/>

--- a/APIS/princeton/xml/princeton.apis.p624.xml
+++ b/APIS/princeton/xml/princeton.apis.p624.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/6h440w05w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/q811kp132"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p625.xml
+++ b/APIS/princeton/xml/princeton.apis.p625.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/9306t1891"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/h989r6724"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p625"/>

--- a/APIS/princeton/xml/princeton.apis.p626.xml
+++ b/APIS/princeton/xml/princeton.apis.p626.xml
@@ -77,7 +77,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/ww72bf10f"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/4q77fv854"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p626"/>

--- a/APIS/princeton/xml/princeton.apis.p627.xml
+++ b/APIS/princeton/xml/princeton.apis.p627.xml
@@ -78,7 +78,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/zw12z788d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/qb98mj987"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p627"/>

--- a/APIS/princeton/xml/princeton.apis.p628.xml
+++ b/APIS/princeton/xml/princeton.apis.p628.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bv73c392f"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p629.xml
+++ b/APIS/princeton/xml/princeton.apis.p629.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/x346d6767"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/gq67jv70h"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p63.xml
+++ b/APIS/princeton/xml/princeton.apis.p63.xml
@@ -76,6 +76,13 @@
                <bibl type="ddbdp">SB:14:12086</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9p290d85w"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p630.xml
+++ b/APIS/princeton/xml/princeton.apis.p630.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/gm80hx926"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/dz010t56j"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p631.xml
+++ b/APIS/princeton/xml/princeton.apis.p631.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/wm117r588"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3f462895n"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p632.xml
+++ b/APIS/princeton/xml/princeton.apis.p632.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/dj52w728k"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/qr46r433r"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p632"/>

--- a/APIS/princeton/xml/princeton.apis.p633.xml
+++ b/APIS/princeton/xml/princeton.apis.p633.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/f7623g17w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/0g354j728"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p633"/>

--- a/APIS/princeton/xml/princeton.apis.p634.xml
+++ b/APIS/princeton/xml/princeton.apis.p634.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/wm117t456"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p635.xml
+++ b/APIS/princeton/xml/princeton.apis.p635.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/rx913s48q"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/kd17cx367"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p636.xml
+++ b/APIS/princeton/xml/princeton.apis.p636.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/nk322g93f"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/sq87bz12j"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p636"/>

--- a/APIS/princeton/xml/princeton.apis.p637.xml
+++ b/APIS/princeton/xml/princeton.apis.p637.xml
@@ -73,7 +73,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/w3763935g"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ft848v13d"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p637"/>

--- a/APIS/princeton/xml/princeton.apis.p638.xml
+++ b/APIS/princeton/xml/princeton.apis.p638.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/ft848t200"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/xd07gx204"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p638"/>

--- a/APIS/princeton/xml/princeton.apis.p639.xml
+++ b/APIS/princeton/xml/princeton.apis.p639.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/3484zk51k"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/7m01bq19s"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p639"/>

--- a/APIS/princeton/xml/princeton.apis.p64.xml
+++ b/APIS/princeton/xml/princeton.apis.p64.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Medical Text Imiddle I AD]</title>
+            <title>Medical Text [middle I AD]</title>
          </titleStmt>
          <publicationStmt>
             <authority>APIS</authority>
@@ -72,6 +72,13 @@
                </bibl>
                <bibl type="ddbdp">P.Princ.:3:114</bibl>
             </listBibl>
+         </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/br86b707m"/>
+               </figure>
+            </p>
          </div>
       </body>
    </text>

--- a/APIS/princeton/xml/princeton.apis.p640.xml
+++ b/APIS/princeton/xml/princeton.apis.p640.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/9g54xm240"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/b8515r71n"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p640"/>

--- a/APIS/princeton/xml/princeton.apis.p642.xml
+++ b/APIS/princeton/xml/princeton.apis.p642.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/th83m191q"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/m613n210b"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p642"/>

--- a/APIS/princeton/xml/princeton.apis.p645.xml
+++ b/APIS/princeton/xml/princeton.apis.p645.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/tm70mx76g"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3484zm43h"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p645"/>

--- a/APIS/princeton/xml/princeton.apis.p646.xml
+++ b/APIS/princeton/xml/princeton.apis.p646.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/z603r102p"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/zp38wh13f"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p647.xml
+++ b/APIS/princeton/xml/princeton.apis.p647.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/dz010s64m"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/p5547v883"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p647"/>

--- a/APIS/princeton/xml/princeton.apis.p649.xml
+++ b/APIS/princeton/xml/princeton.apis.p649.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/vq27zr01k"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9k41zj01p"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p649"/>

--- a/APIS/princeton/xml/princeton.apis.p650.xml
+++ b/APIS/princeton/xml/princeton.apis.p650.xml
@@ -75,7 +75,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/vq27zr01k"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9k41zj01p"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p651.xml
+++ b/APIS/princeton/xml/princeton.apis.p651.xml
@@ -75,7 +75,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/ww72bf10f"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/z603r194p"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p651"/>

--- a/APIS/princeton/xml/princeton.apis.p652.xml
+++ b/APIS/princeton/xml/princeton.apis.p652.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/6m311r90q"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/vm40xw093"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p653.xml
+++ b/APIS/princeton/xml/princeton.apis.p653.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2227ms24r"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ms35td149"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p654.xml
+++ b/APIS/princeton/xml/princeton.apis.p654.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2n49t429k"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/nz806320q"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p654"/>

--- a/APIS/princeton/xml/princeton.apis.p655.xml
+++ b/APIS/princeton/xml/princeton.apis.p655.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/ns064863g"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/dj52w821m"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p656.xml
+++ b/APIS/princeton/xml/princeton.apis.p656.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/6h440w05w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9593tz63q"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p657.xml
+++ b/APIS/princeton/xml/princeton.apis.p657.xml
@@ -73,6 +73,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/6d570113j"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p657"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p658.xml
+++ b/APIS/princeton/xml/princeton.apis.p658.xml
@@ -73,7 +73,10 @@
          </div>
          <div type="figure">
             <p>
-               <figure>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/2n49t522m"/>
+              </figure>
+              <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p658"/>
                </figure>
             </p>

--- a/APIS/princeton/xml/princeton.apis.p659.xml
+++ b/APIS/princeton/xml/princeton.apis.p659.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/qr46r340b"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6q182p65z"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p66.xml
+++ b/APIS/princeton/xml/princeton.apis.p66.xml
@@ -78,11 +78,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/sx61dp87h"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3t945v281"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p66"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p660.xml
+++ b/APIS/princeton/xml/princeton.apis.p660.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/5h73pz64v"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/zc77st626"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p660"/>

--- a/APIS/princeton/xml/princeton.apis.p661.xml
+++ b/APIS/princeton/xml/princeton.apis.p661.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/mp48sg35n"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/vx021j61v"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p663.xml
+++ b/APIS/princeton/xml/princeton.apis.p663.xml
@@ -72,6 +72,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/xw42nc42n"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p663"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p664.xml
+++ b/APIS/princeton/xml/princeton.apis.p664.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/np193c758"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/zk51vm272"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p665.xml
+++ b/APIS/princeton/xml/princeton.apis.p665.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/3x816q20c"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/4j03d317j"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p665"/>

--- a/APIS/princeton/xml/princeton.apis.p668.xml
+++ b/APIS/princeton/xml/princeton.apis.p668.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9019s5979"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p669.xml
+++ b/APIS/princeton/xml/princeton.apis.p669.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8w32rb073"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p671.xml
+++ b/APIS/princeton/xml/princeton.apis.p671.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/kd17cz32q"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p672.xml
+++ b/APIS/princeton/xml/princeton.apis.p672.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/w0892d53s"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9s1619682"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p673.xml
+++ b/APIS/princeton/xml/princeton.apis.p673.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8049g951j"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p674.xml
+++ b/APIS/princeton/xml/princeton.apis.p674.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/z890rz70b"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p675.xml
+++ b/APIS/princeton/xml/princeton.apis.p675.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/xp68km674"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p678.xml
+++ b/APIS/princeton/xml/princeton.apis.p678.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/n009w4885"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3n2042591"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p679.xml
+++ b/APIS/princeton/xml/princeton.apis.p679.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/mc87pt75v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p680.xml
+++ b/APIS/princeton/xml/princeton.apis.p680.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2z10wv698"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p681.xml
+++ b/APIS/princeton/xml/princeton.apis.p681.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/p2677006q"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p682.xml
+++ b/APIS/princeton/xml/princeton.apis.p682.xml
@@ -87,7 +87,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/j6731635v"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/5h73q0565"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p683.xml
+++ b/APIS/princeton/xml/princeton.apis.p683.xml
@@ -89,7 +89,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2514np08d"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/37720h242"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p685.xml
+++ b/APIS/princeton/xml/princeton.apis.p685.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/g445cg73h"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/sb397c763"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p685"/>

--- a/APIS/princeton/xml/princeton.apis.p686.xml
+++ b/APIS/princeton/xml/princeton.apis.p686.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/8g84mp858"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/gf06g618n"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p686"/>

--- a/APIS/princeton/xml/princeton.apis.p687.xml
+++ b/APIS/princeton/xml/princeton.apis.p687.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1c18dm24p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p688.xml
+++ b/APIS/princeton/xml/princeton.apis.p688.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2z10ws800"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/n583xz33m"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p688"/>

--- a/APIS/princeton/xml/princeton.apis.p69.xml
+++ b/APIS/princeton/xml/princeton.apis.p69.xml
@@ -79,11 +79,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/c534fr53k"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/sf268860c"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p69"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p690.xml
+++ b/APIS/princeton/xml/princeton.apis.p690.xml
@@ -84,7 +84,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/pr76f6002"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/0p096b429"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p691.xml
+++ b/APIS/princeton/xml/princeton.apis.p691.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/xw42nb49m"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/b2774020g"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p691"/>

--- a/APIS/princeton/xml/princeton.apis.p692.xml
+++ b/APIS/princeton/xml/princeton.apis.p692.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/t435gg588"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/t435gh519"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p693.xml
+++ b/APIS/princeton/xml/princeton.apis.p693.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/d217qs10m"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/dz010t571"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p694.xml
+++ b/APIS/princeton/xml/princeton.apis.p694.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/f4752k337"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/5425kf20w"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p695.xml
+++ b/APIS/princeton/xml/princeton.apis.p695.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/f4752k337"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/cz30px16x"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p696.xml
+++ b/APIS/princeton/xml/princeton.apis.p696.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/g158bk88r"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8623j225z"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p7.xml
+++ b/APIS/princeton/xml/princeton.apis.p7.xml
@@ -80,11 +80,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2b88qf76c"/>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/ww72bg02c"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p7"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p70.xml
+++ b/APIS/princeton/xml/princeton.apis.p70.xml
@@ -76,11 +76,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/w3763935g"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/05741w21z"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p70"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p700.xml
+++ b/APIS/princeton/xml/princeton.apis.p700.xml
@@ -84,7 +84,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/pr76f6002"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/7d278x52z"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p701.xml
+++ b/APIS/princeton/xml/princeton.apis.p701.xml
@@ -82,27 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <head>Recto :: 0 :: 12 kb image</head>
-                  <figDesc> 12</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p701&amp;size=12&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Recto :: 0 :: 636 kb image</head>
-                  <figDesc> 150</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p701&amp;size=150&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Recto :: 0 :: 2360 kb image</head>
-                  <figDesc> 300</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p701&amp;size=300&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <head>Recto :: 0 :: 180 kb image</head>
-                  <figDesc> 75</figDesc>
-                  <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p701&amp;size=75&amp;face=f&amp;tile=0"/>
-               </figure>
-               <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/8049g764m"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6d5701122"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p701"/>

--- a/APIS/princeton/xml/princeton.apis.p702.xml
+++ b/APIS/princeton/xml/princeton.apis.p702.xml
@@ -76,7 +76,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/x920g045n"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2801pk84p"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p703.xml
+++ b/APIS/princeton/xml/princeton.apis.p703.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/js956k32v"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p704.xml
+++ b/APIS/princeton/xml/princeton.apis.p704.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/fq978024h"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p705.xml
+++ b/APIS/princeton/xml/princeton.apis.p705.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/cf95jf054"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/m039k824g"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p706.xml
+++ b/APIS/princeton/xml/princeton.apis.p706.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/794080741"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ft848v12x"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p707.xml
+++ b/APIS/princeton/xml/princeton.apis.p707.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/ff365784j"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/44558h815"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p707"/>

--- a/APIS/princeton/xml/princeton.apis.p708.xml
+++ b/APIS/princeton/xml/princeton.apis.p708.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/bc386m80z"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1v53k148r"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p708"/>

--- a/APIS/princeton/xml/princeton.apis.p709.xml
+++ b/APIS/princeton/xml/princeton.apis.p709.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/47429d64b"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p710.xml
+++ b/APIS/princeton/xml/princeton.apis.p710.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/t722hc380"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/p8418r71w"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p712.xml
+++ b/APIS/princeton/xml/princeton.apis.p712.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/000002601"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/xk81jp89t"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p713.xml
+++ b/APIS/princeton/xml/princeton.apis.p713.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/ht24wn02f"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/37720h242"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p714.xml
+++ b/APIS/princeton/xml/princeton.apis.p714.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1j92gb980"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p715.xml
+++ b/APIS/princeton/xml/princeton.apis.p715.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/kh04dv15w"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p717.xml
+++ b/APIS/princeton/xml/princeton.apis.p717.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/xk81jn97w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2b88qg689"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p718.xml
+++ b/APIS/princeton/xml/princeton.apis.p718.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/n870zt40t"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8336h5419"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p719.xml
+++ b/APIS/princeton/xml/princeton.apis.p719.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/000002601"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2b88qg69s"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p720.xml
+++ b/APIS/princeton/xml/princeton.apis.p720.xml
@@ -77,7 +77,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/7d278w61h"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/mw22v897j"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p721.xml
+++ b/APIS/princeton/xml/princeton.apis.p721.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/zk51vn23j"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p724.xml
+++ b/APIS/princeton/xml/princeton.apis.p724.xml
@@ -67,6 +67,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/db78tg53p"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p724"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p725.xml
+++ b/APIS/princeton/xml/princeton.apis.p725.xml
@@ -69,6 +69,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9019s693s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p726.xml
+++ b/APIS/princeton/xml/princeton.apis.p726.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/q811kq08f"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p729.xml
+++ b/APIS/princeton/xml/princeton.apis.p729.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/1c18dk29p"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p730.xml
+++ b/APIS/princeton/xml/princeton.apis.p730.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/2b88qh64s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p732.xml
+++ b/APIS/princeton/xml/princeton.apis.p732.xml
@@ -78,7 +78,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/b5644v139"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/r494vp68d"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p737.xml
+++ b/APIS/princeton/xml/princeton.apis.p737.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/d504rn91w"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/7p88cm06g"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p737"/>

--- a/APIS/princeton/xml/princeton.apis.p738.xml
+++ b/APIS/princeton/xml/princeton.apis.p738.xml
@@ -78,6 +78,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/np193d676"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p738"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p741.xml
+++ b/APIS/princeton/xml/princeton.apis.p741.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k3569784w"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p743.xml
+++ b/APIS/princeton/xml/princeton.apis.p743.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3b591f02c"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p744.xml
+++ b/APIS/princeton/xml/princeton.apis.p744.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/rj4307158"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hx11xj75n"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p75.xml
+++ b/APIS/princeton/xml/princeton.apis.p75.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/g732df462"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p751.xml
+++ b/APIS/princeton/xml/princeton.apis.p751.xml
@@ -62,6 +62,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/0r9677259"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p756.xml
+++ b/APIS/princeton/xml/princeton.apis.p756.xml
@@ -62,6 +62,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/0v838406h"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p76.xml
+++ b/APIS/princeton/xml/princeton.apis.p76.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/z029p8237"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p762.xml
+++ b/APIS/princeton/xml/princeton.apis.p762.xml
@@ -69,6 +69,13 @@
             <listBibl>
                <bibl>Unpublished</bibl>
             </listBibl>
+            <div type="figure">
+               <p>
+                  <figure>
+                     <graphic url="https://dpul.princeton.edu/papyri/catalog/zs25xc975"/>
+                  </figure>
+               </p>
+            </div>
          </div>
       </body>
    </text>

--- a/APIS/princeton/xml/princeton.apis.p763.xml
+++ b/APIS/princeton/xml/princeton.apis.p763.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/rf55zc19n"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p766.xml
+++ b/APIS/princeton/xml/princeton.apis.p766.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/73666897z"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p769.xml
+++ b/APIS/princeton/xml/princeton.apis.p769.xml
@@ -63,6 +63,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/rf55zc19n"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p774.xml
+++ b/APIS/princeton/xml/princeton.apis.p774.xml
@@ -62,6 +62,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/5m60qx38w"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p776.xml
+++ b/APIS/princeton/xml/princeton.apis.p776.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6t053k484"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p777.xml
+++ b/APIS/princeton/xml/princeton.apis.p777.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k3569878s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p792.xml
+++ b/APIS/princeton/xml/princeton.apis.p792.xml
@@ -71,6 +71,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/xs55mg57w"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p792"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p798.xml
+++ b/APIS/princeton/xml/princeton.apis.p798.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/c247dw60c"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p799.xml
+++ b/APIS/princeton/xml/princeton.apis.p799.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/pv63g4694"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p8.xml
+++ b/APIS/princeton/xml/princeton.apis.p8.xml
@@ -80,7 +80,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/bg257h653"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/jq085p48r"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p804.xml
+++ b/APIS/princeton/xml/princeton.apis.p804.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k3569878s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p806.xml
+++ b/APIS/princeton/xml/princeton.apis.p806.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k3569878s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p808.xml
+++ b/APIS/princeton/xml/princeton.apis.p808.xml
@@ -63,6 +63,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k3569878s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p813.xml
+++ b/APIS/princeton/xml/princeton.apis.p813.xml
@@ -62,6 +62,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/hh63t136x"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p814.xml
+++ b/APIS/princeton/xml/princeton.apis.p814.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3n2042604"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p815.xml
+++ b/APIS/princeton/xml/princeton.apis.p815.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bv73c489s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p818.xml
+++ b/APIS/princeton/xml/princeton.apis.p818.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ff365971g"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p822.xml
+++ b/APIS/princeton/xml/princeton.apis.p822.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/n870zw274"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p823.xml
+++ b/APIS/princeton/xml/princeton.apis.p823.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bg257k53h"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p827.xml
+++ b/APIS/princeton/xml/princeton.apis.p827.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/pv63g4694"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p828.xml
+++ b/APIS/princeton/xml/princeton.apis.p828.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/zp38wj08t"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p830.xml
+++ b/APIS/princeton/xml/princeton.apis.p830.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k3569878s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p837.xml
+++ b/APIS/princeton/xml/princeton.apis.p837.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bg257k53h"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p839.xml
+++ b/APIS/princeton/xml/princeton.apis.p839.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k3569878s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p842.xml
+++ b/APIS/princeton/xml/princeton.apis.p842.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/bg257k53h"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p846.xml
+++ b/APIS/princeton/xml/princeton.apis.p846.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/k3569878s"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p847.xml
+++ b/APIS/princeton/xml/princeton.apis.p847.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/79408168x"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p848.xml
+++ b/APIS/princeton/xml/princeton.apis.p848.xml
@@ -65,6 +65,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8c97kt922"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p852.xml
+++ b/APIS/princeton/xml/princeton.apis.p852.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/st74cv92r"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p858.xml
+++ b/APIS/princeton/xml/princeton.apis.p858.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/z890rx75b"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p887.xml
+++ b/APIS/princeton/xml/princeton.apis.p887.xml
@@ -64,6 +64,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/nv935731f"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p888.xml
+++ b/APIS/princeton/xml/princeton.apis.p888.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8p58pj408"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p889.xml
+++ b/APIS/princeton/xml/princeton.apis.p889.xml
@@ -66,6 +66,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/8p58pj408"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p891.xml
+++ b/APIS/princeton/xml/princeton.apis.p891.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/tm70mz68d"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p892.xml
+++ b/APIS/princeton/xml/princeton.apis.p892.xml
@@ -67,6 +67,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3197xq54t"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/APIS/princeton/xml/princeton.apis.p9.xml
+++ b/APIS/princeton/xml/princeton.apis.p9.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/2b88qf76c"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/6682x746m"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p904.xml
+++ b/APIS/princeton/xml/princeton.apis.p904.xml
@@ -67,6 +67,9 @@
          </div>
          <div type="figure">
             <p>
+              <figure>
+                 <graphic url="https://dpul.princeton.edu/papyri/catalog/pv63g376q"/>
+              </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p904"/>
                </figure>

--- a/APIS/princeton/xml/princeton.apis.p907.xml
+++ b/APIS/princeton/xml/princeton.apis.p907.xml
@@ -79,7 +79,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/kd17cw449"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/3n2042604"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p92.xml
+++ b/APIS/princeton/xml/princeton.apis.p92.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/x633f362g"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ws859k164"/>
                </figure>
             </p>
          </div>

--- a/APIS/princeton/xml/princeton.apis.p93.xml
+++ b/APIS/princeton/xml/princeton.apis.p93.xml
@@ -81,11 +81,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/jh343v88r"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/t722hd311"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p93"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p94.xml
+++ b/APIS/princeton/xml/princeton.apis.p94.xml
@@ -81,11 +81,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/9593tx71s"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/pc289n59m"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p94"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p95.xml
+++ b/APIS/princeton/xml/princeton.apis.p95.xml
@@ -81,11 +81,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/b8515q971"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/ff365877z"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p95"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p97.xml
+++ b/APIS/princeton/xml/princeton.apis.p97.xml
@@ -79,11 +79,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://arks.princeton.edu/ark:/88435/9306t1891"/>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/9880vv49b"/>
                </figure>
                <figure>
                   <graphic url="http://www.columbia.edu/cgi-bin/dlo?obj=princeton.apis.p97"/>
-               </figure>
+                </figure>
             </p>
          </div>
       </body>

--- a/APIS/princeton/xml/princeton.apis.p98.xml
+++ b/APIS/princeton/xml/princeton.apis.p98.xml
@@ -68,6 +68,13 @@
          <div type="bibliography" subtype="citations">
             <p>No citations.</p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://dpul.princeton.edu/papyri/catalog/c821gq25n"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>


### PR DESCRIPTION
Princeton has updated once again its digital collections for papyri, deprecating the old `http://arks.princeton.edu/ark:/` hyperlinks used throughout PN. 

After manually iterating through APIS XML and collating with entries in the new site, I have added or updated hyperlinks, which the enclosed commits push to the canonical repo. 

A few things to note:

1. Changes have been made only to the APIS files; HGV/DCLP have been left untouched. Perhaps Carmen can cook up something to transfer the new links to those databases, too.
2. Princeton has a habit of housing multiple fragments within the same glazing. Occasionally (but not always) a separate page has been created in the catalogue for each of the individual pieces, but where that is not true I've resorted to using the single hyperlink for the multiple papyri under the same glass. Where that happens, the catalogue entry refers to another papyrus even though the image also depicts the papyrus in question. I acknowledge that will be potentially confusing for some users, though the intent is to provide access to an image of the papyrus.