### PR TITLE
Pylon 1

### DIFF
--- a/APIS/lund/xml/lund.apis.219.xml
+++ b/APIS/lund/xml/lund.apis.219.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">lund.apis.219</idno>
             <idno type="controlNo">(SeUB)219</idno>
+            <idno type="TM">142605</idno>
+            <idno type="HGV">142605a</idno>
+            <idno type="HGV">142605b</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/Biblio/97/96113.xml
+++ b/Biblio/97/96113.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96113" type="article" xml:lang="en" subtype="journal">
+  <title level="a" type="main">A Register of Receipts (?) from a Military Context</title>
+  <author n="1">
+    <forename>Dan</forename>
+    <surname>Deac</surname>
+  </author>
+  <date>2022</date>
+  <ptr target="https://doi.org/10.48631/pylon.2022.1.89341"/>
+  <relatedItem type="appearsIn" n="1">
+    <bibl>
+      <ptr target="https://papyri.info/biblio/2374"/>
+      <!-- ignore - start, i.e. SoSOL users may not edit this  -->
+      <!-- ignore - stop -->
+    </bibl>
+  </relatedItem>
+  <biblScope type="issue">1</biblScope>
+  <idno type="pi">96113</idno>
+</bibl>

--- a/DCLP/132/131710.xml
+++ b/DCLP/132/131710.xml
@@ -88,7 +88,7 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
-         <change when="2021-07-08" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+         <change when="2021-07-08" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/383/382542.xml
+++ b/DCLP/383/382542.xml
@@ -101,7 +101,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Vote - Accept-Straight-to-Finalization - Yes.</change>
           <change when="2021-06-29T13:29:02-04:00"
                  who="http://papyri.info/editor/users/maebeme">Submit - Submitted as part of the research project "The Books of Karanis": principal investigator C.M. Sampson. </change>
-          <change when="2021-06-26" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-06-26" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/383/382543.xml
+++ b/DCLP/383/382543.xml
@@ -122,7 +122,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Vote - Accept-Straight-to-Finalization - Fine. The upper margin of col. i is preserved</change>
           <change when="2021-06-29T13:46:11-04:00"
                  who="http://papyri.info/editor/users/maebeme">Submit - Submitted as part of the research project "The Books of Karanis": principal investigator C.M. Sampson. </change>
-          <change when="2021-06-26" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-06-26" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/383/382544.xml
+++ b/DCLP/383/382544.xml
@@ -103,7 +103,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Vote - Accept-Straight-to-Finalization - Yes.</change>
           <change when="2021-06-29T13:30:53-04:00"
                  who="http://papyri.info/editor/users/maebeme">Submit - Submitted as part of the research project "The Books of Karanis": principal investigator C.M. Sampson. </change>
-          <change when="2021-06-26" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-06-26" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/383/382545.xml
+++ b/DCLP/383/382545.xml
@@ -101,7 +101,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Vote - Accept-Straight-to-Finalization - Yes.</change>
           <change when="2021-06-29T14:30:05-04:00"
                  who="http://papyri.info/editor/users/maebeme">Submit - Submitted as part of the research project "The Books of Karanis": principal investigator C.M. Sampson. </change>
-          <change when="2021-06-26" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-06-26" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/383/382546.xml
+++ b/DCLP/383/382546.xml
@@ -101,7 +101,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Vote - Accept-Straight-to-Finalization - Yes.</change>
           <change when="2021-06-29T14:33:31-04:00"
                  who="http://papyri.info/editor/users/maebeme">Submit - Submitted as part of the research project "The Books of Karanis": principal investigator C.M. Sampson.</change>
-          <change when="2021-06-26" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-06-26" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/383/382547.xml
+++ b/DCLP/383/382547.xml
@@ -101,7 +101,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Vote - Accept-Straight-to-Finalization - Yes.</change>
           <change when="2021-06-29T14:37:32-04:00"
                  who="http://papyri.info/editor/users/maebeme">Submit - Submitted as part of the research project "The Books of Karanis": principal investigator C.M. Sampson. </change>
-          <change when="2021-06-26" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-06-26" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/383/382548.xml
+++ b/DCLP/383/382548.xml
@@ -101,7 +101,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Vote - Accept-Straight-to-Finalization - Yes.</change>
           <change when="2021-06-29T14:42:14-04:00"
                  who="http://papyri.info/editor/users/maebeme">Submit - Submitted as part of the research project "The Books of Karanis": principal investigator C.M. Sampson. </change>
-          <change when="2021-06-26" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-06-26" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/383/382549.xml
+++ b/DCLP/383/382549.xml
@@ -126,7 +126,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Vote - Accept-Straight-to-Finalization - Yes.</change>
           <change when="2021-06-29T14:39:51-04:00"
                  who="http://papyri.info/editor/users/maebeme">Submit - Submitted as part of the research project "The Books of Karanis": principal investigator C.M. Sampson.</change>
-          <change when="2021-06-26" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-06-26" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/698/697546.xml
+++ b/DCLP/698/697546.xml
@@ -66,7 +66,7 @@
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change when="2022-06-28" who="https://papyri.info/editor/Mike%20Sampson">DCLP entry Xwalked</change>
+            <change when="2022-06-28" who="https://papyri.info/editor/users/Mike%20Sampson">DCLP entry Xwalked</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/DCLP/703/702606.xml
+++ b/DCLP/703/702606.xml
@@ -88,7 +88,7 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
-         <change when="2021-08-17" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+         <change when="2021-08-17" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/958/957669.xml
+++ b/DCLP/958/957669.xml
@@ -106,7 +106,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Vote - Accept-Straight-to-Finalization - Yes, fine.</change>
           <change when="2021-12-16T10:38:09-05:00"
                  who="http://papyri.info/editor/users/Mike%20Sampson">Submit - Initial entry, from ed. pr.</change>
-          <change when="2021-07-08" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-07-08" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/958/957670.xml
+++ b/DCLP/958/957670.xml
@@ -101,7 +101,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Vote - Accept-Straight-to-Finalization - Yes, fine.</change>
           <change when="2021-12-16T10:46:31-05:00"
                  who="http://papyri.info/editor/users/Mike%20Sampson">Submit - Initial submission, from ed. pr.</change>
-          <change when="2021-07-08" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-07-08" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/958/957671.xml
+++ b/DCLP/958/957671.xml
@@ -106,7 +106,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Submit - Initial entry, from ed.pr.</change>
           <change when="2021-12-16T15:47:55-05:00"
                  who="http://papyri.info/editor/users/Mike%20Sampson">Submit - Initial entry, from ed.pr.</change>
-          <change when="2021-07-08" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-07-08" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DCLP/958/957672.xml
+++ b/DCLP/958/957672.xml
@@ -106,7 +106,7 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Vote - Accept-Straight-to-Finalization - Yes. Fine.</change>
           <change when="2022-01-07T15:28:18-05:00"
                  who="http://papyri.info/editor/users/Mike%20Sampson">Submit - Initial entry, from ed. pr.</change>
-          <change when="2021-07-08" who="http://papyri.info/editor/Mike%20Sampson">DCLP metadata Xwalked</change>
+          <change when="2021-07-08" who="http://papyri.info/editor/users/Mike%20Sampson">DCLP metadata Xwalked</change>
       </revisionDesc>
   </teiHeader>
   <text>

--- a/DDB_EpiDoc_XML/pylon/pylon.1/pylon.1.12r.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.1/pylon.1.12r.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>pylon.1.12r</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">pylon.1.12r</idno>
+                <idno type="ddb-hybrid">pylon;1;12r</idno>
+                <idno type="HGV">142605a</idno>
+               <idno type="TM">142605</idno>
+                <availability>
+                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+                        <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+                            Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>
+                    <bibl>Pylon 1 12r</bibl>
+                </p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="grc">Greek</language>
+                <language ident="la">Latin</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-05" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+         <body>
+            <div xml:id="ed1" xml:lang="grc" type="edition" xml:space="preserve">
+<div n="i" subtype="column" type="textpart"><ab>
+<lb n="1" xml:id="ed1col1ln1"/><gap reason="lost" extent="unknown" unit="character"/>ευς
+<lb n="2" xml:id="ed1col1ln2"/><gap reason="lost" extent="unknown" unit="character"/>τιου
+<lb n="3" xml:id="ed1col1ln3"/><gap reason="lost" extent="unknown" unit="character"/><unclear>α</unclear>νω
+<lb n="4" xml:id="ed1col1ln4"/><gap reason="lost" extent="unknown" unit="character"/>ησ<gap reason="illegible" quantity="2" unit="character"/><unclear>σ</unclear>
+<lb n="5" xml:id="ed1col1ln5"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="1" unit="character"/><unclear>ο</unclear>ν<unclear>πα</unclear>  
+<lb n="6" xml:id="ed1col1ln6"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="4" unit="character"/>
+<lb n="7" xml:id="ed1col1ln7"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="2" unit="character"/>αν<unclear>το</unclear>  
+<lb n="8" xml:id="ed1col1ln8"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="4" unit="character"/>
+<lb n="9" xml:id="ed1col1ln9"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="4" unit="character"/>
+<lb n="10" xml:id="ed1col1ln10"/><gap reason="lost" extent="unknown" unit="character"/>τι<gap reason="illegible" quantity="2" unit="character"/>
+<lb n="11" xml:id="ed1col1ln11"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="1" unit="character"/><unclear>π</unclear><gap reason="illegible" quantity="1" unit="character"/><unclear>η</unclear>ς
+<lb n="12" xml:id="ed1col1ln12"/><gap reason="lost" extent="unknown" unit="character"/><unclear>α</unclear>φιν 
+<lb n="13"/><gap reason="lost" extent="unknown" unit="line"/>
+</ab></div>
+<div n="ii" subtype="column" type="textpart"><ab>
+<lb n="1" xml:id="ed1col2ln1"/>Βιρρίου Φλώρο<supplied reason="lost">υ</supplied> <gap reason="lost" quantity="20" unit="character" precision="low"/> <supplied reason="lost">καὶ οὐδέν σοι</supplied>
+<lb n="2" xml:id="ed1col2ln2"/><choice><reg>ἐγκαλῶ</reg><orig>ἐνκαλῶ</orig></choice>. ἔτους δεκ<unclear>ά</unclear><supplied reason="lost">του Αὐτοκράτορος Καίσαρος Νέρ</supplied>
+<lb n="3" break="no" xml:id="ed1col2ln3"/>ουα <supplied reason="lost">T</supplied><unclear>ρ</unclear>αιανοῦ Σεβαστοῦ Γε<unclear>ρ</unclear><supplied reason="lost">µανικοῦ Δακικοῦ,</supplied>
+<lb n="4" xml:id="ed1col2ln4"/>Φαῶφι <num value="5"><hi rend="supraline">ε</hi></num>
+<milestone rend="paragraphos" unit="undefined"/>
+<lb n="5" xml:id="ed1col2ln5"/>Μᾶρκος <choice><reg>Οὐαλέριoς</reg><orig>Οὐαλέρις</orig></choice> <unclear>M</unclear><gap reason="lost" quantity="10" unit="character" precision="low"/> <supplied reason="lost">ἀπὸ τῶν</supplied> <supplied reason="lost" cert="low">ἐντίμως</supplied> <supplied reason="lost">ἀπο</supplied>
+<lb n="6" break="no" xml:id="ed1col2ln6"/>λελυμένων οὐε<unclear>τ</unclear><supplied reason="lost">ρανῶν</supplied> <gap reason="lost" quantity="20" unit="character" precision="low"/>
+<lb n="7" xml:id="ed1col2ln7"/>ἀρμοκούστορι τύρ<unclear>μ</unclear><supplied reason="lost">ης</supplied> <gap reason="lost" quantity="20" unit="character" precision="low"/> <supplied reason="lost" cert="low">χαίρειν.</supplied>
+<lb n="8" xml:id="ed1col2ln8"/>ἀπέσχον πα<supplied reason="lost">ρὰ σοῦ</supplied> <gap reason="lost" quantity="25" unit="character" precision="low"/>
+<lb n="9" xml:id="ed1col2ln9"/>τα ἀρ<unclear>γυρ</unclear><supplied reason="lost">ίου</supplied> <gap reason="lost" quantity="30" unit="character" precision="low"/>
+<lb n="10" xml:id="ed1col2ln10"/>ἐπάρχου <supplied reason="lost" cert="low">εἴλης</supplied> <gap reason="lost" quantity="15" unit="character" precision="low"/> <supplied reason="lost" cert="low">καὶ οὐδέν σοι</supplied>
+<lb n="11" xml:id="ed1col2ln11"/><choice><reg>ἐγκαλῶ</reg><orig>ἐ<unclear>νκ</unclear><supplied reason="lost" cert="low">αλῶ</supplied></orig></choice> <gap reason="lost" extent="unknown" unit="character"/>
+<lb n="12"/><gap reason="lost" extent="unknown" unit="line"/> 
+</ab></div></div>
+         </body>
+      </text>
+</TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.1/pylon.1.12v.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.1/pylon.1.12v.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>pylon.1.12v</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">pylon.1.12v</idno>
+                <idno type="ddb-hybrid">pylon;1;12v</idno>
+                <idno type="HGV">142605b</idno>
+               <idno type="TM">142605</idno>
+                <availability>
+                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+                        <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+                            Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>
+                    <bibl>Pylon 1 12v</bibl>
+                </p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="grc">Greek</language>
+                <language ident="la">Latin</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-05" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+         <body>
+            <div xml:id="ed2" xml:lang="grc" type="edition" xml:space="preserve">
+<div n="i" subtype="column" type="textpart"><ab>
+<lb n="1"/><gap reason="lost" extent="unknown" unit="line"/>
+<lb n="1" xml:id="ed2col1ln1"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="1" unit="character"/>ιβλο
+<lb n="2" xml:id="ed2col1ln2"/><gap reason="lost" extent="unknown" unit="character"/> <hi rend="supraline">ιδ</hi> <expan><ex>ἔτους</ex></expan>
+<lb n="2a"/><gap reason="lost" extent="unknown" unit="character"/> <space extent="unknown" unit="character"/> 
+<lb n="3" xml:id="ed2col1ln3"/><gap reason="lost" extent="unknown" unit="character"/> διὰ <choice><reg><expan>χειρό<ex>ς</ex></expan></reg><orig><expan>χιρ<unclear>ό</unclear><ex>ς</ex></expan></orig></choice>
+<lb n="4" xml:id="ed2col1ln4"/><gap reason="lost" extent="unknown" unit="character"/> Tῦβι <hi rend="supraline">ιδ</hi> <expan><ex>ἔτους</ex></expan> 
+</ab></div>
+<div n="ii" subtype="column" type="textpart"><ab>
+<lb n="1"/><gap reason="lost" extent="unknown" unit="line"/>
+<lb n="1"/><hi rend="supraline">ιθ</hi> <unclear>η</unclear> <gap reason="lost" extent="unknown" unit="character"/>
+<lb n="2"/><choice><reg>ἔχω</reg><orig>ἔχο</orig></choice> Φ<unclear>λαο</unclear>υ<unclear>ι</unclear><gap reason="lost" extent="unknown" unit="character"/>
+<lb n="3"/><gap reason="lost" extent="unknown" unit="line"/> 
+</ab></div></div>
+         </body>
+      </text>
+</TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.1/pylon.1.17.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.1/pylon.1.17.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>pylon.1.17</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">pylon.1.17</idno>
+                <idno type="ddb-hybrid">pylon;1;17</idno>
+                <idno type="HGV">971907</idno>
+                <idno type="TM">971907</idno>
+                <availability>
+                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+                        <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+                            Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>
+                    <bibl>Pylon 1 17</bibl>
+                </p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="grc">Greek</language>
+                <language ident="la">Latin</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-04" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:id="ed1" xml:lang="grc" type="edition" xml:space="preserve">
+                <ab>
+<lb n="1"/><supplied reason="lost">ἔτους <app type="editorial"><lem><num value="24">κδ</num></lem><rdg><num value="20">κ</num></rdg></app><g type="slanting-stroke"/><g type="slanting-stroke"/> Μάρκου Αὐρηλίου Σεου</supplied><unclear>ή</unclear><supplied reason="lost">ρ</supplied><unclear>ο</unclear><supplied reason="lost">υ</supplied>
+<lb n="2"/><supplied reason="lost">Ἀντωνίνου</supplied> Παρθι<unclear>κ</unclear>οῦ Μ<unclear>ε</unclear>γίστου
+<lb n="3"/><choice><reg>Βρεταννικ<supplied reason="lost">ο</supplied>ῦ</reg><orig>Βρ<unclear>ετ</unclear>τανικ<supplied reason="lost">ο</supplied>ῦ</orig></choice> Μ<unclear>εγί</unclear>στ<unclear>ου</unclear> <expan><unclear>Γε</unclear>ρμ<unclear>α</unclear>νικ<ex>οῦ</ex></expan>
+<lb n="4"/>Μεγίστου Εὐσεβοῦς Σεβαστοῦ <choice><reg>Ἐπειφ</reg><orig>Ἐπιφ</orig></choice> <num value="23">κγ</num>.
+<lb n="5"/><choice><reg><expan>διέγρ<ex>αψεν</ex></expan></reg><orig><expan>διαίγρ<ex>αψεν</ex></expan></orig></choice> Αὐρηλίῳ Μέλανι <expan>γρ<ex>αμματεῖ</ex></expan> <expan>πρ<ex>ακτόρων</ex></expan> <expan>ἀρ<ex>γυρικῶν</ex></expan>
+<lb n="6"/><app type="editorial"><lem><expan><supplied reason="lost">Κ</supplied><unclear>αρ</unclear><ex>ανίδος</ex></expan></lem><rdg><expan>Αὐρ<ex>ήλιος</ex></expan></rdg></app> <choice><reg>Τερέντιος</reg><orig>Τερεντίου</orig></choice> Ἰουλίας Λογγινίας
+<lb n="7"/><app type="editorial"><lem><gap reason="illegible" quantity="1" unit="character"/> <expan><unclear>π</unclear><ex>αραδείσου</ex></expan></lem><rdg><expan>προ<ex cert="low">βάτων</ex></expan></rdg></app> <num value="22">κβ</num> <expan><ex>ἔτους</ex></expan> <app type="editorial"><lem>δραχμὰς</lem><rdg><choice><reg>δραχμὰς</reg><orig>δραχμαὶ</orig></choice></rdg></app> <num value="36">τριάκοντα ἕξ</num>, <expan><ex>γίνονται</ex></expan> <expan><ex>δραχμαὶ</ex></expan> <num value="36">λϛ</num>.
+                </ab>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV12/11645.xml
+++ b/HGV_meta_EpiDoc/HGV12/11645.xml
@@ -4,21 +4,22 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>keiner</title>
+            <title>Ricevuta di pagamento del πελωχικόν</title>
          </titleStmt>
          <publicationStmt>
             <idno type="filename">11645</idno>
             <idno type="TM">11645</idno>
-            <idno type="ddb-perseus-style">0154;2;182</idno>
-            <idno type="ddb-filename">p.lond.2.182</idno>
-            <idno type="ddb-hybrid">p.lond;2;182</idno>
+            <idno type="ddb-filename">pylon.1.3</idno>
+            <idno type="ddb-hybrid">pylon;1;3</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>unbekannt</settlement>
+                     <settlement>London</settlement>
                   </placeName>
+                  <collection>British Library</collection>
+                  <idno type="invNo">Pap. 182</idno>
                </msIdentifier>
                <physDesc>
                   <objectDesc>
@@ -46,6 +47,11 @@
                   </provenance>
                </history>
             </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96102"/>
+               </bibl>
+            </listBibl>            
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
@@ -74,6 +80,7 @@
          <change who="HGV" when="1995-12-14">Record created</change>
          <change who="HGV" when="2009-07-02">Record last modified</change>
          <change when="2011-04-20" who="IDP">Crosswalked to EpiDoc XML</change>
+         <change when="2022-07-04" who="https://papyri.info/editor/users/Mike%20Sampson">Updates from Pylon 1</change>
       </revisionDesc>
    </teiHeader>
    <text>
@@ -95,11 +102,10 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lond.</title>
-                  <biblScope type="volume">2</biblScope>
-                  <biblScope type="numbers">182</biblScope>
-                  <biblScope type="generic">a</biblScope>
-                  <biblScope type="pages">(S. XVII)</biblScope>
+                  <title level="s" type="abbreviated">Pylon</title>
+                  <biblScope n="1" type="volume">1</biblScope>
+                  <biblScope n="2" type="fascicle">(2022)</biblScope>
+                  <biblScope n="3" type="number">Nr. 3</biblScope>
                </bibl>
             </listBibl>
          </div>
@@ -110,10 +116,18 @@
          </div>
          <div type="figure">
             <p>
-               <figure>
+               <figure n="1">
                   <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_182"/>
                </figure>
+               <figure n="2">
+                  <graphic url="https://doi.org/10.48631/pylon.2022.1.89330"/>
+               </figure>
             </p>
+         </div>
+         <div type="bibliography" subtype="otherPublications">
+            <listBibl>
+               <bibl type="publication" subtype="other">P.Lond. II 182 a (S. XVII)</bibl>
+            </listBibl>
          </div>
       </body>
    </text>

--- a/HGV_meta_EpiDoc/HGV143/142605a.xml
+++ b/HGV_meta_EpiDoc/HGV143/142605a.xml
@@ -4,22 +4,22 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A Receipt for the Didrachmia of Souchos</title>
+            <title>A Register of Receipts (?) from a Military Context</title>
          </titleStmt>
          <publicationStmt>
             <authority>Papyri.info</authority>
-            <idno type="TM">971879</idno>
-            <idno type="ddb-filename">pylon.1.18</idno>
-            <idno type="ddb-hybrid">pylon;1;18</idno>
+            <idno type="TM">142605</idno>
+            <idno type="ddb-filename">pylon.1.12r</idno>
+            <idno type="ddb-hybrid">pylon;1;12r</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>Oxford</settlement>
+                     <settlement>Lund</settlement>
                   </placeName>
-                  <collection>Sackler Library</collection>
-                  <idno type="invNo">EES 89A/151(c)</idno>
+                  <collection>University</collection>
+                  <idno type="invNo">P. 213</idno>
                </msIdentifier>
                <physDesc>
                   <objectDesc>
@@ -32,26 +32,19 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Karanis (Arsinoites)</origPlace>
-                     <origDate notBefore="0062-04-26" notAfter="0062-05-25">26. Apr. - 25. Mai 62</origDate>
+                     <origPlace>Ägypten</origPlace>
+                     <origDate when="0106-10-02">2. Okt. 106</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName n="1"
-                                   type="ancient"
-                                   ref="https://www.trismegistos.org/place/1008 https://pleiades.stoa.org/places/736932">Karanis</placeName>
-                        <placeName n="2"
-                                   type="ancient"
-                                   subtype="nome"
-                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
-                        <placeName type="ancient" subtype="region">Ägypten</placeName>
+                        <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>
             </msDesc>
             <listBibl>
                <bibl type="SB">
-                  <ptr target="https://papyri.info/biblio/96112"/>
+                  <ptr target="https://papyri.info/biblio/96113"/>
                </bibl>
             </listBibl>            
          </sourceDesc>
@@ -72,12 +65,12 @@
          <textClass>
             <keywords scheme="hgv">
                <term n="1">Quittung</term>
-               <term n="2">Steuer</term>
+               <term n="2">Geld</term>
             </keywords>
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change when="2022-07-01" who="https://papyri.info/editor/users/james.cowey">Xwalk from Pylon 1</change>
+         <change when="2022-07-05" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
       </revisionDesc>
    </teiHeader>
    <text>
@@ -88,14 +81,14 @@
             <title level="s" type="abbreviated">Pylon</title>
             <biblScope n="1" type="volume">1</biblScope>
             <biblScope n="2" type="fascicle">(2022)</biblScope>
-            <biblScope n="3" type="number">Nr. 18</biblScope>
+            <biblScope n="3" type="number">Nr. 12r</biblScope>
           </bibl>
         </listBibl>
       </div>
       <div type="figure">
         <p>
           <figure n="1">
-            <graphic url="https://doi.org/10.48631/pylon.2022.1.89346"/>
+            <graphic url="https://doi.org/10.48631/pylon.2022.1.89341"/>
           </figure>
         </p>
       </div>

--- a/HGV_meta_EpiDoc/HGV143/142605b.xml
+++ b/HGV_meta_EpiDoc/HGV143/142605b.xml
@@ -4,22 +4,22 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A Receipt for the Didrachmia of Souchos</title>
+            <title>Fragmentary text</title>
          </titleStmt>
          <publicationStmt>
             <authority>Papyri.info</authority>
-            <idno type="TM">971879</idno>
-            <idno type="ddb-filename">pylon.1.18</idno>
-            <idno type="ddb-hybrid">pylon;1;18</idno>
+            <idno type="TM">142605</idno>
+            <idno type="ddb-filename">pylon.1.12v</idno>
+            <idno type="ddb-hybrid">pylon;1;12v</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>Oxford</settlement>
+                     <settlement>Lund</settlement>
                   </placeName>
-                  <collection>Sackler Library</collection>
-                  <idno type="invNo">EES 89A/151(c)</idno>
+                  <collection>University</collection>
+                  <idno type="invNo">P. 213</idno>
                </msIdentifier>
                <physDesc>
                   <objectDesc>
@@ -32,26 +32,19 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Karanis (Arsinoites)</origPlace>
-                     <origDate notBefore="0062-04-26" notAfter="0062-05-25">26. Apr. - 25. Mai 62</origDate>
+                     <origPlace>Ägypten</origPlace>
+                     <origDate notBefore="0110-12-27" notAfter="0111-01-25">27. Dez. 110 - 25. Jan. 111</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName n="1"
-                                   type="ancient"
-                                   ref="https://www.trismegistos.org/place/1008 https://pleiades.stoa.org/places/736932">Karanis</placeName>
-                        <placeName n="2"
-                                   type="ancient"
-                                   subtype="nome"
-                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
-                        <placeName type="ancient" subtype="region">Ägypten</placeName>
+                        <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>
             </msDesc>
             <listBibl>
                <bibl type="SB">
-                  <ptr target="https://papyri.info/biblio/96112"/>
+                  <ptr target="https://papyri.info/biblio/96113"/>
                </bibl>
             </listBibl>            
          </sourceDesc>
@@ -71,13 +64,12 @@
          </langUsage>
          <textClass>
             <keywords scheme="hgv">
-               <term n="1">Quittung</term>
-               <term n="2">Steuer</term>
+               <term n="1">Fragment</term>
             </keywords>
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change when="2022-07-01" who="https://papyri.info/editor/users/james.cowey">Xwalk from Pylon 1</change>
+         <change when="2022-07-05" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
       </revisionDesc>
    </teiHeader>
    <text>
@@ -88,14 +80,14 @@
             <title level="s" type="abbreviated">Pylon</title>
             <biblScope n="1" type="volume">1</biblScope>
             <biblScope n="2" type="fascicle">(2022)</biblScope>
-            <biblScope n="3" type="number">Nr. 18</biblScope>
+            <biblScope n="3" type="number">Nr. 12v</biblScope>
           </bibl>
         </listBibl>
       </div>
       <div type="figure">
         <p>
           <figure n="1">
-            <graphic url="https://doi.org/10.48631/pylon.2022.1.89346"/>
+            <graphic url="https://doi.org/10.48631/pylon.2022.1.89341"/>
           </figure>
         </p>
       </div>

--- a/HGV_meta_EpiDoc/HGV40/39584.xml
+++ b/HGV_meta_EpiDoc/HGV40/39584.xml
@@ -4,21 +4,22 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>keiner</title>
+            <title>Private Letter</title>
          </titleStmt>
          <publicationStmt>
             <idno type="filename">39584</idno>
             <idno type="TM">39584</idno>
-            <idno type="ddb-perseus-style">0154;3;868</idno>
-            <idno type="ddb-filename">p.lond.3.868</idno>
-            <idno type="ddb-hybrid">p.lond;3;868</idno>
+            <idno type="ddb-filename">pylon.1.4</idno>
+            <idno type="ddb-hybrid">pylon;1;4</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>unbekannt</settlement>
+                     <settlement>London</settlement>
                   </placeName>
+                  <collection>British Library</collection>
+                  <idno type="invNo">Pap. 868</idno>
                </msIdentifier>
                <physDesc>
                   <objectDesc>
@@ -32,10 +33,15 @@
                <history>
                   <origin>
                      <origPlace>unbekannt</origPlace>
-                     <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
+                     <origDate notBefore="0626" notAfter="0675" precision="low">Mitte VII</origDate>
                   </origin>
                </history>
             </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96104"/>
+               </bibl>
+            </listBibl>            
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
@@ -55,8 +61,10 @@
          </langUsage>
          <textClass>
             <keywords scheme="hgv">
-               <term>Brief (privat)</term>
-               <term>N.N. an N.N.</term>
+               <term n="1">Brief (privat)</term>
+               <term n="2">Fisch</term>
+               <term n="3">Probleme</term>
+               <term n="4">Grüße</term>
             </keywords>
          </textClass>
       </profileDesc>
@@ -64,26 +72,33 @@
          <change who="HGV" when="1995-07-24">Record created</change>
          <change who="HGV" when="2009-07-02">Record last modified</change>
          <change when="2011-04-20" who="IDP">Crosswalked to EpiDoc XML</change>
+         <change when="2022-07-04" who="https://papyri.info/editor/users/Mike%20Sampson">Updates from Pylon 1</change>         
       </revisionDesc>
    </teiHeader>
    <text>
       <body>
-         <div type="commentary" subtype="general">
-            <p>Descr.</p>
-         </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lond.</title>
-                  <biblScope type="volume">3</biblScope>
-                  <biblScope type="numbers">868</biblScope>
-                  <biblScope type="pages">(S. XLI)</biblScope>
+                  <title level="s" type="abbreviated">Pylon</title>
+                  <biblScope n="1" type="volume">1</biblScope>
+                  <biblScope n="2" type="fascicle">(2022)</biblScope>
+                  <biblScope n="3" type="number">Nr. 4</biblScope>
                </bibl>
             </listBibl>
          </div>
-         <div type="bibliography" subtype="illustrations">
-            <p>keine</p>
+         <div type="figure">
+         <p>
+            <figure n="1">
+               <graphic url="https://doi.org/10.48631/pylon.2022.1.89335"/>
+            </figure>
+         </p>
          </div>
+         <div type="bibliography" subtype="otherPublications">
+            <listBibl>
+               <bibl type="publication" subtype="other">P.Lond. III 868 (S. XLI)</bibl>
+            </listBibl>
+         </div>         
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV972/971907.xml
+++ b/HGV_meta_EpiDoc/HGV972/971907.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv971907">

--- a/HGV_meta_EpiDoc/HGV972/971907.xml
+++ b/HGV_meta_EpiDoc/HGV972/971907.xml
@@ -1,0 +1,103 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv971907">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A receipt for garden tax paid to Aurelius Melas</title></titleStmt>
+      <publicationStmt>
+        <authority>Papyri.info</authority>
+        <idno type="TM">971907</idno>
+        <idno type="HGV">971907</idno>
+        <idno type="ddb-filename">pylon.1.17</idno>
+        <idno type="ddb-hybrid">pylon;1;17</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Hamburg</settlement>
+            </placeName>
+            <collection>Staats- und Universitätsbibliothek</collection>
+            <idno type="invNo">P.Hamb.graec. 185</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Karanis (Arsinoites)</origPlace>
+              <origDate when="0216-07-17">17. Juli 216</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1"
+                           type="ancient"
+                           ref="https://www.trismegistos.org/place/1008 https://pleiades.stoa.org/places/736932">Karanis</placeName>
+                <placeName n="2" type="ancient" subtype="nome">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+            <bibl type="SB">
+                <ptr target="https://papyri.info/biblio/96099"/>
+            </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Steuern</term>
+          <term n="3">Geld</term>
+          <term n="4">Paradeisos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+        <change when="2022-07-04" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">Pylon</title>
+            <biblScope n="1" type="volume">1</biblScope>
+            <biblScope n="2" type="fascicle">(2022)</biblScope>
+            <biblScope n="3" type="number">Nr. 17</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="https://doi.org/10.48631/pylon.2022.1.89345"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
Added/updated HGV meta for Messeri, Z-R, Deac, and Sampson in Pylon 1; added DDB for Sampson and Deac. Lund APIS idnos for aggregation following Deac in Pylon 1; various updates to revisionDesc caused by incomplete @who. 