### PR TITLE
Xwalk translations from Pylon 1

### DIFF
--- a/HGV_trans_EpiDoc/11645.xml
+++ b/HGV_trans_EpiDoc/11645.xml
@@ -38,7 +38,7 @@
     </teiHeader>
     <text>
         <body>
-            <divxml:lang="it" type="translation" xml:space="preserve">
+            <div xml:lang="it" type="translation" xml:space="preserve">
                 <p>
                     <milestone unit="line" n="1"/> Anno II di Marco Aurelio Antonino Pio Felice Augusto, Tybi 21 [16.1.219]. <milestone unit="line" n="5"/> Ha pagato agli Aurelii Afrodisio ex archiereo e Mysthes ex agoranomo, <milestone unit="line" n="8" rend="break"/> entrambi buleuti, meridarchi della divisione di Eraclide, per la tassa dei mulini, Panephremmis, figlio di Stotoetis, abitante del villaggio di Soknopaiu Nesos, dracme 28, fanno dracme 28 <milestone unit="line" n="16" rend="break"/> e il 27 di Pachon [22.5.219] (ha pagato) dracme 26, fanno dracme 26, in tutto.
                 </p>

--- a/HGV_trans_EpiDoc/11645.xml
+++ b/HGV_trans_EpiDoc/11645.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Ricevuta di pagamento del πελωχικόν</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">11645</idno>
+                <idno type="TM">11645</idno>
+                <idno type="HGV">11645</idno>
+                <idno type="ddb-hybrid">pylon;1;3</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <divxml:lang="it" type="translation" xml:space="preserve">
+                <p>
+                    <milestone unit="line" n="1"/> Anno II di Marco Aurelio Antonino Pio Felice Augusto, Tybi 21 [16.1.219]. <milestone unit="line" n="5"/> Ha pagato agli Aurelii Afrodisio ex archiereo e Mysthes ex agoranomo, <milestone unit="line" n="8" rend="break"/> entrambi buleuti, meridarchi della divisione di Eraclide, per la tassa dei mulini, Panephremmis, figlio di Stotoetis, abitante del villaggio di Soknopaiu Nesos, dracme 28, fanno dracme 28 <milestone unit="line" n="16" rend="break"/> e il 27 di Pachon [22.5.219] (ha pagato) dracme 26, fanno dracme 26, in tutto.
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/142605.xml
+++ b/HGV_trans_EpiDoc/142605.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Register of receipts (?) from a military context</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">142605</idno>
+                <idno type="TM">142605</idno>
+                <idno type="HGV">142605a</idno>
+                <idno type="HGV">142605b</idno>
+                <idno type="ddb-hybrid">pylon;1;12r</idno>
+                <idno type="ddb-hybrid">pylon;1;12v</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:id="trans1" xml:lang="en" type="translation" xml:space="preserve">
+                <div n="r" type="textpart">
+                    <p>
+                        <milestone unit="line" n="1"/> (m1) (…) of Birrius Florus (…) (... I make no) claim (against you). The 10th year of the (emperor Caesar) Nerva Traianus Augustus, Germanicus, (Dacicus,) Phaophi 5.<milestone unit="line" n="5" rend="break"/> (m2) Marcus Valerius M(<gap reason="illegible" extent="unknown" unit="character"/>), (from among the honorably) discharged veterans, to the <emph rend="italics">custos armorum</emph> of the <emph rend="italics">turma</emph> of (<gap reason="illegible" extent="unknown" unit="character"/>, greetings!). I have received from (you...) money (<gap reason="illegible" extent="unknown" unit="character"/>) of the commander (…) (... that I make no) claim (against you? …).
+                    </p>
+                </div>
+                <div n="v" type="textpart">
+                    <p>
+                        <milestone unit="line" n="1"/> (…) year 14 (…received) by hand (…) Tybi, year 14. (…)
+                    </p>
+                </div>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/15701.xml
+++ b/HGV_trans_EpiDoc/15701.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Sale of a Slave</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">15701</idno>
+                <idno type="TM">15701</idno>
+                <idno type="HGV">15701</idno>
+                <idno type="dclp-hybrid">pylon;1;11_1</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    <milestone unit="line" n="1"/> [To N.N.] alias Hipparchus, archidicastes and [superintendent of the <emph rend="italics">chrematistae</emph> and] the other courts, [from] Aurelius Horigenes, soldier of the <emph rend="italics">legio</emph> [<emph rend="italics">II Traiana Germanica</emph>] <emph rend="italics">Antoniniana fortis</emph> in the 
+century of Aurelius Ma–, [and from Iulius Eutyches …] Aurelius Protarchus … Areius … <milestone unit="line" n="7" rend="break"/> Iulius Eutyches, through his co-guarantor [Aurelius Protarchus, agrees that he has sold to Aurelius] Horigenes the female slave called 
+Ken– … Paphlagonian [by birth], imported by sea, [without warranty and being free from epilepsy and] leprosy, for the price of <emph rend="italics">n</emph> drachmas of silver, [which] Iulius Eutyches has received from [Aurelius Horigenes, so that from now on] 
+Aurelius Horigenes, having taken delivery of [the slave Ken– and having performed(?)] the examination [in accordance with] what has been ordained [and having paid for her] the tax due on slaves, possesses [and owns] her 
+[and has the right to sell her to others] and to deploy her and to make use [of her as he pleases without hindrance], the guarantee resting upon [the seller Iulius Eutyches] himself [and his] guarantor Aurelius Protarchus … 
+[Anyone who proceeds (against Aurelius Horigenes)] in any way whatsoever [or makes a claim] on account of the slave or a part of her, they (agree) to repel [at once at their own expense] or else forfeit on mutual guarantee 
+[to the buyer the principal of the price plus one-half together with the] damages [and expenses, as if in consequence of a legal decision …] 
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/15701.xml
+++ b/HGV_trans_EpiDoc/15701.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">15701</idno>
                 <idno type="TM">15701</idno>
                 <idno type="HGV">15701</idno>
-                <idno type="dclp-hybrid">pylon;1;11_1</idno>
+                <idno type="ddb-hybrid">pylon;1;11_1</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/16998.xml
+++ b/HGV_trans_EpiDoc/16998.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Sale of a Slave</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">16998</idno>
+                <idno type="TM">16998</idno>
+                <idno type="HGV">16998</idno>
+                <idno type="dclp-hybrid">pylon;1;11_2</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    <milestone unit="line" n="1"/> [In the fourth year of Imperator Caesar Marcus] Aurelius Probus Gothicus Maximus Germanicus [Maximus Persicus Maximus Pius Felix Augustus, (in the month of) Panemus] (which is) Pachon (<emph rend="italics">blank</emph>), in the splendid and most splendid 
+[city of Oxyrhynchites, before Aurelius Agathinus alias Horigenes,] concessionary of the notarial office. <milestone unit="line" n="4" rend="break"/> [Aurelius Theon, chief priest and councillor] of the splendid [and] most splendid [city] of Oxyrhynchites, [son of Theon, former 
+agoranomus of the same city, has purchased in the street from] Aurelia Rhodine, freedwoman of [the citizen] Eudaemonis daughter of S–on, [about 42 years old, acting without a guardian according to Roman custom] 
+by virtue of the <emph rend="italics">ius liberorum</emph>, with as her assistant [and co-guarantor of the following slave her] husband [Aurelius Heraclas alias Diogenes son of D–, former … of the] same city, mother Maxima, from the same city, 
+the slave [belonging to her] and conveyed to her through the notarial office here [in the <emph rend="italics">n</emph>th year of the reign of Aurelianus in the month Hathyr by her former and deceased] husband Aurelius Horion son of Anicetus, 
+[former gymnasiarch and councillor of the same city, in repayment of four talents of silver which he received] from her [in instalments] for his pressing needs [and which came from the sale of her feminine] goods. 
+<milestone unit="line" n="11"/> She is called Stratonice, [about 27 years old, with no distinguishing mark, and was formally examined as] indicated [in the previous contract]. The buyer [Aurelius Theon] has forthwith received [the slave Stratonice free from epilepsy and] 
+leprosy at the price [mutually] agreed upon [for the aforementioned slave Stratonice], seven talents [and two thousand seven hundred drachmas of silver of Imperial] coinage, [which the seller Rhodine has received on the spot in full] 
+from the buyer Theon [under the supervision of her said husband Aurelius Heraclas alias Diogenes]. The said [seller Rhodine] sells and guarantees … 
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/16998.xml
+++ b/HGV_trans_EpiDoc/16998.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">16998</idno>
                 <idno type="TM">16998</idno>
                 <idno type="HGV">16998</idno>
-                <idno type="dclp-hybrid">pylon;1;11_2</idno>
+                <idno type="ddb-hybrid">pylon;1;11_2</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/19979.xml
+++ b/HGV_trans_EpiDoc/19979.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Copia di estratti da registri di censimento</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">19979</idno>
+                <idno type="TM">19979</idno>
+                <idno type="HGV">19979</idno>
+                <idno type="ddb-hybrid">pylon;1;9</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:id="trans1" xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    <milestone unit="line" n="1"/> Dal registro di censimento con descrizioni personali del 9° anno di Domiziano, Bithynon Isionos, volume 1, fogli da 30 a 39. <milestone unit="line" n="2"/> Casa privata di Apollonios alias Isidoros, situata nello stesso quartiere. <milestone unit="line" n="3" rend="break"/> Omissis. Ha dichiarato in aggiunta come inquilini: Diogenes, figlio di Kastor il figlio di Dios e di Apia la figlia di Heron, cateco dei 6475, sottoposto a epikrisis nell’8° anno di Nerone, di anni 45, nessun segno particolare; <milestone unit="line" n="5"/> Heron, il fratello, figlio della stessa madre, cateco, sottoposto a epikrisis nel 9° anno di Nerone, di anni 41, cicatrice sulla fronte a destra. Omissis. Donne: <milestone unit="line" n="7" rend="break"/> Tamaron, figlia di Protarchos il figlio di Protarchos, figlia di cateco, moglie di Heron, di anni 45; Herois, figlia di entrambi, di anni 15; Eudaimonis, altra (figlia), di anni 11; Sambous, altra (figlia), di anni 3. Antonius, segretario dei bibliophylakes, ho vistato. <milestone unit="line" n="10" rend="break"/> Dal registro di censimento con descrizioni personali dell’8° anno del Divo Vespasiano, Bithynon Isionos. <milestone unit="line" n="11"/> Casa privata di Apollonios alias Isidoros, nello stesso quartiere. Omissis. Inquilini: […]
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/27638.xml
+++ b/HGV_trans_EpiDoc/27638.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">SPP 22 60 Revisited</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">27638</idno>
+                <idno type="TM">27638</idno>
+                <idno type="HGV">27638</idno>
+                <idno type="ddb-hybrid">pylon;1;1</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                <milestone n="1" unit="line"/> To Pammenes, strategos of the Athribite, from Hephaistarion daughter of Achilleus granddaughter of Leonides, citizen, with as her guardian her brother and husband NN son of Achilleus, of the Phylaxithalassian tribe and Althaian deme. <milestone n="7" rend="break" unit="line"/> Purchasing from Boubastarion whose mother is Dioskorous daughter of Dioskoros, granddaughter of Potammon, from Athribis, <milestone n="11" rend="break" unit="line"/> a slave named Crispinus nicknamed Herakleides, about 30 (?) years old, …, with a scar …
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/39584.xml
+++ b/HGV_trans_EpiDoc/39584.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Private Letter</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">39584</idno>
+                <idno type="TM">39584</idno>
+                <idno type="HGV">39584</idno>
+                <idno type="ddb-hybrid">pylon;1;5</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:id="trans1" xml:lang="en" type="translation" xml:space="preserve">
+                <div n="r" type="textpart">
+                    <p>
+                        <milestone unit="line" n="1"/> I have received the letter of my brother, and I have received the articles, the eight koriaxos-fish and four (fresh) catches (of fish?). Since you know the friendship between us, you did not (?) ...: write a letter, so that they may not be roused in vain (?), since you know that, as for you and me, regarding the headmen (meizones) from Migtolis—since I know that they are causing considerable bother. Since I heard that you (?) have gone back to your land again, my soul rejoiced greatly, and (so did those of) all from the house. I embrace Thalet. Embrace lady Maria and her little child. Lord Georgios, who has written this, gives you very many greetings in the Lord. Embrace warmly Apa Gerontios.
+                    </p>
+                </div>
+                <div n="v" type="textpart">
+                    <p>
+                        <milestone unit="line" n="15"/> To my brother, with God, ...
+                    </p>
+                </div>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/63992.xml
+++ b/HGV_trans_EpiDoc/63992.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Geometry</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">63992</idno>
+                <idno type="TM">63992</idno>
+                <idno type="HGV">63992</idno>
+                <idno type="ddb-hybrid">pylon;1;4</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    <milestone n="1" unit="line"/>(Problem 1) … The result is 1,800 “mixed” fingers. Divide it by 288, the remainder by 12 in order to convert to [cubits? 6] and fingers 6. (Problem 2) … tapering quadrilateral with the length of … triangle(s?) 36 fingers, height … triangle(s?) 36 fingers … result … 
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/63992.xml
+++ b/HGV_trans_EpiDoc/63992.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">63992</idno>
                 <idno type="TM">63992</idno>
                 <idno type="HGV">63992</idno>
-                <idno type="ddb-hybrid">pylon;1;4</idno>
+                <idno type="dclp-hybrid">pylon;1;4</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/64339.xml
+++ b/HGV_trans_EpiDoc/64339.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Metrological text</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="dclp">64339</idno>
+                <idno type="TM">64339</idno>
+                <idno type="filename">64339</idno>
+                <idno type="dclp-hybrid">p.oxy;49;3455</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                <milestone n="1" unit="line"/> The so-called Ptolemaic cubit has the length of one cubit, the width of 24 and the thickness of 24 (sic! understand 12) fingers, so that the dimensions multiplied result in a cubit measuring 288 “mixed” fingers, 6,912 “ordinary” ones. The Nicomedian cubit, in which … are purchased (?) has the length of one cubit, the width of [24] fingers, the thickness of 8 fingers, so that the Nicomedian cubit measures [1]92 “mixed” fingers, [4,608] “ordinary” ones. The solid cubit has the length of one cubit, the width of 24 fingers, and the thickness of 24 fingers, so that the solid cubit measures 576 “mixed” fingers, 13,824 “ordinary” ones.
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971734.xml
+++ b/HGV_trans_EpiDoc/971734.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971734</idno>
                 <idno type="TM">971734</idno>
                 <idno type="HGV">971734</idno>
-                <idno type="dclp-hybrid">o.berenike;4;512</idno>
+                <idno type="ddb-hybrid">o.berenike;4;512</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971734.xml
+++ b/HGV_trans_EpiDoc/971734.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Request to buy bdellium</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971734</idno>
+                <idno type="TM">971734</idno>
+                <idno type="HGV">971734</idno>
+                <idno type="dclp-hybrid">o.berenike;4;512</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    ... also buy two mnas of bdellium. Farewell.
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971735.xml
+++ b/HGV_trans_EpiDoc/971735.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Letter mentioning myrrh and pepper</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971735</idno>
+                <idno type="TM">971735</idno>
+                <idno type="HGV">971735</idno>
+                <idno type="dclp-hybrid">o.berenike;4;513</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    … myrrh and pepper … Greetings from … and Serapous and … . Greet Satorneilos … . … security … . Pauni 20-29 … .
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971735.xml
+++ b/HGV_trans_EpiDoc/971735.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971735</idno>
                 <idno type="TM">971735</idno>
                 <idno type="HGV">971735</idno>
-                <idno type="dclp-hybrid">o.berenike;4;513</idno>
+                <idno type="ddb-hybrid">o.berenike;4;513</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971736.xml
+++ b/HGV_trans_EpiDoc/971736.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">End of a letter</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971736</idno>
+                <idno type="TM">971736</idno>
+                <idno type="HGV">971736</idno>
+                <idno type="dclp-hybrid">o.berenike;4;514</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    … Send me the receipt … the 4th. Greetings. Petosiris … to take four keramia.
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971736.xml
+++ b/HGV_trans_EpiDoc/971736.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971736</idno>
                 <idno type="TM">971736</idno>
                 <idno type="HGV">971736</idno>
-                <idno type="dclp-hybrid">o.berenike;4;514</idno>
+                <idno type="ddb-hybrid">o.berenike;4;514</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971738.xml
+++ b/HGV_trans_EpiDoc/971738.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Letter of Sigillios</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971738</idno>
+                <idno type="TM">971738</idno>
+                <idno type="HGV">971738</idno>
+                <idno type="dclp-hybrid">o.berenike;4;516</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Sigillios to Firmus, many greetings. I want you to know ... of linen ... of wool ....
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971738.xml
+++ b/HGV_trans_EpiDoc/971738.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971738</idno>
                 <idno type="TM">971738</idno>
                 <idno type="HGV">971738</idno>
-                <idno type="dclp-hybrid">o.berenike;4;516</idno>
+                <idno type="ddb-hybrid">o.berenike;4;516</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971739.xml
+++ b/HGV_trans_EpiDoc/971739.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Sarapion to Andouros</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971739</idno>
+                <idno type="TM">971739</idno>
+                <idno type="HGV">971739</idno>
+                <idno type="dclp-hybrid">o.berenike;4;517</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Sarapion son of Kasios to Andouros, greetings. Dispatch for Kronios son of Harpochration 15 pol( ) jars of wine … in the month of … .
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971739.xml
+++ b/HGV_trans_EpiDoc/971739.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971739</idno>
                 <idno type="TM">971739</idno>
                 <idno type="HGV">971739</idno>
-                <idno type="dclp-hybrid">o.berenike;4;517</idno>
+                <idno type="ddb-hybrid">o.berenike;4;517</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971740.xml
+++ b/HGV_trans_EpiDoc/971740.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Sarapion to Andouros</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971740</idno>
+                <idno type="TM">971740</idno>
+                <idno type="HGV">971740</idno>
+                <idno type="dclp-hybrid">o.berenike;4;518</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Sarapion son of Kasios to Andouros, greetings. Dispatch for Amphiomis son of Harmiusis eleven pol( ) jars of wine, 11 jars. I have signed.
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971740.xml
+++ b/HGV_trans_EpiDoc/971740.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971740</idno>
                 <idno type="TM">971740</idno>
                 <idno type="HGV">971740</idno>
-                <idno type="dclp-hybrid">o.berenike;4;518</idno>
+                <idno type="ddb-hybrid">o.berenike;4;518</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971741.xml
+++ b/HGV_trans_EpiDoc/971741.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971741</idno>
                 <idno type="TM">971741</idno>
                 <idno type="HGV">971741</idno>
-                <idno type="dclp-hybrid">o.berenike;4;519</idno>
+                <idno type="ddb-hybrid">o.berenike;4;519</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971741.xml
+++ b/HGV_trans_EpiDoc/971741.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Sarapion to Andouros</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971741</idno>
+                <idno type="TM">971741</idno>
+                <idno type="HGV">971741</idno>
+                <idno type="dclp-hybrid">o.berenike;4;519</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Sarapion son of Kasios to Andouros, greetings. Dispatch for Psenosiris son of Paeris two jars of Italian wine and for Pakoibis … jars of Laodicean wine, totals … Laodicean wine.
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971742.xml
+++ b/HGV_trans_EpiDoc/971742.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971742</idno>
                 <idno type="TM">971742</idno>
                 <idno type="HGV">971742</idno>
-                <idno type="dclp-hybrid">o.berenike;4;520</idno>
+                <idno type="ddb-hybrid">o.berenike;4;520</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971742.xml
+++ b/HGV_trans_EpiDoc/971742.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Sarapion to Andouros</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971742</idno>
+                <idno type="TM">971742</idno>
+                <idno type="HGV">971742</idno>
+                <idno type="dclp-hybrid">o.berenike;4;520</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Sarapion son of Kasios to Andouros, greetings. Dispatch for Pet- son of Chambekis twenty-four pol( ) jars of wine, totals 24 jars. I have signed in the month of Sebastos, 23.
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971743.xml
+++ b/HGV_trans_EpiDoc/971743.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971743</idno>
                 <idno type="TM">971743</idno>
                 <idno type="HGV">971743</idno>
-                <idno type="dclp-hybrid">o.berenike;4;521</idno>
+                <idno type="ddb-hybrid">o.berenike;4;521</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971743.xml
+++ b/HGV_trans_EpiDoc/971743.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Sarapion to Pakoibis</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971743</idno>
+                <idno type="TM">971743</idno>
+                <idno type="HGV">971743</idno>
+                <idno type="dclp-hybrid">o.berenike;4;521</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Sarapion son of Kasios to Pakoibis, greetings. Dispatch for Kronios son of Pisais twenty-three marsippoi. I have signed.
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971744.xml
+++ b/HGV_trans_EpiDoc/971744.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Receipt mentioning the century of Bassus</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971744</idno>
+                <idno type="TM">971744</idno>
+                <idno type="HGV">971744</idno>
+                <idno type="dclp-hybrid">o.berenike;4;522</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Of the dekania of … Pisais son of Ps- … Nemoni- … in the century of Bassus … of the legion of … ptolemaica … .
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971744.xml
+++ b/HGV_trans_EpiDoc/971744.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971744</idno>
                 <idno type="TM">971744</idno>
                 <idno type="HGV">971744</idno>
-                <idno type="dclp-hybrid">o.berenike;4;522</idno>
+                <idno type="ddb-hybrid">o.berenike;4;522</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971746.xml
+++ b/HGV_trans_EpiDoc/971746.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971746</idno>
                 <idno type="TM">971746</idno>
                 <idno type="HGV">971746</idno>
-                <idno type="dclp-hybrid">o.berenike;4;524</idno>
+                <idno type="ddb-hybrid">o.berenike;4;524</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971746.xml
+++ b/HGV_trans_EpiDoc/971746.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Account</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971746</idno>
+                <idno type="TM">971746</idno>
+                <idno type="HGV">971746</idno>
+                <idno type="dclp-hybrid">o.berenike;4;524</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    From that of Ision for assistance, 384, and for the boat 116, totals 500. And from Kronios 100 and from Zethos 100, from Claudius 57 and through Ision 30 (totals) 87 … Ision … [57?] and … 17, totals 74 and similarly 27 and from … totals 114 and similarly 23 totals 137.
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971748.xml
+++ b/HGV_trans_EpiDoc/971748.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971748</idno>
                 <idno type="TM">971748</idno>
                 <idno type="HGV">971748</idno>
-                <idno type="dclp-hybrid">o.berenike;4;526</idno>
+                <idno type="ddb-hybrid">o.berenike;4;526</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971748.xml
+++ b/HGV_trans_EpiDoc/971748.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Writing exercise?</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971748</idno>
+                <idno type="TM">971748</idno>
+                <idno type="HGV">971748</idno>
+                <idno type="dclp-hybrid">o.berenike;4;526</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Year 3. Thoth /Phaophi\ 1. Give, deliver, bestow; and blows … .
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971750.xml
+++ b/HGV_trans_EpiDoc/971750.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971750</idno>
                 <idno type="TM">971750</idno>
                 <idno type="HGV">971750</idno>
-                <idno type="dclp-hybrid">o.berenike;4;528</idno>
+                <idno type="ddb-hybrid">o.berenike;4;528</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971750.xml
+++ b/HGV_trans_EpiDoc/971750.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Coptic ostrakon</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971750</idno>
+                <idno type="TM">971750</idno>
+                <idno type="HGV">971750</idno>
+                <idno type="dclp-hybrid">o.berenike;4;528</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    [… that I have established (?)] for you? … [Pe(?)]kosh represented by me … for me […] first? Tybi [of the x indiction (?)] [to x] Tybi [of the x indiction (?)] [… if] I am [asked… .
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971751.xml
+++ b/HGV_trans_EpiDoc/971751.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971751</idno>
                 <idno type="TM">971751</idno>
                 <idno type="HGV">971751</idno>
-                <idno type="dclp-hybrid">o.berenike;4;529</idno>
+                <idno type="ddb-hybrid">o.berenike;4;529</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971751.xml
+++ b/HGV_trans_EpiDoc/971751.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Jar inscription</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971751</idno>
+                <idno type="TM">971751</idno>
+                <idno type="HGV">971751</idno>
+                <idno type="dclp-hybrid">o.berenike;4;529</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Deliver to … .
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971752.xml
+++ b/HGV_trans_EpiDoc/971752.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971752</idno>
                 <idno type="TM">971752</idno>
                 <idno type="HGV">971752</idno>
-                <idno type="dclp-hybrid">o.berenike;4;530</idno>
+                <idno type="ddb-hybrid">o.berenike;4;530</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971752.xml
+++ b/HGV_trans_EpiDoc/971752.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Jar inscription</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971752</idno>
+                <idno type="TM">971752</idno>
+                <idno type="HGV">971752</idno>
+                <idno type="dclp-hybrid">o.berenike;4;530</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Harsonoeris … .
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971753.xml
+++ b/HGV_trans_EpiDoc/971753.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971753</idno>
                 <idno type="TM">971753</idno>
                 <idno type="HGV">971753</idno>
-                <idno type="dclp-hybrid">o.berenike;4;531</idno>
+                <idno type="ddb-hybrid">o.berenike;4;531</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971753.xml
+++ b/HGV_trans_EpiDoc/971753.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Receipt for delivery</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971753</idno>
+                <idno type="TM">971753</idno>
+                <idno type="HGV">971753</idno>
+                <idno type="dclp-hybrid">o.berenike;4;531</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    I, Gaius, checked … of Publius Aelius Nikaios … 7, loads 3 … freight … .
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971754.xml
+++ b/HGV_trans_EpiDoc/971754.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971754</idno>
                 <idno type="TM">971754</idno>
                 <idno type="HGV">971754</idno>
-                <idno type="dclp-hybrid">o.berenike;4;532</idno>
+                <idno type="ddb-hybrid">o.berenike;4;532</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971754.xml
+++ b/HGV_trans_EpiDoc/971754.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Label</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971754</idno>
+                <idno type="TM">971754</idno>
+                <idno type="HGV">971754</idno>
+                <idno type="dclp-hybrid">o.berenike;4;532</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    185 through (the gate?)
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971755.xml
+++ b/HGV_trans_EpiDoc/971755.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Dipinto</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971755</idno>
+                <idno type="TM">971755</idno>
+                <idno type="HGV">971755</idno>
+                <idno type="dclp-hybrid">o.berenike;4;533</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Of Kalliopios … .
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971755.xml
+++ b/HGV_trans_EpiDoc/971755.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971755</idno>
                 <idno type="TM">971755</idno>
                 <idno type="HGV">971755</idno>
-                <idno type="dclp-hybrid">o.berenike;4;533</idno>
+                <idno type="ddb-hybrid">o.berenike;4;533</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971756.xml
+++ b/HGV_trans_EpiDoc/971756.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Delivery order?</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971756</idno>
+                <idno type="TM">971756</idno>
+                <idno type="HGV">971756</idno>
+                <idno type="dclp-hybrid">o.berenike;4;534</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    To Egypt (...) of the archers.
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971756.xml
+++ b/HGV_trans_EpiDoc/971756.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971756</idno>
                 <idno type="TM">971756</idno>
                 <idno type="HGV">971756</idno>
-                <idno type="dclp-hybrid">o.berenike;4;534</idno>
+                <idno type="ddb-hybrid">o.berenike;4;534</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971757.xml
+++ b/HGV_trans_EpiDoc/971757.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Costrel with dipinto</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971757</idno>
+                <idno type="TM">971757</idno>
+                <idno type="HGV">971757</idno>
+                <idno type="dclp-hybrid">o.berenike;4;535</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Heron
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971757.xml
+++ b/HGV_trans_EpiDoc/971757.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971757</idno>
                 <idno type="TM">971757</idno>
                 <idno type="HGV">971757</idno>
-                <idno type="dclp-hybrid">o.berenike;4;535</idno>
+                <idno type="ddb-hybrid">o.berenike;4;535</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971759.xml
+++ b/HGV_trans_EpiDoc/971759.xml
@@ -11,7 +11,7 @@
                 <idno type="filename">971759</idno>
                 <idno type="TM">971759</idno>
                 <idno type="HGV">971759</idno>
-                <idno type="dclp-hybrid">o.berenike;4;537</idno>
+                <idno type="ddb-hybrid">o.berenike;4;537</idno>
                 <availability>
                     <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
                 </availability>

--- a/HGV_trans_EpiDoc/971759.xml
+++ b/HGV_trans_EpiDoc/971759.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Jar inscription with isopsephism</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971759</idno>
+                <idno type="TM">971759</idno>
+                <idno type="HGV">971759</idno>
+                <idno type="dclp-hybrid">o.berenike;4;537</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    484, chi mu gamma
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971879.xml
+++ b/HGV_trans_EpiDoc/971879.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">A Receipt for the Didrachmia of Souchos</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971879</idno>
+                <idno type="TM">971879</idno>
+                <idno type="HGV">971879</idno>
+                <idno type="ddb-hybrid">pylon;1;18</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    <milestone unit="line" n="1"/> Thrasymachos, son of Melas, of the Maronian deme, to Ptolemaios alias Petheus the elder, son of Petheus, greetings. You have paid the <emph rend="italics">didrachmia</emph> of Souchos, twice greatest god, for the vaulted room you purchased, which was previously an oil mill but has now collapsed, located in Karanis, from Gaius Longinus, son of Gaius, cavalryman of [the <emph rend="italics">ala</emph>] <emph rend="italics">Augusta</emph>, [<emph rend="italics">turma</emph> of … Year] 8, Germanikeios …
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_trans_EpiDoc/971907.xml
+++ b/HGV_trans_EpiDoc/971907.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+    <teiHeader type="text">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">A receipt for garden tax paid to Aurelius Melas</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+                <idno type="filename">971907</idno>
+                <idno type="TM">971907</idno>
+                <idno type="HGV">971907</idno>
+                <idno type="ddb-hybrid">pylon;1;17</idno>
+                <availability>
+                    <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>The contents of this document were Xwalked from Pylon.</p>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+                <language ident="ar">Arabisch</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-07-21" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon 1</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div xml:lang="en" type="translation" xml:space="preserve">
+                <p>
+                    Year 24 of Marcus Aurelius Severus Antoninus Parthicus Maximus Britannicus Maximus Germanicus Maximus Felix Pius Augustus, Epeiph 23. <milestone unit="line" n="5"/> Terentius, son of Iulia Longinia, has paid thirty-six drachmas (36 dr.) in garden tax for year 22 to Aurelius Melas, secretary of the praktores argyrikon of Karanis. 
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
Most of the translations published in Pylon 1 are included in this pull (the exceptions are Micucci, Nicolardi, and Vergara). I'm not sure whether it is preferable to wait for the upcoming re-index before merging: some files (e.g. Benaissa's) still have to have their DDB text updated (with dummy headers), while the translation idnos are already pointing to those yet-to-be-created files.