### PR TITLE
divs for convex/concave

### DIFF
--- a/DDB_EpiDoc_XML/bgu/bgu.20/bgu.20.2873.xml
+++ b/DDB_EpiDoc_XML/bgu/bgu.20/bgu.20.2873.xml
@@ -14,7 +14,7 @@
             <idno type="TM">316236</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab> 
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/><num value="7"><hi rend="supraline">ζ</hi></num> ἡ γυνή σου <unclear>Γε</unclear><surplus><unclear>λ</unclear></surplus><unclear>λ</unclear>
 <lb n="2" break="no"/><unclear>λ</unclear><surplus><unclear>λ</unclear></surplus>οῦς ἔπινε με
 <lb n="3" break="no"/>τὰ τοῦ χωλοῦ Πο<unclear>ῦτ</unclear>
@@ -52,14 +52,14 @@
 <lb n="5" break="no"/>ως ἔπινε μετὰ
 <lb n="6"/>Τετέ<unclear>ωνο</unclear>ς
 <lb n="7"/><choice><reg> ἀφ’</reg><orig>ἀπ’</orig></choice> <expan>ὥ<unclear>ρ</unclear><ex>ας</ex></expan> <num value="8"><unclear>η</unclear></num>
-</ab></div> 
-<div n="side" subtype="concave" type="textpart"><ab>
-   
+</ab></div>
+<div n="concave" subtype="side" type="textpart"><ab>
+
 <lb n="8"/><app type="alternative"><lem><choice><reg>ἐσχήκασι</reg><orig>ἔσχικαν</orig></choice></lem><rdg>ἔσχηκεν</rdg></app> τὸ κρα
 <lb n="9" break="no"/>βάττιόν σου καὶ
 <lb n="10"/>τὴν ὑδρίαν
-</ab></div> 
- 
+</ab></div>
+
 
 
 

--- a/DDB_EpiDoc_XML/o.krok/o.krok.1/o.krok.1.79.xml
+++ b/DDB_EpiDoc_XML/o.krok/o.krok.1/o.krok.1.79.xml
@@ -14,7 +14,7 @@
             <idno type="TM">88670</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,9 +44,9 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="convex" type="textpart"><ab> 
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/><unclear>λ</unclear>ό<unclear>γος</unclear> <unclear>πυρ</unclear>οῦ καὶ <expan>κριθῆ<ex>ς</ex></expan> πραισιδίου <expan>Κορκοδ<ex>ιλὼ</ex></expan>
-<lb n="2"/><app type="alternative"><lem><gap reason="lost" quantity="10" unit="character"/>ο</lem><rdg><supplied reason="lost">ἐπιδεδομένος ὑπ</supplied>ό</rdg></app> τι<unclear>ν</unclear>ος κουράτορος τοῦ     
+<lb n="2"/><app type="alternative"><lem><gap reason="lost" quantity="10" unit="character"/>ο</lem><rdg><supplied reason="lost">ἐπιδεδομένος ὑπ</supplied>ό</rdg></app> τι<unclear>ν</unclear>ος κουράτορος τοῦ
 <lb n="3"/><app type="alternative"><lem><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap></lem><rdg><unclear>αὐτοῦ</unclear> <unclear>πραισιδίου</unclear></rdg></app>
 <lb n="4"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
 <lb n="5"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
@@ -56,7 +56,7 @@
 <lb n="9"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
 <lb n="10"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
 
-</ab></div> <div n="concave" type="textpart"><ab> 
+</ab></div> <div n="concave" subtype="side" type="textpart"><ab>
 <lb n="11"/>τις κουράτωρ ἐπι<del rend="erasure">δ<unclear>ε</unclear><gap reason="illegible" quantity="4" unit="character"/></del>
 <lb n="12"/><expan><unclear>δέδωκ</unclear><ex>α</ex></expan> τὸν προκείμενον
 <lb n="13"/>λόγον <space extent="unknown" unit="character"/>

--- a/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.161.xml
+++ b/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.161.xml
@@ -14,7 +14,7 @@
             <idno type="TM">704446</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
     <lb n="1"/><supplied reason="lost">Φιλοκλῆς</supplied> Σκιφὶ τῇ ἀδελ
 
     <lb n="2" break="no"/><supplied reason="lost">φῇ πλεῖστα</supplied> <choice><reg><supplied reason="lost">χα</supplied>ίρειν</reg><orig><supplied reason="lost">χα</supplied>ίριν</orig></choice> καὶ <choice><reg>διὰ</reg><orig>διὲ</orig></choice>
@@ -60,8 +60,8 @@
     <lb n="7"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="2" unit="character"/>
 
     <lb n="7"/><gap reason="lost" extent="unknown" unit="line"/>
-</ab></div> 
-<div n="side" subtype="concave" type="textpart"><ab>     
+</ab></div>
+<div n="concave" subtype="side" type="textpart"><ab>
     <lb n="8"/>ἀσπ<gap reason="lost" extent="unknown" unit="character"/>
 
     <lb n="8"/><gap reason="lost" extent="unknown" unit="line"/>

--- a/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.193.xml
+++ b/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.193.xml
@@ -14,7 +14,7 @@
             <idno type="TM">704478</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,27 +44,27 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/>Μένανδρος Γαλλωνία<unclear>ι</unclear>
 <lb n="2"/>τῇ <choice><reg>θυγατρί</reg><orig>θυγατρ<unclear>εὶ</unclear></orig></choice> χαίρειν.
 <lb n="3"/>τὸ προσκύνημά σου, τέκ
 <lb n="4" break="no"/>νον, ποιῶ παρὰ πᾶσι τοῖς
 <lb n="5"/>θεοῖς. τί με, τέκνον, μέμφῃ
 <lb n="6"/><choice><reg>ὅτι</reg><orig>ὅτει</orig></choice> οὐκ ἔγραψά σοι <choice><reg>ἐπιστο<lb n="7" break="no"/>λήν</reg><orig>ἐπι<supplied reason="lost">σ</supplied><unclear>τυ</unclear>
-<lb n="7" break="no"/>λήν</orig></choice>; τί<unclear>ν</unclear>α<gap reason="illegible" quantity="7" unit="character"/>ιν<unclear>α</unclear>ς; εἶπον <unclear>ὅτι</unclear> 
+<lb n="7" break="no"/>λήν</orig></choice>; τί<unclear>ν</unclear>α<gap reason="illegible" quantity="7" unit="character"/>ιν<unclear>α</unclear>ς; εἶπον <unclear>ὅτι</unclear>
 <lb n="8"/><q> δυσωποῦμαι μηδὲν <unclear>ἔ</unclear>χων πέμ
 <lb n="9" break="no"/>ψαι σοι </q>. <choice><reg>γράφεις</reg><orig>γραφῖ<unclear>ς</unclear></orig></choice> <gap reason="illegible" quantity="7" unit="character"/> γὰρ τοὺς
-<lb n="10"/>θεούς. οὐδένα <unclear>γὰρ</unclear> <unclear>ἔχ</unclear>ομεν εἰ μὴ σ<unclear>ὲ</unclear><surplus><unclear>ν</unclear></surplus>. 
+<lb n="10"/>θεούς. οὐδένα <unclear>γὰρ</unclear> <unclear>ἔχ</unclear>ομεν εἰ μὴ σ<unclear>ὲ</unclear><surplus><unclear>ν</unclear></surplus>.
 <lb n="11"/><unclear>εἰ</unclear> <choice><reg>ἴσχυον</reg><orig>ἤσχυον</orig></choice> ἐληλυθ<gap reason="illegible" quantity="1" unit="character"/>ν ἂν παρὰ
 <lb n="12"/>σέ. νῦν δε<unclear>ῖν</unclear> οὐκ <choice><reg>οἰκίαν</reg><orig>οἰκαι<unclear>ν</unclear></orig></choice> οὐδὲ
 <lb n="13"/>βλέπε<unclear>ιν</unclear> <unclear>μη</unclear>τέρ<unclear>α</unclear> <unclear>σο</unclear>υ. μήτηρ
 <lb n="14"/><choice><reg>ἐστὶ</reg><orig>ἐ<unclear>στεὶ</unclear></orig></choice> <unclear>Διδ</unclear>ύμη καὶ Κάππ
 <lb n="15" break="no"/>αρις δεύτερος πατήρ.
 <lb n="16"/>μὴ οὖν, τέκνον, ἀ
-<lb n="17" break="no"/>γωνία ὡς παρὰ 
+<lb n="17" break="no"/>γωνία ὡς παρὰ
 <lb n="18"/>ξένους.
 </ab></div>
-<div n="side" subtype="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="19"/>ἐὰν δύνῃ, τέκνον,
 <lb n="20"/>ἐκεῖ <choice><reg>ἡμιαρτάβιον</reg><orig>εἱμιαρτάβιν</orig></choice>
 <lb n="21"/><choice><reg>σíτου</reg><orig>σείτου</orig></choice> ἀγοράσαι καὶ ἀρ

--- a/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.215.xml
+++ b/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.215.xml
@@ -14,7 +14,7 @@
             <idno type="TM">704500</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/>Μάξιμος
 <lb n="2"/><del rend="erasure"><gap reason="illegible" quantity="1" unit="character"/></del> Παπιρίῳ τῷ
 <lb n="3"/>ἀδελφῷ <choice><reg>πλεῖστα</reg><orig>πλῖστα</orig></choice>
@@ -68,7 +68,7 @@
 <lb n="21"/><choice><reg>ἀγγείου</reg><orig>ἀνγύω</orig></choice> <choice><reg>τοῦ</reg><orig>τῶ</orig></choice> <choice><reg>ἐ<lb n="22" break="no"/>λαίου</reg><orig>ἐ
 <lb n="22" break="no"/>λέαυ</orig></choice>.
 </ab></div>
-<div n="side" subtype="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="23"/>οἶδες ὅτι ἔχω ἐλάδιν. ἄρτι ἂν δὲ
 <lb n="24"/><choice><reg>χρῄζω</reg><orig>χρίζω</orig></choice> γράψω <choice><reg>σοι</reg><orig>συ</orig></choice> <choice><reg>ἵνα</reg><orig>εἵνα</orig></choice> μοι <choice><reg>πέμ<lb n="25" break="no"/>ψῃς</reg><orig>πέν
 <lb n="25" break="no"/>ψῃς</orig></choice> τὸ <choice><reg>ἀγγεῖον</reg><orig>ἀνγῆν</orig></choice> τοῦ <choice><reg>ἐλαίου</reg><orig>ἐλαυ</orig></choice>. <choice><reg>πέμψον</reg><orig>πένψον</orig></choice>

--- a/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.219.xml
+++ b/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.219.xml
@@ -14,7 +14,7 @@
             <idno type="TM">704504</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/>Ὀφέλλις κ<unclear>α</unclear>ὶ <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="2"/>ος καὶ <unclear>Ῥ</unclear>ογᾶτος <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="3"/>τῷ ἀδελφῷ πλεῖ<supplied reason="lost">στα χαίρειν.</supplied>
@@ -59,7 +59,7 @@
 <lb n="12" break="no"/>τάνας, καὶ τὸν <choice><reg>σῖτον</reg><orig>σεῖτον</orig></choice>. ἀσπά
 <lb n="13" break="no"/>ζου τὴν ἀδελφὴν ἡμῶν
 </ab></div>
-<div n="side" subtype="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="14"/>καὶ κυρίαν Ἰσίδωραν.
 <lb n="15"/>ἀσπάζετα<supplied reason="omitted">ί</supplied> σε τὸ <choice><reg>πραισί<lb n="16" break="no"/>διον</reg><orig>πραισί
 <lb n="16" break="no"/>διν</orig></choice>. ἔρρωσο.

--- a/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.225.xml
+++ b/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.225.xml
@@ -14,7 +14,7 @@
             <idno type="TM">704510</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,10 +44,10 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/><choice><reg>Σαραπιὰς</reg><orig>Σεραφιὰ<supplied reason="lost">ς</supplied></orig></choice> <gap reason="lost" quantity="9" unit="character" precision="low"/>
 <lb n="2"/>ρίῳ τῷ κ<unclear>υ</unclear><supplied reason="lost">ρίῳ καὶ ἀδε</supplied>
-<lb n="3" break="no"/>λφῷ <choice><reg>πλεῖσ<supplied reason="lost">τα</supplied></reg><orig>πλῖσ<supplied reason="lost">τα</supplied></orig></choice> <supplied reason="lost">χαίρειν καὶ διὰ</supplied> 
+<lb n="3" break="no"/>λφῷ <choice><reg>πλεῖσ<supplied reason="lost">τα</supplied></reg><orig>πλῖσ<supplied reason="lost">τα</supplied></orig></choice> <supplied reason="lost">χαίρειν καὶ διὰ</supplied>
 <lb n="4"/>παντὸς ὑ<supplied reason="lost">γιαίνειν· ὑγιαί</supplied>
 <lb n="5" break="no"/>νω δὲ καἰ<unclear>γ</unclear><supplied reason="lost">ὼ καὶ τὸ προσ</supplied>
 <lb n="6" break="no"/>κύνημά σ<supplied reason="lost">ο</supplied><unclear>υ</unclear> <supplied reason="lost">ποιῶ π</supplied><unclear>αρ</unclear>
@@ -59,7 +59,7 @@
 <lb n="12"/><supplied reason="lost">καθε</supplied>ύδω
 <lb n="13"/><gap reason="lost" quantity="5" unit="character"/>του
 </ab></div>
-<div n="side" subtype="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="14"/><gap reason="lost" quantity="8" unit="character"/>εμοι μ
 <lb n="15" break="no"/><gap reason="lost" quantity="7" unit="character"/><gap reason="illegible" quantity="1" unit="character"/>επιλα
 <lb n="16" break="no"/><gap reason="lost" quantity="4" unit="character"/> <supplied reason="lost">εὔ</supplied>χομαι το
@@ -73,7 +73,7 @@
 <lb n="24"/>η<gap reason="illegible" quantity="7" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
 <lb n="25"/>ἀσπα<gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
 <lb n="26"/>ν<gap reason="lost" extent="unknown" unit="character"/>
-<lb n="27"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/> 
+<lb n="27"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
 <lb n="27"/><gap reason="lost" extent="unknown" unit="line"/>
 </ab></div></div>
       </body>

--- a/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.233.xml
+++ b/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.233.xml
@@ -14,7 +14,7 @@
             <idno type="TM">704518</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/><gap reason="lost" extent="unknown" unit="line"/>
 <lb n="1"/><gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
 <lb n="2"/>παρὰ <unclear>τοῖ</unclear><supplied reason="lost">ς ἐνθά</supplied>
@@ -56,7 +56,7 @@
 <lb n="8"/>ἐγὼ γὰρ <subst><add place="inline">πᾶ<unclear>σ</unclear>αν</add><del rend="corrected">πᾶζαν</del></subst>
 <lb n="9"/><unclear>ἡμ</unclear>έραν τὸ προσ
 </ab></div>
-<div n="side" subtype="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="10" break="no"/><gap reason="lost" extent="unknown" unit="line"/>
 <lb n="10"/><gap reason="illegible" quantity="2" unit="character"/><gap reason="lost" quantity="4" unit="character"/> <supplied reason="lost">ἡμ</supplied>ι<unclear>μά</unclear>
 <lb n="11" break="no"/>τιν ἅλα.

--- a/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.269.xml
+++ b/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.269.xml
@@ -14,7 +14,7 @@
             <idno type="TM">704554</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -43,7 +43,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/><supplied reason="lost">Λονγεῖνος</supplied> <choice><reg><supplied reason="lost">Ἀπο</supplied>λινάρις</reg><orig><supplied reason="lost">Ἀπο</supplied>λιναρίῳ</orig></choice>
 <lb n="2"/><unclear>Ἀ</unclear><supplied reason="lost">πολιναρίῳ</supplied> <supplied reason="lost">τῷ</supplied> <supplied reason="lost">ἀδελφ</supplied>ῷ <choice><reg>πλεῖστα</reg><orig>πλῖστα</orig></choice> <expan>χαί<ex>ρειν</ex></expan>·
 <lb n="3"/>πρὸ <unclear>μ</unclear><supplied reason="lost">ὲν</supplied> <supplied reason="lost">παντὸς</supplied> <choice><reg><supplied reason="lost">εὔχο</supplied>μαί</reg><orig><supplied reason="lost">εὔχω</supplied>μέ</orig></choice> <choice><reg>σε</reg><orig>σεν</orig></choice> <choice><reg>ὑγιαίνειν</reg><orig>ὑγ<supplied reason="omitted">ι</supplied>ένι<supplied reason="omitted">ν</supplied></orig></choice>·
@@ -55,7 +55,7 @@
 <lb n="8"/><gap reason="lost" extent="unknown" unit="line"/>
 <lb n="9,md" rend="perpendicular"/> <supplied reason="lost">σωτ</supplied>ηρίας σου
 </ab></div>
-<div n="side" subtype="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="10"/><gap reason="lost" extent="unknown" unit="line"/>
 <lb n="10"/><choice><reg>ἔχεις</reg><orig>ἔχις</orig></choice> το<gap reason="lost" quantity="12" unit="character" precision="low"/> <expan><unclear>ἐ</unclear>πιστο<ex>λῆς</ex></expan>
 <lb n="11"/>συνεσ<unclear>τ</unclear><gap reason="lost" quantity="12" unit="character" precision="low"/>υ ἐστιν

--- a/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.331.xml
+++ b/DDB_EpiDoc_XML/o.krok/o.krok.2/o.krok.2.331.xml
@@ -14,7 +14,7 @@
             <idno type="TM">704616</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/>Π<unclear>αρ</unclear>άβολος <choice><reg>Ἰσχυρᾶτι</reg><orig>Εἰσχυρᾶτι</orig></choice> τῷ ἀδελ
 <lb n="2" break="no"/><unclear>φ</unclear><supplied reason="lost">ῷ</supplied> <choice><reg>πλεῖστα</reg><orig><unclear>π</unclear>λῖστα</orig></choice> <expan>χ<ex>αίρειν</ex></expan> καὶ <choice><reg>διὰ</reg><orig>διὲ</orig></choice> παντὸς <choice><reg>ὑγιαί<supplied reason="lost">νει</supplied>ν</reg><orig>ὑγιέ
 <lb n="3" break="no"/><supplied reason="lost">νι</supplied><unclear>ν</unclear></orig></choice>. τ<supplied reason="lost">ὸ</supplied> προσκύνημά σου <choice><reg>ποιῶ</reg><orig>ποῶ</orig></choice> παρὰ <choice><reg>τοῖς</reg><orig>τῦς</orig></choice>
@@ -63,7 +63,7 @@
 <lb n="16"/><gap reason="illegible" quantity="4" unit="character"/>οβια
 <lb n="17"/><unclear>ἐρε</unclear>ᾶ
 </ab></div>
-<div n="side" subtype="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="18"/>ἀγόρασόν μοι
 <lb n="19"/>δελφα<unclear>κί</unclear>δα <unclear>εσα</unclear><gap reason="lost" extent="unknown" unit="character"/>
 <lb n="19"/>α<unclear>ρι</unclear>σ<unclear>τα</unclear> τη<gap reason="illegible" quantity="2" unit="character"/>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.13.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.13.xml
@@ -14,7 +14,7 @@
             <idno type="TM">131061</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/><unclear>τῷ</unclear> Ἀ<unclear>φρ</unclear>οδισίω<unclear>ι</unclear>
 <lb n="2"/>ἀπὸ <unclear>Θὼθ</unclear> <num value="1"><unclear>α</unclear></num> <unclear>ἕω</unclear>ς Τῦβι <num value="2">β</num>
 <lb n="3"/>α
@@ -65,7 +65,7 @@
 <lb n="18"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
 <lb n="19"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
 </ab></div>
-<div n="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="1"/><gap reason="illegible" quantity="4" unit="character"/> Πμουν Ψωι
 <lb n="2"/>Ψ <gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> <expan><ex>ἀρτάβην</ex></expan> <num value="1">α</num>
 <lb n="3"/>Φ <gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> <expan><ex>ἀρτάβην</ex></expan> <num value="1">α</num>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.155.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.155.xml
@@ -14,7 +14,7 @@
             <idno type="TM">131203</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -47,13 +47,13 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="Convex" type="textpart"><ab>
+<div n="convex" subytpe="side" type="textpart"><ab>
 <lb n="1"/><expan>ὕδ<ex>ρευμα</ex></expan> <expan>Πμο<ex>υν</ex></expan> Ὀσιρε
 <lb n="2"/><choice><reg><expan>Παστ<ex cert="low">ωοῦς</ex></expan></reg><orig><abbr>Παστ</abbr></orig></choice> Κέρ
 <lb n="3" break="no"/>δων <expan>ἀπ<ex>ελεύθερος</ex></expan>
 <lb n="4"/><num value="20">κ</num> <expan><ex>ἔτους</ex></expan>
-</ab></div> 
-<div n="Concave" type="textpart"><ab>
+</ab></div>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="1"/><expan><supplied reason="lost">ὕδ<ex>ρευμα</ex></supplied></expan> <expan>Πμ<ex>ουν</ex></expan> Ψω
 <lb n="2"/><abbr>Πα<gap reason="illegible" quantity="3" unit="character"/></abbr>
 <lb n="3"/><choice><reg cert="low">Σαμουν</reg><orig>Σαμ<gap reason="illegible" quantity="3" unit="character"/></orig></choice>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.155.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.155.xml
@@ -47,7 +47,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="convex" subytpe="side" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/><expan>ὕδ<ex>ρευμα</ex></expan> <expan>Πμο<ex>υν</ex></expan> Ὀσιρε
 <lb n="2"/><choice><reg><expan>Παστ<ex cert="low">ωοῦς</ex></expan></reg><orig><abbr>Παστ</abbr></orig></choice> Κέρ
 <lb n="3" break="no"/>δων <expan>ἀπ<ex>ελεύθερος</ex></expan>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.307.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.307.xml
@@ -14,7 +14,7 @@
             <idno type="TM">131356</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -49,7 +49,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="1"/>εαν<gap reason="lost" extent="unknown" unit="character"/>
 <lb n="2"/>προσ<gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
 <lb n="3"/>λι<gap reason="lost" quantity="2" unit="character"/>λλα<gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
@@ -61,7 +61,7 @@
 <lb n="9"/>παρ’ ἡ<unclear>μῶ</unclear>ν <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="10"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> <gap reason="lost" extent="unknown" unit="character"/>
 </ab></div>
-<div n="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/>εἰ<unclear>ς</unclear> <gap reason="illegible" quantity="3" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
 <lb n="2"/>κα<gap reason="illegible" quantity="2" unit="character"/> αρι<unclear>α</unclear> ταυ<unclear>τ</unclear><gap reason="lost" extent="unknown" unit="character"/>
 <lb n="3"/><gap reason="illegible" quantity="8" unit="character"/> <gap reason="lost" extent="unknown" unit="character"/>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.5.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.5.xml
@@ -2,58 +2,66 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
   <teiHeader>
-      <fileDesc>
-         <titleStmt>
-            <title>o.trim.1.5</title>
-         </titleStmt>
-         <publicationStmt>
-            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">o.trim.1.5</idno>
-            <idno type="ddb-hybrid">o.trim;1;5</idno>
-            <idno type="HGV">131053</idno>
-            <idno type="TM">131053</idno>
-            <availability>
-               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
-          Commons Attribution 3.0 License</ref>.</p>
+    <fileDesc>
+      <titleStmt>
+        <title>o.trim.1.5</title>
+      </titleStmt>
+      <publicationStmt>
+        <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+        <idno type="filename">o.trim.1.5</idno>
+        <idno type="ddb-hybrid">o.trim;1;5</idno>
+        <idno type="HGV">131053</idno>
+        <idno type="TM">131053</idno>
+        <availability>
+          <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+            <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
+              Commons Attribution 3.0 License</ref>.</p>
             </availability>
-         </publicationStmt>
-         <sourceDesc>
+          </publicationStmt>
+          <sourceDesc>
             <p>
-               <bibl>O.Trim. 1 5</bibl>
+              <bibl>O.Trim. 1 5</bibl>
             </p>
-         </sourceDesc>
-      </fileDesc>
-      <profileDesc>
-         <langUsage>
+          </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+          <langUsage>
             <language ident="en">English</language>
             <language ident="grc">Greek</language>
-         </langUsage>
-      </profileDesc>
-      <revisionDesc>
+          </langUsage>
+        </profileDesc>
+        <revisionDesc>
           <change when="2012-06-25T06:34:27.348-04:00"
-                 who="http://papyri.info/editor/users/Zoom">Finalized - OK</change>
-          <change when="2012-06-25T06:34:27.342-04:00"
-                 who="http://papyri.info/editor/users/joshuad.sosin">Vote - AcceptText - Accept. See Verhoogt's.</change>
-          <change when="2012-06-25T06:34:27.335-04:00"
-                 who="http://papyri.info/editor/users/Arthur%20Verhoogt">Vote - AcceptText - This text on concave side; faint traces on convex (see Introduction to text). Change to &lt;D= etc. =D&gt;</change>
-          <change when="2012-05-23T11:30:56.849-04:00"
-                 who="http://papyri.info/editor/users/PaulvdLaan">Entered Greek text from O.Trim.1.5</change>
-          <change when="2012-05-23T11:26:22-04:00" who="http://papyri.info/editor">Automated creation from template</change>
-      </revisionDesc>
-  </teiHeader>
-  <text>
-      <body>
-         <head xml:lang="en"/>
-         <div xml:lang="grc" type="edition" xml:space="preserve">
-<ab>
-<lb n="1"/><gap reason="illegible" quantity="4" unit="character"/><unclear>ιος</unclear> <expan>κριθ<ex>ῆς</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="6"><unclear>ϛ</unclear></num>
-<lb n="2"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
-<lb n="3"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
-<lb n="4"/><space extent="unknown" unit="character"/> <expan>κε<unclear>ρ</unclear><ex>άμια</ex></expan> <num value="4"><unclear>δ</unclear></num>
-<lb n="5"/><space extent="unknown" unit="character"/> <gap reason="illegible" quantity="2" unit="character"/> <num value="2">β</num>
-<lb n="6"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
-</ab></div>
-      </body>
-  </text>
-</TEI>
+            who="http://papyri.info/editor/users/Zoom">Finalized - OK</change>
+            <change when="2012-06-25T06:34:27.342-04:00"
+              who="http://papyri.info/editor/users/joshuad.sosin">Vote - AcceptText - Accept. See Verhoogt's.</change>
+              <change when="2012-06-25T06:34:27.335-04:00"
+                who="http://papyri.info/editor/users/Arthur%20Verhoogt">Vote - AcceptText - This text on concave side; faint traces on convex (see Introduction to text). Change to &lt;D= etc. =D&gt;</change>
+                <change when="2012-05-23T11:30:56.849-04:00"
+                  who="http://papyri.info/editor/users/PaulvdLaan">Entered Greek text from O.Trim.1.5</change>
+                  <change when="2012-05-23T11:26:22-04:00" who="http://papyri.info/editor">Automated creation from template</change>
+                </revisionDesc>
+              </teiHeader>
+              <text>
+                <body>
+                  <head xml:lang="en"/>
+                  <div xml:lang="grc" type="edition" xml:space="preserve">
+                    <div n="concave" subtype="side" type="textpart">
+                      <ab>
+                        <lb n="1"/><gap reason="illegible" quantity="4" unit="character"/><unclear>ιος</unclear> <expan>κριθ<ex>ῆς</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="6"><unclear>ϛ</unclear></num>
+                        <lb n="2"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
+                        <lb n="3"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
+                        <lb n="4"/><space extent="unknown" unit="character"/> <expan>κε<unclear>ρ</unclear><ex>άμια</ex></expan> <num value="4"><unclear>δ</unclear></num>
+                        <lb n="5"/><space extent="unknown" unit="character"/> <gap reason="illegible" quantity="2" unit="character"/> <num value="2">β</num>
+                        <lb n="6"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
+                      </ab>
+                    </div>
+                    <div n="convex" subtype="side" type="textpart">
+                      <ab>
+                        <lb n="1"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
+                      </ab>
+                    </div>
+                  </div>
+                </body>
+              </text>
+            </TEI>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.50.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.50.xml
@@ -14,7 +14,7 @@
             <idno type="TM">131098</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -46,15 +46,15 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="concave" type="textpart"><ab> 
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="1"/><expan>Πμο<ex>υν</ex></expan> <expan>Ἀλεξάνδρ<unclear>ο</unclear><ex>υ</ex></expan>
 <lb n="2"/>υἱὸς <expan>Στεφ<unclear>ά</unclear>νο<ex>υ</ex></expan> <abbr>δέσμ</abbr> <num><gap reason="illegible" quantity="1" unit="character"/></num>
 <lb n="3"/>Ἄμμων <expan>Μέρσ<ex>ιος</ex></expan> <expan>δέσμ<ex>η</ex></expan> <num value="1">α</num>
 <lb n="4"/><app type="alternative"><lem><gap reason="illegible" quantity="2" unit="character"/></lem><rdg>λ<gap reason="illegible" quantity="1" unit="character"/></rdg><rdg>π<gap reason="illegible" quantity="1" unit="character"/></rdg></app>θος <abbr><gap reason="illegible" quantity="1" unit="character"/>αρ<gap reason="illegible" quantity="1" unit="character"/></abbr> <abbr>δέσμ</abbr> <num><gap reason="illegible" quantity="1" unit="character"/></num> <expan>σεση<ex>μείωμαι</ex></expan>
 <lb n="5"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> <expan>Κλαύδι<ex>ος</ex></expan>
 <lb n="6"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> υἱὸς <choice><reg>Κόρακος</reg><orig>Κόρακι</orig></choice>
-</ab></div> 
-<div n="convex" type="textpart"><ab> 
+</ab></div>
+<div n="convex" subtype="side" type="textpart"><ab> 
 <lb n="1"/>Βερρι <abbr>Εὐφρατ</abbr>
 <lb n="2"/><expan><supplied reason="lost">Ἁρ</supplied>ποκρ<ex>ατίων</ex></expan> <expan>ξ<ex>έσται</ex></expan> <num value="32">λβ</num>
 <lb n="3"/>Ἑρμησία <expan>ξ<ex>έσται</ex></expan> <num value="32">λβ</num>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.51.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.51.xml
@@ -14,7 +14,7 @@
             <idno type="TM">131099</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -46,18 +46,18 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="Convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1,ms"/><hi rend="supraline"><gap reason="illegible" quantity="1" unit="character"/></hi><num value="19">ιθ</num>
 <lb n="1"/><abbr>Φιλομ</abbr> Ἁθὺρ <num value="29"><hi rend="supraline">κθ</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="2">β</num>, <expan>κρ<ex>ιθῆς</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2"><unclear>β</unclear></num>. <expan>Ἁδρ<ex>ιανοῦ</ex></expan> <num value="6"><hi rend="supraline">ϛ</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="5"><unclear>ε</unclear></num> <gap reason="lost" extent="unknown" unit="character"/>
-<lb n="2,ms"/><abbr>μ</abbr> <num value="12">ιβ</num> 
+<lb n="2,ms"/><abbr>μ</abbr> <num value="12">ιβ</num>
 <lb n="2"/><expan>κρ<ex>ιθῆς</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="4">δ</num>. <num value="15"><hi rend="supraline">ιε</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="3">γ</num> <expan>μά<ex>τια</ex></expan> <num value="8">η</num>. <num value="20"><hi rend="supraline">κ</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="5">ε</num> <expan>κ<supplied reason="lost">ρ<ex>ιθῆς</ex></supplied></expan> <gap reason="lost" extent="unknown" unit="character"/>
-<lb n="3,ms"/><abbr>Φιλομ</abbr> <num value="29"><hi rend="supraline">κθ</hi></num> 
+<lb n="3,ms"/><abbr>Φιλομ</abbr> <num value="29"><hi rend="supraline">κθ</hi></num>
 <lb n="3"/><expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="2">β</num>. Τῦβι <num value="5"><hi rend="supraline">ε</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="2">β</num>. <space extent="unknown" unit="character"/> <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="4,ms"/><expan><unclear>ὁ</unclear>μο<ex>ίως</ex></expan> <expan><unclear>μ</unclear>ά<ex>τια</ex></expan> <num value="3"><unclear>γ</unclear></num>
 <lb n="4"/><expan>Πετο<ex>σῖρις</ex></expan> <abbr><hi rend="supraline">γν</hi></abbr> Ἁθὺρ <num value="15">κ<hi rend="supraline">ε</hi></num> <expan>κρ<ex>ιθῆς</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="2">β</num>, <expan>ὁ<ex>μοίως</ex></expan> <expan><ex>ἀρτάβην</ex></expan> <num value="1">α</num>. <expan>Ἁδρ<ex>ιανοῦ</ex></expan> <num value="3"><unclear>γ</unclear></num> <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="5"/><num value="9"><hi rend="supraline">θ</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="5">ε</num>. <num value="18"><hi rend="supraline">ιη</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="6">ϛ</num> <expan>μά<ex>τια</ex></expan> <num value="2">β</num>. <expan>Τῦβ<ex>ι</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="5">ε</num> <gap reason="lost" extent="unknown" unit="character"/>
 <milestone rend="paragraphos" unit="undefined"/>
-<lb n="6"/><expan>Ψ<unclear>ε</unclear>να<ex>μοῦνις</ex></expan> <expan>Ἁρπαή<ex>σιος</ex></expan> <expan>Ἁδρ<ex>ιανοῦ</ex></expan> <num value="10">ι</num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="4">δ</num> <expan>μά<ex>τιον</ex></expan> <num value="1">α</num>. 
+<lb n="6"/><expan>Ψ<unclear>ε</unclear>να<ex>μοῦνις</ex></expan> <expan>Ἁρπαή<ex>σιος</ex></expan> <expan>Ἁδρ<ex>ιανοῦ</ex></expan> <num value="10">ι</num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="4">δ</num> <expan>μά<ex>τιον</ex></expan> <num value="1">α</num>.
 <lb n="7"/><num value="16"><hi rend="supraline">ιϛ</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="8"/><expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="4">δ</num>. <expan>Τῦβ<ex>ι</ex></expan> <num value="11">ια</num> <expan>κρ<ex>ιθῆς</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="4">δ </num> <num value="1/2">𐅵</num> <space extent="unknown" unit="character"/> <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="9"/><expan>Πετο<ex>σῖρις</ex></expan> <abbr>Πε</abbr> <expan>Ἁδρ<ex>ιανοῦ</ex></expan> <num value="12"><hi rend="supraline">ιβ</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="7">ζ</num> <expan>μά<ex>τια</ex></expan> <num value="2">β</num> <expan>κρ<ex>ιθῆς</ex></expan> <expan>μά<ex>τια</ex></expan> <num value="3">γ</num> <gap reason="lost" extent="unknown" unit="character"/>
@@ -65,7 +65,7 @@
 <lb n="11"/><num value="16">ις</num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="10">ι</num> <expan>μά<ex>τια</ex></expan> <num value="4">δ</num> <supplied reason="lost"><expan>κρ<ex>ιθῆς</ex></expan></supplied> <expan><ex>ἀρτάβας</ex></expan> <num value="4">δ</num> <num value="1/2">𐅵</num> <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="12"/><abbr>πτ</abbr> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="13">ιγ</num> <num value="1/2">𐅵</num> <gap reason="lost" extent="unknown" unit="character"/>
 </ab></div>
-<div n="Concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="1"/><gap reason="lost" extent="unknown" unit="character"/><expan><supplied reason="lost">Ἁ</supplied>θὺ<ex>ρ</ex></expan> <num value="26"><hi rend="supraline">κϛ</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="6">ϛ</num>. <expan>Ἁδρ<ex>ιανοῦ</ex></expan> <num value="12"><hi rend="supraline">ιβ</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="6">ϛ</num>. <num value="26"><hi rend="supraline">κϛ</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="2">β</num> <expan>κρ<ex>ιθῆς</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="4">δ</num> <num value="1/2">𐅵</num>
 <lb n="2"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="1" unit="character"/> <num value="15"><hi rend="supraline">ιε</hi></num> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="3">γ</num>. <expan>Ὧρο<ex>ς</ex></expan> <expan>Πε<unclear>τε</unclear>χ<ex>ῶντος</ex></expan> <expan><ex>πυροῦ</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="4">δ</num> <expan>κρ<ex>ιθῆς</ex></expan> <num value="2">β</num> <num value="1/2">𐅵</num>
 <lb n="3"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="1" unit="character"/> <expan>κρ<ex>ιθῆς</ex></expan> <expan><ex>ἀρτάβας</ex></expan> <num value="2">β</num> <num value="1/2">𐅵</num>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.68.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.68.xml
@@ -14,7 +14,7 @@
             <idno type="TM">131116</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -48,14 +48,14 @@ l. 5: .8 ---&gt; .8 *slanting-stroke**slanting-stroke*</change>
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="Convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/><expan>ἄρτ<ex>οι</ex></expan> <num value="20"><unclear>κ</unclear></num> <expan>τιφ<ex>άγια</ex></expan>  <num value="20">κ</num>
 <lb n="2"/><expan>οἴ<ex>νου</ex></expan> <expan>κερ<ex>άμια</ex></expan> <num value="2">β</num> <expan>ὀρ<ex>νίθιον</ex></expan> <num value="1">α</num>
 <lb n="3"/><expan>χόρτ<ex>ου</ex></expan> <expan>δέσμ<ex>αι</ex></expan> <num value="10">ι</num>
 <lb n="4"/><expan>κριθ<ex>ῆς</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num> τῷ α<gap reason="illegible" quantity="2" unit="character"/>
 <lb n="5"/><gap reason="illegible" quantity="8" unit="character"/>
-</ab></div> 
-<div n="Concave" type="textpart"><ab>
+</ab></div>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="1"/><gap reason="illegible" quantity="7" unit="character"/>
 <lb n="2"/><gap reason="illegible" quantity="7" unit="character"/>
 <lb n="3"/>Χοίακ

--- a/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.84.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.1/o.trim.1.84.xml
@@ -14,7 +14,7 @@
             <idno type="TM">131132</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -43,21 +43,21 @@
   <text>
       <body>
          <head xml:lang="en"/>
-         <div xml:lang="grc" type="edition" xml:space="preserve"> 
-<div n="convex" type="textpart"><ab> 
+         <div xml:lang="grc" type="edition" xml:space="preserve">
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/>Κλαύδιος
 <lb n="2"/>Τι<unclear>μ</unclear>όθεος
 <lb n="3"/>Νικάων
 <lb n="4"/><expan>Δίδυμ<ex>ος</ex></expan>
 <lb n="5"/>Φιλάμμ<unclear>ων</unclear>
 <lb n="6"/><expan>Νι<unclear>λ</unclear>ίω<ex>ν</ex></expan>
- </ab></div> 
-<div n="concave" type="textpart"><ab> 
+ </ab></div>
+<div n="concave" subtype="side" type="textpart"><ab> 
 <lb n="1"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> ος
 <lb n="2"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> ων
 <lb n="3"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> ις
 <lb n="4"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> ν
-<lb n="5"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> ς 
+<lb n="5"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> ς
 </ab></div>
 
       </div>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.455.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.455.xml
@@ -14,7 +14,7 @@
             <idno type="TM">372073</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/><g type="slanting-stroke"/> <expan>υἱὸ<ex>ς</ex></expan> <expan>Ἀμμω<ex>νίου</ex></expan> <gap reason="illegible" quantity="3" unit="character"/>ρ <num value="2">β</num>
 
 <lb n="2"/><g type="slanting-stroke"/> <expan>υἱὸ<ex>ς</ex></expan> <expan>Εὐηθί<unclear>ο</unclear><ex>υ</ex></expan> <num value="2">β</num>
@@ -55,7 +55,7 @@
 
 <lb n="5"/><supplied reason="lost"><g type="slanting-stroke"/></supplied> Πεκῦσι<unclear>ς</unclear> <num value="1"><unclear>α</unclear></num>
 </ab></div>
-<div n="side" subtype="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="6"/>ἀπὸ Πμουω <num value="2">β</num>
 </ab></div>
 </div>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.512.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.512.xml
@@ -14,7 +14,7 @@
             <idno type="TM">372130</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -45,15 +45,15 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="concave" type="textpart"><ab>
-<lb n="1"/><num value="24"><hi rend="supraline">κδ</hi></num> Ἐπεὶφ 
+<div n="concave" subtype="side" type="textpart"><ab>
+<lb n="1"/><num value="24"><hi rend="supraline">κδ</hi></num> Ἐπεὶφ
 
-<lb n="2"/>τοῖς κτῆσι <expan>χόρτ<ex>ου</ex></expan> <expan>δέσμ<ex>ας</ex></expan> <num value="15">ιε</num>.  
+<lb n="2"/>τοῖς κτῆσι <expan>χόρτ<ex>ου</ex></expan> <expan>δέσμ<ex>ας</ex></expan> <num value="15">ιε</num>.
 
 <lb n="3"/><choice><reg>σεσημείωμαι</reg><orig>σεσημίωμαι</orig></choice> Σερῆνος.
 </ab></div>
 
-<div n="side" subtype="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/>Κ
 </ab></div>
       </div>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.524.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.524.xml
@@ -14,7 +14,7 @@
             <idno type="TM">372142</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab>
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/><num value="8">η</num><g type="slanting-stroke"/> <expan><unclear>Φα</unclear>ρ<unclear>μ</unclear><ex>οῦθι</ex></expan> <expan>κριθ<ex>ῆς</ex></expan>
 
 <lb n="2"/><expan>μ<ex>άτια</ex></expan> <num value="18">ιη</num>. <expan>σεση<unclear>μ</unclear><ex>είωμαι</ex></expan>
@@ -52,7 +52,7 @@
 <lb n="3"/>Ψάις.
 </ab></div>
 
-<div n="side" subtype="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="1"/><expan>δι<ex>ὰ</ex></expan> Σερ<unclear>α</unclear><supplied reason="lost">πίωνος</supplied> <gap reason="lost" extent="unknown" unit="character"/>
 
 <lb n="2"/>ἀ<unclear>νν</unclear><supplied reason="lost">ώνας</supplied> <gap reason="lost" extent="unknown" unit="character"/>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.525.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.525.xml
@@ -14,7 +14,7 @@
             <idno type="TM">372143</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="convex" type="textpart"><ab> 
+<div n="convex" subtype="side" type="textpart"><ab>
 <lb n="1"/><expan>δι<ex>ὰ</ex></expan> τοῦ ἀδελφοῦ
 
 <lb n="2"/>Σερήνου <expan>ἀνν<ex>ώνας</ex></expan> <num value="30">λ</num>
@@ -53,9 +53,9 @@
 
 <lb n="4"/><expan>σεση<ex>μείωμαι</ex></expan> <expan>Σαραπίω<ex>ν</ex></expan>
 
-<lb n="5"/>ἐξάκτωρ. 
-    </ab></div> 
-    <div n="concave" type="textpart"><ab> 
+<lb n="5"/>ἐξάκτωρ.
+    </ab></div>
+    <div n="concave" subtype="side" type="textpart"><ab> 
 <lb n="6"/>ὑπὲρ μηνὸς
 
 <lb n="7"/>Θὼθ ὥστε

--- a/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.744.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.744.xml
@@ -14,7 +14,7 @@
             <idno type="TM">372362</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -48,7 +48,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="concave" type="textpart">
+<div n="concave" subtype="side" type="textpart">
 <ab>
 <lb n="1"/><gap reason="lost" extent="unknown" unit="line"/>
 
@@ -61,7 +61,7 @@
 <lb n="5"/><expan>μ<ex>άτιον</ex></expan> <num value="1">α</num>
 </ab>
 </div>
-<div n="side" subtype="convex" type="textpart">
+<div n="convex" subtype="side" type="textpart">
 <ab>
 <lb n="1"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc><certainty match=".." locus="name"/></gap> <num value="60"><unclear>ξ</unclear></num> Ἑρμησ<unclear>ί</unclear>α
 </ab>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.758.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.758.xml
@@ -14,7 +14,7 @@
             <idno type="TM">372376</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,13 +44,13 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart">
+<div n="convex" subtype="side" type="textpart">
 <ab>
 <lb n="1"/><num value="1">α</num> <expan>Ψεναμούνιο<ex>ς</ex></expan>
 <lb n="2"/>Ψ<gap reason="illegible" quantity="3" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
 </ab>
 </div>
-<div n="side" subtype="concave" type="textpart">
+<div n="concave" subtype="side" type="textpart">
 <ab>
 <lb n="1"/><gap reason="illegible" quantity="2" unit="line"><desc>vestiges</desc></gap>
 </ab>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.765.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.765.xml
@@ -14,7 +14,7 @@
             <idno type="TM">372383</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart">
+<div n="convex" subtype="side" type="textpart">
 <ab>
 <lb n="1"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="1" unit="character"/> <num value="27"><hi rend="supraline">κ<unclear>ζ</unclear></hi></num> ὡς τοῦ λίνου
 
@@ -53,9 +53,9 @@
 <lb n="3"/>ἔτους <num value="1"><unclear>α</unclear></num>
 </ab>
 </div>
-<div n="side" subtype="concave" type="textpart">
+<div n="concave" subtype="side" type="textpart">
 <ab>
-1.Σεντλελα
+<lb n="1"/>Σεντλελα
 </ab>
 </div>      </div>
       </body>

--- a/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.780.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.780.xml
@@ -14,7 +14,7 @@
             <idno type="TM">372398</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,7 +44,7 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart">
+<div n="convex" subtype="side" type="textpart">
 <ab>
 <lb n="1"/>Γαιανὸς <gap reason="lost" extent="unknown" unit="character"/>
 
@@ -55,7 +55,7 @@
 <lb n="3"/><gap reason="lost" extent="unknown" unit="line"/>
 </ab>
 </div>
-<div n="side" subtype="concave" type="textpart">
+<div n="concave" subtype="side" type="textpart">
 <ab>
 <lb n="1"/><num value="6"><hi rend="supraline">ϛ</hi></num> <abbr>Ἀμμ</abbr> <gap reason="illegible" quantity="2" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
 

--- a/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.838.xml
+++ b/DDB_EpiDoc_XML/o.trim/o.trim.2/o.trim.2.838.xml
@@ -14,7 +14,7 @@
             <idno type="TM">372456</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
-          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+          <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative
           Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
@@ -44,21 +44,21 @@
       <body>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="side" subtype="convex" type="textpart"><ab>
-<lb n="1"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> 
+<div n="convex" subtype="side" type="textpart"><ab>
+<lb n="1"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
 <lb n="2"/>τῷ ἰδίῳ <choice><reg>Σαραπίωνι <gap reason="lost" extent="unknown" unit="character"/></reg><orig>Σαραπίωνο<supplied reason="lost">ς</supplied> <gap reason="lost" extent="unknown" unit="character"/></orig></choice>
 <lb n="3"/>χαίρειν. καλῶς ποιήσε<unclear>ι</unclear><supplied reason="lost">ς</supplied> <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="4"/>τὸν <choice><reg>κύριον</reg><orig>κύριν</orig></choice> <unclear>κό</unclear>μιζε υἱὸν Δωρό<supplied reason="lost">θεον</supplied> <gap reason="lost" extent="unknown" unit="character"/>
-<lb n="5"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> 
+<lb n="5"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap>
 <lb n="5"/><gap reason="lost" extent="unknown" unit="line"/>
 </ab></div>
 
-<div n="side" subtype="concave" type="textpart"><ab>
+<div n="concave" subtype="side" type="textpart"><ab>
 <lb n="1"/><gap reason="illegible" quantity="7" unit="character"/> τον ε<gap reason="illegible" quantity="5" unit="character"/>
 <lb n="2"/><gap reason="lost" quantity="1" unit="character"/>ετησιν δοὺς <gap reason="illegible" quantity="5" unit="character"/>ς
 <lb n="3"/>μάτια σίτου <gap reason="illegible" quantity="8" unit="character"/>
 <lb n="3"/><gap reason="lost" extent="unknown" unit="line"/>
-</ab></div> 
+</ab></div>
       </div>
       </body>
   </text>


### PR DESCRIPTION
Where convex and concave has been encoded as a `<div>`, DDB is a bit inconsistent, with `@subtype="side"` occasionally entered as `@n` (or omitted entirely). This pull updates a few files to standardize things for ostraca: the values for `@n` are `convex` or `concave`, while @subtype should be `side`. 