### PR TITLE
BASP 58 Xwalk

### DIFF
--- a/HGV_meta_EpiDoc/HGV143/142876.xml
+++ b/HGV_meta_EpiDoc/HGV143/142876.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>An order from the Late Antique Herakleopolite nome (P.Lund inv. 41)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">142876</idno>
+        <idno type="TM">142876</idno>
+        <idno type="ddb-filename">basp.58.151</idno>
+        <idno type="ddb-hybrid">basp;58;151</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Lund</settlement>
+            </placeName>
+            <collection>University</collection>
+            <idno type="invNo">P. 41</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolites</origPlace>
+              <origDate notBefore="0301" notAfter="0500" precision="low">IV - V</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95980"/>
+            <biblScope type="pp">151</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Anweisung</term>
+          <term n="2">Zahlung</term>
+          <term n="3">Wein</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 151</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 152</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV845/844316.xml
+++ b/HGV_meta_EpiDoc/HGV845/844316.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Some remarks on P.Carlsberg inv. 555 + PSI inv. D 111</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">844316</idno>
+        <idno type="TM">844316</idno>
+        <idno type="ddb-filename">basp.58.370</idno>
+        <idno type="ddb-hybrid">basp;58;370</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Copenhagen</settlement>
+            </placeName>
+            <collection>Carlsberg Papyrus Collection</collection>
+            <idno type="invNo">P. 555 Ro + Florence, Istituto Papirologico ’G. Vitelli’ PSI inv. D 111 Ro</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoites</origPlace>
+              <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome" ref="https://pleiades.stoa.org/places/736893 https://www.trismegistos.org/place/332">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95989"/>
+            <biblScope type="pp">370</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Militär</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 370</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971610.xml
+++ b/HGV_meta_EpiDoc/HGV972/971610.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Three more Hermopolite Samaritans</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971610</idno>
+        <idno type="TM">971610</idno>
+        <idno type="ddb-filename">basp.58.173</idno>
+        <idno type="ddb-hybrid">basp;58;173</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Oxford</settlement>
+            </placeName>
+            <collection>Bodleian Library</collection>
+            <idno type="invNo">MS. Gr. class. f. 106 (P)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hermopolites</origPlace>
+              <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95983"/>
+            <biblScope type="pp">173</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+          <term n="2">Namen</term>
+          <term n="3">Ortsname</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 173</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 174</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971611.xml
+++ b/HGV_meta_EpiDoc/HGV972/971611.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Topographical tax-register in Greek from Eighth-Century Fayyūm</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971611</idno>
+        <idno type="TM">971611</idno>
+        <idno type="ddb-filename">basp.58.188</idno>
+        <idno type="ddb-hybrid">basp;58;188</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Aberdeen</settlement>
+            </placeName>
+            <collection>King’s College</collection>
+            <idno type="invNo">147 c</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fayūm</origPlace>
+              <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome" ref="https://pleiades.stoa.org/places/736893 https://www.trismegistos.org/place/332">Fayūm</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95985"/>
+            <biblScope type="pp">188</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Register</term>
+          <term n="2">Steuer</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 188</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 189</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971612.xml
+++ b/HGV_meta_EpiDoc/HGV972/971612.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Topographical tax-register in Greek from Eighth-Century Fayyūm</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971612</idno>
+        <idno type="TM">971612</idno>
+	 <idno type="ddb-filename">basp.58.196</idno>
+        <idno type="ddb-hybrid">basp;58;196</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+               <settlement>Aberdeen</settlement>
+            </placeName>
+            <collection>King’s College</collection>
+            <idno type="invNo">134 a</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Fayūm</origPlace>
+              <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome" ref="https://pleiades.stoa.org/places/736893 https://www.trismegistos.org/place/332">Fayūm</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+  <bibl type="SB">
+    <ptr target="https://papyri.info/biblio/95985"/>
+    <biblScope type="pp">196</biblScope>
+  </bibl>
+</listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+    <textClass>
+      <keywords scheme="hgv">
+        <term n="1">Register</term>
+        <term n="2">Steuer</term>
+      </keywords>
+    </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 196</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 197</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971650.xml
+++ b/HGV_meta_EpiDoc/HGV972/971650.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for two chickens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971650</idno>
+        <idno type="TM">971650</idno>
+        <idno type="ddb-filename">basp.58.99_1</idno>
+        <idno type="ddb-hybrid">basp;58;99_1</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 15/791/2011 (5)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">99</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Hühner</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 99</biblScope>
+            <biblScope type="number">Nr. 1</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 99</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971651.xml
+++ b/HGV_meta_EpiDoc/HGV972/971651.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of deliveries of chickens by Tithoes</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971651</idno>
+        <idno type="TM">971651</idno>
+        <idno type="ddb-filename">basp.58.100_2</idno>
+        <idno type="ddb-hybrid">basp;58;100_2</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 15/791/2011 (1)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">100</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+          <term n="2">Lieferung</term>
+          <term n="3">Hühner</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 100</biblScope>
+            <biblScope type="number">Nr. 2</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 101</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971652.xml
+++ b/HGV_meta_EpiDoc/HGV972/971652.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for two chickens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971652</idno>
+        <idno type="TM">971652</idno>
+        <idno type="ddb-filename">basp.58.102_3</idno>
+        <idno type="ddb-hybrid">basp;58;102_3</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 2/725/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">102</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Hühner</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 102</biblScope>
+            <biblScope type="number">Nr. 3</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 102</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971653.xml
+++ b/HGV_meta_EpiDoc/HGV972/971653.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for a chicken</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971653</idno>
+        <idno type="TM">971653</idno>
+        <idno type="ddb-filename">basp.58.102_4</idno>
+        <idno type="ddb-hybrid">basp;58;102_4</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 14/770/2010 (1)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">102</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Huhn</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 102</biblScope>
+            <biblScope type="number">Nr. 4</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 102</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971654.xml
+++ b/HGV_meta_EpiDoc/HGV972/971654.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for two chickens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971654</idno>
+        <idno type="TM">971654</idno>
+        <idno type="ddb-filename">basp.58.103_5</idno>
+        <idno type="ddb-hybrid">basp;58;103_5</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 5/728/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">103</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Hühner</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 103</biblScope>
+            <biblScope type="number">Nr. 5</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 103</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971655.xml
+++ b/HGV_meta_EpiDoc/HGV972/971655.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for a chicken</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971655</idno>
+        <idno type="TM">971655</idno>
+        <idno type="ddb-filename">basp.58.104_6</idno>
+        <idno type="ddb-hybrid">basp;58;104_6</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 4/727/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">104</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Huhn</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 104</biblScope>
+            <biblScope type="number">Nr. 6</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 104</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971656.xml
+++ b/HGV_meta_EpiDoc/HGV972/971656.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for a chicken</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971656</idno>
+        <idno type="TM">971656</idno>
+        <idno type="ddb-filename">basp.58.105_7</idno>
+        <idno type="ddb-hybrid">basp;58;105_7</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 8/731/2009 [a?]</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">105</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Huhn</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 105</biblScope>
+            <biblScope type="number">Nr. 7</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 105</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971657.xml
+++ b/HGV_meta_EpiDoc/HGV972/971657.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for four chickens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971657</idno>
+        <idno type="TM">971657</idno>
+        <idno type="ddb-filename">basp.58.105_8</idno>
+        <idno type="ddb-hybrid">basp;58;105_8</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 8/731/2009 [b?]</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">105</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Hühner</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 105</biblScope>
+            <biblScope type="number">Nr. 8</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 105</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971658.xml
+++ b/HGV_meta_EpiDoc/HGV972/971658.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for six chickens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971658</idno>
+        <idno type="TM">971658</idno>
+        <idno type="ddb-filename">basp.58.106_9</idno>
+        <idno type="ddb-hybrid">basp;58;106_9</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 1/724/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">106</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Hühner</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 106</biblScope>
+            <biblScope type="number">Nr. 9</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 106</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971659.xml
+++ b/HGV_meta_EpiDoc/HGV972/971659.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for six chickens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971659</idno>
+        <idno type="TM">971659</idno>
+        <idno type="ddb-filename">basp.58.106_10</idno>
+        <idno type="ddb-hybrid">basp;58;106_10</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 13/769/2010 (1)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">106</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Hühner</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 106</biblScope>
+            <biblScope type="number">Nr. 10</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 106</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971660.xml
+++ b/HGV_meta_EpiDoc/HGV972/971660.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for a chicken</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971660</idno>
+        <idno type="TM">971660</idno>
+        <idno type="ddb-filename">basp.58.107_11</idno>
+        <idno type="ddb-hybrid">basp;58;107_11</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 7/730/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">107</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Huhn</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 107</biblScope>
+            <biblScope type="number">Nr. 11</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 107</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971661.xml
+++ b/HGV_meta_EpiDoc/HGV972/971661.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for four chickens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971661</idno>
+        <idno type="TM">971661</idno>
+        <idno type="ddb-filename">basp.58.107_12</idno>
+        <idno type="ddb-hybrid">basp;58;107_12</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 11/767/2010 (2)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">107</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Hühner</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 107</biblScope>
+            <biblScope type="number">Nr. 12</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 107</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971662.xml
+++ b/HGV_meta_EpiDoc/HGV972/971662.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for four chickens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971662</idno>
+        <idno type="TM">971662</idno>
+        <idno type="ddb-filename">basp.58.108_13</idno>
+        <idno type="ddb-hybrid">basp;58;108_13</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 9/732/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">108</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Hühner</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 108</biblScope>
+            <biblScope type="number">Nr. 13</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 108</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971663.xml
+++ b/HGV_meta_EpiDoc/HGV972/971663.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for four chickens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971663</idno>
+        <idno type="TM">971663</idno>
+        <idno type="ddb-filename">basp.58.108_14</idno>
+        <idno type="ddb-hybrid">basp;58;108_14</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 3/726/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">108</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Hühner</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 108</biblScope>
+            <biblScope type="number">Nr. 14</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 108</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971664.xml
+++ b/HGV_meta_EpiDoc/HGV972/971664.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for a chicken</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971664</idno>
+        <idno type="TM">971664</idno>
+        <idno type="ddb-filename">basp.58.109_15</idno>
+        <idno type="ddb-hybrid">basp;58;109_15</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 2/725/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">109</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Huhn</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 109</biblScope>
+            <biblScope type="number">Nr. 15</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 109</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971665.xml
+++ b/HGV_meta_EpiDoc/HGV972/971665.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for a chicken</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971665</idno>
+        <idno type="TM">971665</idno>
+        <idno type="ddb-filename">basp.58.109_16</idno>
+        <idno type="ddb-hybrid">basp;58;109_16</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 7/730/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">109</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Huhn</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 109</biblScope>
+            <biblScope type="number">Nr. 16</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 109</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971666.xml
+++ b/HGV_meta_EpiDoc/HGV972/971666.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Delivery note for dates</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971666</idno>
+        <idno type="TM">971666</idno>
+        <idno type="ddb-filename">basp.58.110_17</idno>
+        <idno type="ddb-hybrid">basp;58;110_17</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 9/732/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">110</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Datteln</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 110</biblScope>
+            <biblScope type="number">Nr. 17</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 110</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971667.xml
+++ b/HGV_meta_EpiDoc/HGV972/971667.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for oil</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971667</idno>
+        <idno type="TM">971667</idno>
+        <idno type="ddb-filename">basp.58.111_18</idno>
+        <idno type="ddb-hybrid">basp;58;111_18</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 3/726/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">111</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Notiz</term>
+          <term n="2">Lieferung</term>
+          <term n="3">Datteln</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 111</biblScope>
+            <biblScope type="number">Nr. 18</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 111</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971668.xml
+++ b/HGV_meta_EpiDoc/HGV972/971668.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for hay</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971668</idno>
+        <idno type="TM">971668</idno>
+        <idno type="ddb-filename">basp.58.112_19</idno>
+        <idno type="ddb-hybrid">basp;58;112_19</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 11/767/2010 (1)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">112</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Heu</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 112</biblScope>
+            <biblScope type="number">Nr. 19</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 112</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971669.xml
+++ b/HGV_meta_EpiDoc/HGV972/971669.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for wheat</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971669</idno>
+        <idno type="TM">971669</idno>
+        <idno type="ddb-filename">basp.58.113_20</idno>
+        <idno type="ddb-hybrid">basp;58;113_20</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 6/729/2009 [a?]</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">113</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Weizen</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 113</biblScope>
+            <biblScope type="number">Nr. 20</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 113</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971670.xml
+++ b/HGV_meta_EpiDoc/HGV972/971670.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for must</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971670</idno>
+        <idno type="TM">971670</idno>
+        <idno type="ddb-filename">basp.58.113_21</idno>
+        <idno type="ddb-hybrid">basp;58;113_21</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 6/729/2009 [b?]</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">113</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Most</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 113</biblScope>
+            <biblScope type="number">Nr. 21</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 113</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971671.xml
+++ b/HGV_meta_EpiDoc/HGV972/971671.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for dates</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971671</idno>
+        <idno type="TM">971671</idno>
+        <idno type="ddb-filename">basp.58.114_22</idno>
+        <idno type="ddb-hybrid">basp;58;114_22</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 1/724/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">114</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Datteln</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 114</biblScope>
+            <biblScope type="number">Nr. 22</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 114</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971672.xml
+++ b/HGV_meta_EpiDoc/HGV972/971672.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for oil</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971672</idno>
+        <idno type="TM">971672</idno>
+        <idno type="ddb-filename">basp.58.114_23</idno>
+        <idno type="ddb-hybrid">basp;58;114_23</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 14/770/2010 (2)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">114</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Öl</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 114</biblScope>
+            <biblScope type="number">Nr. 23</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 114</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971673.xml
+++ b/HGV_meta_EpiDoc/HGV972/971673.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for oil and dates</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971673</idno>
+        <idno type="TM">971673</idno>
+        <idno type="ddb-filename">basp.58.115_24</idno>
+        <idno type="ddb-hybrid">basp;58;115_24</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 10/766/2010 (2)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">115</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Öl</term>
+          <term n="3">Datteln</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 115</biblScope>
+            <biblScope type="number">Nr. 24</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 115</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971674.xml
+++ b/HGV_meta_EpiDoc/HGV972/971674.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for epibole didrachmou</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971674</idno>
+        <idno type="TM">971674</idno>
+        <idno type="ddb-filename">basp.58.117_25</idno>
+        <idno type="ddb-hybrid">basp;58;117_25</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 12/768/2010 (1)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">117</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 117</biblScope>
+            <biblScope type="number">Nr. 25</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 117</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971675.xml
+++ b/HGV_meta_EpiDoc/HGV972/971675.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Order for two artabas of dates</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971675</idno>
+        <idno type="TM">971675</idno>
+        <idno type="ddb-filename">basp.58.118_26</idno>
+        <idno type="ddb-hybrid">basp;58;118_26</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 4/727/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">118</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Auftrag</term>
+          <term n="2">Datteln</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 118</biblScope>
+            <biblScope type="number">Nr. 26</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 118</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971676.xml
+++ b/HGV_meta_EpiDoc/HGV972/971676.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Order for two moia of chaff</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971676</idno>
+        <idno type="TM">971676</idno>
+        <idno type="ddb-filename">basp.58.118_27</idno>
+        <idno type="ddb-hybrid">basp;58;118_27</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 15/791/2011 (3)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">118</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Auftrag</term>
+          <term n="2">Spreu</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 118</biblScope>
+            <biblScope type="number">Nr. 27</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 118</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971677.xml
+++ b/HGV_meta_EpiDoc/HGV972/971677.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Order to pay money</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971677</idno>
+        <idno type="TM">971677</idno>
+        <idno type="ddb-filename">basp.58.119_28</idno>
+        <idno type="ddb-hybrid">basp;58;119_28</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 5/728/2009</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">119</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Auftrag</term>
+          <term n="2">Zahlung</term>
+          <term n="3">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 119</biblScope>
+            <biblScope type="number">Nr. 28</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 119</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971678.xml
+++ b/HGV_meta_EpiDoc/HGV972/971678.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of names</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971678</idno>
+        <idno type="TM">971678</idno>
+        <idno type="ddb-filename">basp.58.120_29</idno>
+        <idno type="ddb-hybrid">basp;58;120_29</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 10/766/2010 (1)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">120</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+          <term n="2">Namen</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 120</biblScope>
+            <biblScope type="number">Nr. 29</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 120-121</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971679.xml
+++ b/HGV_meta_EpiDoc/HGV972/971679.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Memorandum or receipt for a donkey</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971679</idno>
+        <idno type="TM">971679</idno>
+        <idno type="ddb-filename">basp.58.121_30</idno>
+        <idno type="ddb-hybrid">basp;58;121_30</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 12/768/2010 (2)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">121</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Notiz (?)</term>
+          <term n="2">Quittung (?)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 121</biblScope>
+            <biblScope type="number">Nr. 30</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 121</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971680.xml
+++ b/HGV_meta_EpiDoc/HGV972/971680.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of names</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971680</idno>
+        <idno type="TM">971680</idno>
+        <idno type="ddb-filename">basp.58.122_31</idno>
+        <idno type="ddb-hybrid">basp;58;122_31</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 13/769/2010 (2)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">122</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+          <term n="2">Namen</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 122</biblScope>
+            <biblScope type="number">Nr. 31</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 122</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971681.xml
+++ b/HGV_meta_EpiDoc/HGV972/971681.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971681</idno>
+        <idno type="TM">971681</idno>
+        <idno type="ddb-filename">basp.58.123_32</idno>
+        <idno type="ddb-hybrid">basp;58;123_32</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 15/791/2011 (2)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">123</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 123</biblScope>
+            <biblScope type="number">Nr. 32</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 123</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971682.xml
+++ b/HGV_meta_EpiDoc/HGV972/971682.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of donkeys</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971682</idno>
+        <idno type="TM">971682</idno>
+        <idno type="ddb-filename">basp.58.124_33</idno>
+        <idno type="ddb-hybrid">basp;58;124_33</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 15/791/2011 (4)</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">124</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+          <term n="2">Eseln</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 124</biblScope>
+            <biblScope type="number">Nr. 33</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 124</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971683.xml
+++ b/HGV_meta_EpiDoc/HGV972/971683.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Memorandum about hay</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971683</idno>
+        <idno type="TM">971683</idno>
+        <idno type="ddb-filename">basp.58.125_34</idno>
+        <idno type="ddb-hybrid">basp;58;125_34</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 16/738/2019 - Inv. 2019-1</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">125</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Notiz</term>
+          <term n="2">Heu</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 125</biblScope>
+            <biblScope type="number">Nr. 34</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 125</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971684.xml
+++ b/HGV_meta_EpiDoc/HGV972/971684.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for oil and dates</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971684</idno>
+        <idno type="TM">971684</idno>
+        <idno type="ddb-filename">basp.58.126_35</idno>
+        <idno type="ddb-hybrid">basp;58;126_35</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 17/939/2019 - Inv. 2019-2</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">126</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Öl</term>
+          <term n="3">Datteln</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 126</biblScope>
+            <biblScope type="number">Nr. 35</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 126</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971685.xml
+++ b/HGV_meta_EpiDoc/HGV972/971685.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt straw and eggs</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971685</idno>
+        <idno type="TM">971685</idno>
+        <idno type="ddb-filename">basp.58.127_36</idno>
+        <idno type="ddb-hybrid">basp;58;127_36</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 18/940/2019 - Inv. 2019-3</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">127</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Stroh</term>
+          <term n="3">Eier</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 127</biblScope>
+            <biblScope type="number">Nr. 36</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 127</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971686.xml
+++ b/HGV_meta_EpiDoc/HGV972/971686.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Order for wine</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971686</idno>
+        <idno type="TM">971686</idno>
+        <idno type="ddb-filename">basp.58.128_37</idno>
+        <idno type="ddb-hybrid">basp;58;128_37</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 19/941/2019 - Inv. 2019-4</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">128</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Auftrag</term>
+          <term n="2">Wein</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 128</biblScope>
+            <biblScope type="number">Nr. 37</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 128</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971687.xml
+++ b/HGV_meta_EpiDoc/HGV972/971687.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for chicken</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971687</idno>
+        <idno type="TM">971687</idno>
+        <idno type="ddb-filename">basp.58.128_38</idno>
+        <idno type="ddb-hybrid">basp;58;128_38</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 19/941/2019 - Inv. 2019-5</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">128</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Huhn</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 128</biblScope>
+            <biblScope type="number">Nr. 38</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 128</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971688.xml
+++ b/HGV_meta_EpiDoc/HGV972/971688.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for oil</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971688</idno>
+        <idno type="TM">971688</idno>
+        <idno type="ddb-filename">basp.58.129_39</idno>
+        <idno type="ddb-hybrid">basp;58;129_39</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 21/943/2019 - Inv. 2019-6</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">129</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Öl</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 129</biblScope>
+            <biblScope type="number">Nr. 39</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 129</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971689.xml
+++ b/HGV_meta_EpiDoc/HGV972/971689.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for oil</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971689</idno>
+        <idno type="TM">971689</idno>
+        <idno type="ddb-filename">basp.58.129_40</idno>
+        <idno type="ddb-hybrid">basp;58;129_40</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 22/944/2019 - Inv. 2019-7</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">129</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Öl</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 129</biblScope>
+            <biblScope type="number">Nr. 40</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 129</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971690.xml
+++ b/HGV_meta_EpiDoc/HGV972/971690.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Order for wine</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971690</idno>
+        <idno type="TM">971690</idno>
+        <idno type="ddb-filename">basp.58.130_41</idno>
+        <idno type="ddb-hybrid">basp;58;130_41</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 23/945/2019 - Inv. 2019-8</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">130</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Auftrag</term>
+          <term n="2">Wein</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 130</biblScope>
+            <biblScope type="number">Nr. 41</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 130</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971691.xml
+++ b/HGV_meta_EpiDoc/HGV972/971691.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Order for oil</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971691</idno>
+        <idno type="TM">971691</idno>
+        <idno type="ddb-filename">basp.58.131_42</idno>
+        <idno type="ddb-hybrid">basp;58;131_42</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 24/946/2019 - Inv. 2019-9</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">131</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Auftrag</term>
+          <term n="2">Öl</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 131</biblScope>
+            <biblScope type="number">Nr. 42</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 131</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971692.xml
+++ b/HGV_meta_EpiDoc/HGV972/971692.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt (?)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971692</idno>
+        <idno type="TM">971692</idno>
+        <idno type="ddb-filename">basp.58.131_43</idno>
+        <idno type="ddb-hybrid">basp;58;131_43</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 25/947/2019 - Inv. 2019-10</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">131</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung (?)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 131</biblScope>
+            <biblScope type="number">Nr. 43</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 131</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971693.xml
+++ b/HGV_meta_EpiDoc/HGV972/971693.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for oil</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971693</idno>
+        <idno type="TM">971693</idno>
+        <idno type="ddb-filename">basp.58.132_44</idno>
+        <idno type="ddb-hybrid">basp;58;132_44</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 26/948/2019 - Inv. 2019-11</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">132</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Öl</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 132</biblScope>
+            <biblScope type="number">Nr. 44</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 132</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971694.xml
+++ b/HGV_meta_EpiDoc/HGV972/971694.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971694</idno>
+        <idno type="TM">971694</idno>
+        <idno type="ddb-filename">basp.58.132_45</idno>
+        <idno type="ddb-hybrid">basp;58;132_45</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 27/949/2019 - Inv. 2019-12</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">132</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 132</biblScope>
+            <biblScope type="number">Nr. 45</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 132</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971695.xml
+++ b/HGV_meta_EpiDoc/HGV972/971695.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for hay (?)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971695</idno>
+        <idno type="TM">971695</idno>
+        <idno type="ddb-filename">basp.58.133_46</idno>
+        <idno type="ddb-hybrid">basp;58;133_46</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 28/950/2019 - Inv. 2019-13</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">133</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Heu</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 133</biblScope>
+            <biblScope type="number">Nr. 46</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 133</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971696.xml
+++ b/HGV_meta_EpiDoc/HGV972/971696.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for oil</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971696</idno>
+        <idno type="TM">971696</idno>
+        <idno type="ddb-filename">basp.58.133_47</idno>
+        <idno type="ddb-hybrid">basp;58;133_47</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 29/951/2019 - Inv. 2019-14</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">133</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Öl</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 133</biblScope>
+            <biblScope type="number">Nr. 47</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 133</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971697.xml
+++ b/HGV_meta_EpiDoc/HGV972/971697.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971697</idno>
+        <idno type="TM">971697</idno>
+        <idno type="ddb-filename">basp.58.134_48</idno>
+        <idno type="ddb-hybrid">basp;58;134_48</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ain es-Sabil</settlement>
+            </placeName>
+            <idno type="invNo">SCA 30/952/2019 - Inv. 2019-15</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ain es-Sabil (Oasis Magna)</origPlace>
+              <origDate notBefore="0351" notAfter="0375">351 - 375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/61696 https://pleiades.stoa.org/places/551781152">Ain es-Sabil</placeName>
+                <placeName n="2" type="ancient" subtype="region">Oasis Magna</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95978"/>
+            <biblScope type="pp">134</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 134</biblScope>
+            <biblScope type="number">Nr. 48</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 134</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971701.xml
+++ b/HGV_meta_EpiDoc/HGV972/971701.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>“I renounced my children as aforesaid”: A consensual divorce of 369</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971701</idno>
+        <idno type="TM">971701</idno>
+        <idno type="ddb-filename">basp.58.138</idno>
+        <idno type="ddb-hybrid">basp;58;138</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>London</settlement>
+            </placeName>
+            <collection>British Library</collection>
+            <idno type="invNo">Pap 2700</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoites</origPlace>
+              <origDate when="0369-08-28">28. Aug. 369</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome" ref="https://pleiades.stoa.org/places/736893 https://www.trismegistos.org/place/332">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95979"/>
+            <biblScope type="pp">138</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Scheidung</term>
+          <term n="2">Vertrag</term>
+          <term n="3">Übereinkommen</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 138</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 141</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971702.xml
+++ b/HGV_meta_EpiDoc/HGV972/971702.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A lease of a room from Oxyrhynchus at Washington University in St. Louis</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971702</idno>
+        <idno type="TM">971702</idno>
+        <idno type="ddb-filename">basp.58.157</idno>
+        <idno type="ddb-hybrid">basp;58;157</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>St. Louis</settlement>
+            </placeName>
+            <collection>Washington University</collection>
+            <idno type="invNo">367</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos (Oxyrhynchites)</origPlace>
+              <origDate when="0527-02-26">26. Febr. 527</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+                <placeName n="2" type="ancient" subtype="nome">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95981"/>
+            <biblScope type="pp">157</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag</term>
+          <term n="2">Miete</term>
+          <term n="3">Raum</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 157</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 159</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971703.xml
+++ b/HGV_meta_EpiDoc/HGV972/971703.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A land lease from Oxyrhynchus at Washington University in St. Louis</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971703</idno>
+        <idno type="TM">971703</idno>
+        <idno type="ddb-filename">basp.58.167</idno>
+        <idno type="ddb-hybrid">basp;58;167</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>St. Louis</settlement>
+            </placeName>
+            <collection>Washington University</collection>
+            <idno type="invNo">108</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites</origPlace>
+              <origDate notBefore="0401" notAfter="0525" precision="low">V - Anfang VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95982"/>
+            <biblScope type="pp">167</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag</term>
+          <term n="2">Pacht</term>
+          <term n="3">Land</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 167</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 168</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971704.xml
+++ b/HGV_meta_EpiDoc/HGV972/971704.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A Byzantine land lease from Hermopolis</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971704</idno>
+        <idno type="TM">971704</idno>
+        <idno type="ddb-filename">basp.58.179</idno>
+        <idno type="ddb-hybrid">basp;58;179</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Louisville</settlement>
+            </placeName>
+            <collection>Southern Baptist Theological Seminary</collection>
+            <idno type="invNo">P. 1</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hermopolis (Hermopolites)</origPlace>
+              <origDate notBefore="0526" notAfter="0575" precision="low">Mitte VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/816 https://pleiades.stoa.org/places/756574">Hermopolis</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95984"/>
+            <biblScope type="pp">179</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag</term>
+          <term n="2">Pacht</term>
+          <term n="3">Land</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 179</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 180</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971705.xml
+++ b/HGV_meta_EpiDoc/HGV972/971705.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A companion of Muḥammad in the oldest Egyptian bilingual Entagion</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971705</idno>
+        <idno type="TM">971705</idno>
+        <idno type="ddb-filename">basp.58.211</idno>
+        <idno type="ddb-hybrid">basp;58;211</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Washington</settlement>
+            </placeName>
+            <collection>Library of Congress</collection>
+            <idno type="invNo">P. Ar. 1 + P. Ar. 40</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Tebtynis (Arsinoites)</origPlace>
+              <origDate when="0670">670</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://pleiades.stoa.org/places/736893 https://www.trismegistos.org/place/332">Arsinoites</placeName>
+                <placeName n="2" type="ancient" ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">Tebtynis</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95986"/>
+            <biblScope type="pp">211</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Entagion</term>
+          <term n="2">Anweisung</term>
+          <term n="3">Abgabe</term>
+          <term n="4">Schafe</term>
+          <term n="5">Grünfutter</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 211</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 212</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971706.xml
+++ b/HGV_meta_EpiDoc/HGV972/971706.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A written obligation from al-Ušmūnayn from the year 339 AH/ 950 CE</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971706</idno>
+        <idno type="TM">971706</idno>
+        <idno type="ddb-filename">basp.58.217v</idno>
+        <idno type="ddb-hybrid">basp;58;217v</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Berlin</settlement>
+            </placeName>
+            <collection>Staatliche Museen</collection>
+            <idno type="invNo">P. 24151 Vo</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papier</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>al-Ušmūnayn</origPlace>
+              <origDate when="0950">950</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient">al-Ušmūnayn</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95987"/>
+            <biblScope type="pp">217</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Schuldschein</term>
+          <term n="2">Weizen</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 217v</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration">S. 218</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971707.xml
+++ b/HGV_meta_EpiDoc/HGV972/971707.xml
@@ -87,6 +87,9 @@
           </bibl>
         </listBibl>
       </div>
+      <div type="commentary" subtype="general">
+        <p>Descr.</p>
+      </div>
       <div type="bibliography" subtype="illustrations">
         <p>
           <bibl type="illustration"></bibl>

--- a/HGV_meta_EpiDoc/HGV972/971707.xml
+++ b/HGV_meta_EpiDoc/HGV972/971707.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for payment of nuptial gift</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971707</idno>
+        <idno type="TM">971707</idno>
+        <idno type="ddb-filename">basp.58.217r</idno>
+        <idno type="ddb-hybrid">basp;58;217r</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Berlin</settlement>
+            </placeName>
+            <collection>Staatliche Museen</collection>
+            <idno type="invNo">P. 24151 Ro</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papier</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>al-Ušmūnayn</origPlace>
+              <origDate notBefore="0901" notAfter="1000" precision="low">X</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient">al-Ušmūnayn</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95987"/>
+            <biblScope type="pp"></biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Geschenk</term>
+          <term n="3">Hochzeit</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-02-18" who="https://papyri.info/editor/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">58</biblScope>
+            <biblScope type="fascicle">(2021)</biblScope>
+            <biblScope type="pages">S. 217r</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype="illustrations">
+        <p>
+          <bibl type="illustration"></bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
Xwalk BASP 58 meta for HGV. 

A few things I caught while processing: the material for 971706–7 is paper; these two files' idnos now include the r/v designation; commentary was added for the latter to indicate a descriptum; added the keyword Militär to 844316.