### PR TITLE
<note xml:lang="en">?</note> --> @cert="low"

### DIFF
--- a/DCLP/62/61366.xml
+++ b/DCLP/62/61366.xml
@@ -109,7 +109,7 @@
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <div n="1" subtype="column" type="textpart" corresp="#FR7858"><ab>
 <lb n="1"/><gap reason="lost" extent="unknown" unit="character"/><supplied reason="lost">τῶ</supplied>ν δ᾽ ἐν Πει
-<lb n="2" break="no"/><supplied reason="lost">ραιεῖ <note xml:lang="en">?</note> ταῖς ἀρ</supplied>χαῖς ὑμᾶς,
+<lb n="2" break="no"/><supplied reason="lost" cert="low">ραιεῖ</supplied> <supplied reason="lost">ταῖς ἀρ</supplied>χαῖς ὑμᾶς,
 <lb n="3"/><supplied reason="lost">οἳ τούτων ἁπάν</supplied>των κύ
 <lb n="4" break="no"/><supplied reason="lost">ριοι ἐστέ. διὸ καὶ</supplied> μᾶλλόν
 <lb n="5"/><supplied reason="lost">ἐστι τηρητέον</supplied> τοὺς ἐν

--- a/DCLP/63/62393.xml
+++ b/DCLP/63/62393.xml
@@ -902,7 +902,7 @@
 <lb n="13"/>ἐκείνη<supplied reason="lost">ν τῷ ὅ</supplied>λωι γένε<supplied reason="lost">ι</supplied>  
 <lb n="14"/>καὶ οὐχ<supplied reason="lost">ὶ τ</supplied><unclear>ὸ</unclear> Περιπα  
 <lb n="15" break="no"/>τητικὸ<supplied reason="lost">ν ἢ</supplied> Στωικὴν 
-<lb n="16"/><supplied reason="lost">μόνον αἵρεσι</supplied>ν<note xml:lang="en">?</note> οὐδ' ο <gap reason="illegible" quantity="2" unit="character"/>  
+<lb n="16"/><supplied reason="lost" cert="low">μόνον αἵρεσι</supplied>ν οὐδ' ο <gap reason="illegible" quantity="2" unit="character"/>  
 </ab></div>
 
 <div n="3" subtype="column" type="textpart" corresp="#FR688"><ab>   
@@ -924,7 +924,7 @@
 <lb n="15" break="no"/>ριττοῦ <supplied reason="lost">δ' ἐστὶ</supplied> μάται  
 <lb n="16" break="no"/>ον πρὸς α<supplied reason="lost">ὐτὸν</supplied> τὸν ὄ 
 <lb n="17" break="no"/>χλον ἀν<supplied reason="lost">αφέρειν τοῦτο</supplied> 
-<lb n="18"/><supplied reason="lost">κ</supplied>αὶ ταλα<supplied reason="lost">ιπωρότατον<note xml:lang="en">?</note></supplied> 
+<lb n="18"/><supplied reason="lost">κ</supplied>αὶ ταλα<supplied reason="lost" cert="low">ιπωρότατον</supplied> 
 <lb n="19"/><supplied reason="lost">οὕ</supplied>τως τ <gap reason="illegible" extent="unknown" unit="character"/> <g type="dagger"/>3<g type="dagger"/>3 <gap reason="illegible" quantity="5" unit="character"/> ην <note xml:lang="en">G: ημ</note>   
 </ab></div>
 
@@ -942,7 +942,7 @@
 <lb n="11" break="no"/><supplied reason="lost">σ</supplied>ῃ καλή<supplied reason="omitted">ν</supplied> τις ἡγῆται,  
 <lb n="12"/>τὴν τοῦ σοφοῦ καὶ  
 <lb n="13"/><supplied reason="lost">φ</supplied>ιλοσόφο<supplied reason="lost">υ οὐ τ</supplied>άξει 
-<lb n="14"/>δευτέραν <supplied reason="lost">ὥσ</supplied>περ<note xml:lang="en">?</note>  
+<lb n="14"/>δευτέραν <supplied reason="lost" cert="low">ὥσ</supplied>περ  
 <lb n="15"/>ητ <gap reason="illegible" quantity="10" unit="character"/> ου 
 </ab></div>
 
@@ -1155,8 +1155,8 @@
 <lb n="22" break="no"/><supplied reason="lost">μέν</supplied>ων, εἰ <unclear>μ</unclear>ὴ νὴ Δία  
 <lb n="23"/><supplied reason="lost">κ</supplied>αὶ τῶν ἄ<supplied reason="lost">λ</supplied>λων <supplied reason="lost">ἁπάν</supplied>  
 <lb n="24" break="no"/>των, οὐχ <supplied reason="lost">ὅ</supplied>τι μ<supplied reason="lost">όν</supplied>ους 
-<lb n="25"/>τοὺς <supplied reason="lost">ῥήτ</supplied>ορας <supplied reason="lost">εἶν</supplied>αι τε  
-<lb n="26" break="no"/><supplied reason="lost">χνικοὺς <note xml:lang="en">vel τελείους</note></supplied><gap reason="lost" quantity="4" unit="character"/> 
+<lb n="25"/>τοὺς <supplied reason="lost">ῥήτ</supplied>ορας <supplied reason="lost">εἶν</supplied>αι <app type="alternative"><lem>τε  
+<lb n="26" break="no"/><supplied reason="lost"><certainty match=".." locus="value"/>χνικοὺς</supplied></lem><rdg>τε<lb n="26" break="no"/><supplied reason="lost"><certainty match=".." locus="value"/>λείους</supplied></rdg></app><gap reason="lost" quantity="4" unit="character"/> 
 </ab></div>
 
 <div n="13" subtype="column" type="textpart" corresp="#FR680"><ab>  
@@ -1206,7 +1206,7 @@
 <lb n="18"/>ἀπὸ τούτ<supplied reason="lost">ων</supplied> χρ<supplied reason="lost">ώμ</supplied>ε 
 <lb n="19" break="no"/><supplied reason="lost">ν</supplied>ος καὶ δ<supplied reason="lost">ι' ἐπ</supplied>ιθ<supplied reason="lost">υμία</supplied>ν 
 <lb n="20"/><supplied reason="lost">το</supplied>ῦ δοκε<supplied reason="lost">ῖν</supplied> ἀ<supplied reason="lost">κριβολ</supplied>ό 
-<lb n="21" break="no"/><supplied reason="lost">γος<note xml:lang="en">?</note></supplied> εἶν<supplied reason="lost">αι</supplied><gap reason="lost" quantity="4" unit="character"/> λ <gap reason="illegible" quantity="4" unit="character"/> ν 
+<lb n="21" break="no"/><supplied reason="lost" cert="low">γος</supplied> εἶν<supplied reason="lost">αι</supplied><gap reason="lost" quantity="4" unit="character"/> λ <gap reason="illegible" quantity="4" unit="character"/> ν 
 </ab></div>
 
 <div n="15" subtype="column" type="textpart" corresp="#FR682"><ab>  

--- a/DCLP/63/62448.xml
+++ b/DCLP/63/62448.xml
@@ -1500,7 +1500,7 @@
 <lb n="14" break="no"/>τό<unclear>ρ</unclear>ω<unclear>ν</unclear> <supplied reason="lost">ὅ</supplied>λον τὸν βίον
 <lb n="15"/>θω<supplied reason="lost"><unclear>πε</unclear>ύ</supplied>ειν ὑπομενόν
 <lb n="16" break="no"/>των. <supplied reason="lost">Ἀλ</supplied>λὰ μ<supplied reason="lost">ὴν</supplied> κα<supplied reason="lost">ὶ</supplied> <supplied reason="lost"><unclear>τ</unclear></supplied>ὸ
-<lb n="17"/>φάσ<supplied reason="lost">κειν</supplied> τοῖς εὐ<supplied reason="lost">νομοῦσι</supplied>ν<note xml:lang="en">?</note>
+<lb n="17"/>φάσ<supplied reason="lost">κειν</supplied> τοῖς εὐ<supplied reason="lost" cert="low">νομοῦσι</supplied>ν
 <lb n="18"/>ἀναγκ<supplied reason="lost">αί</supplied>αν <supplied reason="lost">εἶναι</supplied> <supplied reason="lost">τὴν</supplied> <supplied reason="lost">ῥη</supplied>
 <lb n="19" break="no"/>τορικὴ<supplied reason="lost">ν</supplied><gap reason="illegible" quantity="12" unit="character"/><supplied reason="lost"/>
 <lb n="20"/>προ-
@@ -1530,7 +1530,7 @@
 <lb n="8"/><gap reason="illegible" quantity="3" unit="character"/> μ<unclear>ο</unclear>ν καταγενόμ<supplied reason="lost">ε</supplied>
 <lb n="9" break="no"/><supplied reason="lost">νοι</supplied>, κατα<supplied reason="lost">γ</supplied>ελασό<supplied reason="lost">μ</supplied>εθα
 <lb n="10"/><supplied reason="lost">τ</supplied>ῶν κατα<supplied reason="lost"><unclear>γ</unclear></supplied>ελώντ<supplied reason="lost">ων</supplied> τ<supplied reason="lost"><unclear>ε</unclear></supplied>
-<lb n="11"/>καὶ τῶν ὅτι κ<supplied reason="lost">αὶ</supplied><note xml:lang="en">?</note> δι' ἄλλου τὰ
+<lb n="11"/>καὶ τῶν ὅτι κ<supplied reason="lost" cert="low">αὶ</supplied> δι' ἄλλου τὰ
 <lb n="12"/>τεκτονικὰ διοικούμεθα·
 <lb n="13"/><supplied reason="lost"><unclear>π</unclear></supplied>ερὶ ὧν δ' ἂν ἄρχεσθα<supplied reason="lost">ι</supplied>
 <lb n="14"/>δοκιμάσωμεν, οὐδὲ
@@ -1545,7 +1545,7 @@
 <div n="5" corresp="#FR5775" subtype="fragment" type="textpart"><ab>
 <lb n="10"/><gap reason="illegible" quantity="3" unit="character"/> των <gap reason="illegible" quantity="12" unit="character"/>
 <lb n="11"/><supplied reason="lost">ἐρ</supplied>ρωμένως προ<supplied reason="lost">κρινέ</supplied>
-<lb n="12" break="no"/><supplied reason="lost">σ</supplied>θω<note xml:lang="en">?</note> τὸ ῥητορεύ<supplied reason="lost"><unclear>ε</unclear>ιν</supplied> <supplied reason="lost">τοῦ</supplied>
+<lb n="12" break="no"/><supplied reason="lost" cert="low">σ</supplied>θω τὸ ῥητορεύ<supplied reason="lost"><unclear>ε</unclear>ιν</supplied> <supplied reason="lost">τοῦ</supplied>
 <lb n="13"/><supplied reason="lost">φι</supplied>λοσοφεῖν, καὶ ταῦτα
 <lb n="14"/><supplied reason="lost">το</supplied>ῦ μὲν οὕτως σ<unclear>π</unclear>ανί<supplied reason="lost"><unclear>ω</unclear>ς</supplied>
 <lb n="15"/><supplied reason="lost">τοῦ</supplied> δὲ παρ' ὅλην τὴν ζ<supplied reason="lost"><unclear>ω</unclear></supplied>ι
@@ -1653,7 +1653,7 @@
 <lb n="19"/><gap reason="illegible" quantity="1" unit="character"/> ουσιν ο <gap reason="illegible" quantity="3" unit="character"/> ρλμα <gap reason="illegible" quantity="4" unit="character"/>
 <lb n="20"/>τοδασαλλ <gap reason="illegible" quantity="2" unit="character"/> ιτιγα <gap reason="illegible" quantity="3" unit="character"/>
 <lb n="21"/><gap reason="illegible" quantity="2" unit="character"/>ειν <gap reason="illegible" quantity="7" unit="character"/> τῶν <supplied reason="lost">πο</supplied>
-<lb n="22" break="no"/><supplied reason="lost">λι</supplied>τικῶν<note xml:lang="en">?</note><gap reason="illegible" quantity="2" unit="character"/> διαλ <gap reason="illegible" quantity="4" unit="character"/>
+<lb n="22" break="no"/><supplied reason="lost" cert="low">λι</supplied>τικῶν<gap reason="illegible" quantity="2" unit="character"/> διαλ <gap reason="illegible" quantity="4" unit="character"/>
 <lb n="23"/>με<unclear>ο</unclear>ν ετ <gap reason="illegible" quantity="6" unit="character"/> α <gap reason="illegible" quantity="5" unit="character"/>
 <lb n="24"/>α <gap reason="illegible" quantity="2" unit="character"/> ρων <gap reason="illegible" extent="unknown" unit="character"/>
 <lb n="25"/>σοφων τι <gap reason="illegible" extent="unknown" unit="character"/> ρεσ <gap reason="illegible" quantity="3" unit="character"/> η <gap reason="illegible" quantity="1" unit="character"/> ων
@@ -1801,8 +1801,8 @@
 <lb n="25"/>τοισ <gap reason="illegible" quantity="6" unit="character"/>
 <lb n="26"/>μεν <gap reason="illegible" quantity="6" unit="character"/> αρ <gap reason="illegible" extent="unknown" unit="character"/>
 <lb n="27"/>τω <gap reason="illegible" quantity="1" unit="character"/> εν ποιησ <gap reason="illegible" extent="unknown" unit="character"/>
-<lb n="28"/><gap reason="illegible" quantity="2" unit="character"/> ταῦτα τ' ἀντακ<supplied reason="lost">όλου</supplied>
-<lb n="29" break="no"/><supplied reason="lost">θ</supplied>α<note xml:lang="en">?</note> <supplied reason="lost">γέγ</supplied>ονεν ζωιζ <expan><ex cert="low">τ</ex><choice><reg><ex cert="low">ῶι</ex></reg><orig><ex cert="low">ῶ</ex></orig></choice></expan> <gap reason="illegible" extent="unknown" unit="character"/>
+<lb n="28"/><gap reason="illegible" quantity="2" unit="character"/> ταῦτα τ' ἀντακ<supplied reason="lost" cert="low">όλου</supplied>
+<lb n="29" break="no"/><supplied reason="lost" cert="low">θ</supplied>α <supplied reason="lost">γέγ</supplied>ονεν ζωιζ <expan><ex cert="low">τ</ex><choice><reg><ex cert="low">ῶι</ex></reg><orig><ex cert="low">ῶ</ex></orig></choice></expan> <gap reason="illegible" extent="unknown" unit="character"/>
 <lb n="30"/><gap reason="illegible" quantity="8" unit="character"/> εμ<unclear>φ</unclear> <gap reason="illegible" extent="unknown" unit="character"/>
 <lb n="31"/><gap reason="illegible" quantity="6" unit="character"/> ευμεν <gap reason="illegible" extent="unknown" unit="character"/>
 <lb n="32"/><gap reason="lost" quantity="4" unit="character"/> <supplied reason="lost">γ</supplied>ὰρ ε<unclear>ὖ</unclear> καὶ φ <gap reason="illegible" extent="unknown" unit="character"/>
@@ -1903,7 +1903,7 @@
 <lb n="16"/>οὕ<supplied reason="lost">τ</supplied><unclear>ω</unclear>ς ἵστασθαι, μανικόν
 <lb n="17"/>τί <supplied reason="lost">φ</supplied>ασιν ἐπιτηδεύειν
 <lb n="18"/>τὴ<supplied reason="lost">ν</supplied> <supplied reason="lost">ῥη</supplied>τορικήν, εἰ μὴ
-<lb n="19"/>κα<supplied reason="lost">ὶ</supplied> <supplied reason="lost">χ<unclear>ε</unclear></supplied>ῖ<supplied reason="lost">ρον</supplied><note xml:lang="en">?</note> τῶν διὰ τὸ
+<lb n="19"/>κα<supplied reason="lost">ὶ</supplied> <supplied reason="lost">χ<unclear>ε</unclear></supplied>ῖ<supplied reason="lost" cert="low">ρον</supplied> τῶν διὰ τὸ
 <lb n="20"/>π <gap reason="illegible" quantity="3" unit="character"/> α <gap reason="illegible" quantity="5" unit="character"/> α <gap reason="illegible" quantity="3" unit="character"/> τος <g type="dagger"/>3<g type="dagger"/>3 τ<unclear>ο</unclear> <gap reason="lost" quantity="3" unit="line"/>
 <lb n="24"/><gap reason="lost" quantity="8" unit="character"/> <supplied reason="lost">πελαγίζ</supplied>ειν
 <lb n="25"/><supplied reason="lost">καλοῦντες</supplied> <supplied reason="lost">αὑ</supplied>τοῖς μό
@@ -2016,7 +2016,7 @@
 <lb n="20" break="no"/><supplied reason="lost">τω</supplied><unclear>ς</unclear> ὥσπερ ο<supplied reason="lost">ἱ</supplied> φιλ<supplied reason="lost">όσο</supplied>
 <lb n="21" break="no"/><supplied reason="lost">φοι</supplied>. <supplied reason="lost"><unclear>Τ</unclear></supplied>ὰ πολ<supplied reason="lost">λ</supplied>ὰ δὲ κ<supplied reason="lost">αὶ</supplied> <supplied reason="lost">οἱ</supplied>
 <lb n="22"/><supplied reason="lost">διαφέρ</supplied>οντε<supplied reason="lost">ς</supplied> <supplied reason="lost">π</supplied>αιδεί<supplied reason="lost">αι</supplied> δ<supplied reason="lost">ι</supplied>
-<lb n="23" break="no"/><supplied reason="lost">αλεγ</supplied>όμεν<supplied reason="lost">ο</supplied>ι φα<supplied reason="lost">ίνονται<note xml:lang="en">?</note></supplied>
+<lb n="23" break="no"/><supplied reason="lost">αλεγ</supplied>όμεν<supplied reason="lost">ο</supplied>ι φα<supplied reason="lost" cert="low">ίνονται</supplied>
 <lb n="24"/><gap reason="lost" quantity="4" unit="character"/> <supplied reason="lost">τῆ</supplied>ι τοι<unclear>α</unclear>ύτ<choice><reg>ηι</reg><orig>η</orig></choice> <gap reason="illegible" quantity="5" unit="character"/>
 <lb n="25"/><unclear>λσιι</unclear>α <gap reason="illegible" quantity="1" unit="character"/> ατε καὶ τ<supplied reason="lost">ῆς</supplied> <supplied reason="lost">φιλοσ</supplied>
 <lb n="26" break="no"/>οφίας αὐτῶ<supplied reason="lost"><unclear>ν</unclear></supplied>, ἣν <gap reason="illegible" quantity="6" unit="character"/>
@@ -2135,7 +2135,7 @@
 <lb n="23"/>καὶ <gap reason="illegible" quantity="3" unit="character"/> ἐπι<supplied reason="lost">σ</supplied>τη<unclear>μ</unclear> <gap reason="illegible" quantity="4" unit="character"/>
 <lb n="24"/><gap reason="illegible" quantity="8" unit="character"/> <unclear>οὔ</unclear>τε π <gap reason="illegible" quantity="5" unit="character"/>
 <lb n="25"/>σ <gap reason="illegible" quantity="7" unit="character"/> μαθεῖν <gap reason="illegible" quantity="3" unit="character"/>
-<lb n="26"/>λε <gap reason="illegible" quantity="2" unit="character"/> η<unclear>ο</unclear> <gap reason="illegible" quantity="2" unit="character"/> ν. Καὶ κα<supplied reason="lost">τὰ<note xml:lang="en">?</note></supplied>
+<lb n="26"/>λε <gap reason="illegible" quantity="2" unit="character"/> η<unclear>ο</unclear> <gap reason="illegible" quantity="2" unit="character"/> ν. Καὶ κα<supplied reason="lost" cert="low">τὰ</supplied>
 <milestone rend="paragraphos" unit="undefined"/>
 <lb n="27"/>λόγον γ' ὅτι παρὰ τ<supplied reason="lost">ὴ</supplied>ν αἰ
 <lb n="28" break="no"/>τίαν <supplied reason="lost"><unclear>τ</unclear></supplied>αύτην <unclear>ὑ</unclear>πέ<supplied reason="lost">λαβον</supplied>
@@ -2146,7 +2146,7 @@
 <lb n="33" break="no"/>είρουσιν, ὥστε καὶ βου
 <lb n="34" break="no"/>λεύ<supplied reason="lost"><unclear>ον</unclear></supplied>τα<supplied reason="lost">ι</supplied> <supplied reason="lost">κ</supplied>αὶ κρίνουσιν
 <lb n="35"/>οὐκ <unclear>ὀ</unclear><supplied reason="lost">ρθῶς</supplied> <supplied reason="lost">ὑ<unclear>π</unclear></supplied>ὲρ τῶν συμ
-<lb n="36" break="no"/>φερ<supplied reason="lost"><unclear>ό</unclear>ντων</supplied> <supplied reason="lost">καὶ</supplied> πρὸς τού <g type="dagger"/>3<g type="dagger"/>3 <supplied reason="lost">τοις<note xml:lang="en">?</note></supplied>
+<lb n="36" break="no"/>φερ<supplied reason="lost"><unclear>ό</unclear>ντων</supplied> <supplied reason="lost">καὶ</supplied> πρὸς τού <g type="dagger"/>3<g type="dagger"/>3 <supplied reason="lost" cert="low">τοις</supplied>
 </ab></div>
 <div n="16" corresp="#FR5793" subtype="column" type="textpart"><ab>
 <lb n="1"/><supplied reason="lost">τοῖς</supplied> <supplied reason="lost">εἰκόσι</supplied> <g type="dagger"/>3<g type="dagger"/>3 <supplied reason="lost">κα<unclear>τ</unclear></supplied>ὰ λό<supplied reason="lost"><unclear>γ</unclear></supplied>ον <supplied reason="lost">καὶ</supplied> <supplied reason="lost">το</supplied>ῖς εὐ
@@ -2180,7 +2180,7 @@
 <lb n="30"/>γο <gap reason="illegible" quantity="3" unit="character"/> αλλων<unclear>α</unclear><gap reason="illegible" quantity="1" unit="character"/> <supplied reason="lost">ἀν</supplied>α<supplied reason="lost"><unclear>γ</unclear></supplied>κασ
 <lb n="31" break="no"/><supplied reason="lost"><unclear>τ</unclear></supplied>ι<supplied reason="lost"><unclear>κ</unclear>οῖς</supplied> <supplied reason="lost">θ</supplied>εωρο<supplied reason="lost">ῦμεν</supplied> <supplied reason="lost">λόγοις</supplied>,
 <lb n="32"/>ὥσ<supplied reason="lost">περ</supplied> εὐθέως αὐτοῦ
-<lb n="33"/><supplied reason="lost">τ</supplied>οῦ δ<supplied reason="lost">ιοικ</supplied>εῖν<note xml:lang="en">?</note> πόλι<supplied reason="lost">ν</supplied> <gap reason="lost" quantity="2" unit="character"/>ι
+<lb n="33"/><supplied reason="lost">τ</supplied>οῦ δ<supplied reason="lost" cert="low">ιοικ</supplied>εῖν πόλι<supplied reason="lost">ν</supplied> <gap reason="lost" quantity="2" unit="character"/>ι
 <lb n="34"/><gap reason="illegible" quantity="2" unit="character"/> ν<unclear>ι</unclear> <gap reason="illegible" quantity="1" unit="character"/> ιρι <gap reason="illegible" quantity="8" unit="character"/> νον
 <lb n="35"/><gap reason="illegible" quantity="2" unit="character"/> τα <gap reason="illegible" quantity="10" unit="character"/> ου
 </ab></div>
@@ -2218,7 +2218,7 @@
 <lb n="31"/>ἐπιδείκνθται <supplied reason="lost"><unclear>τ</unclear>ῶ</supplied>ν ε<unclear>ἰς</unclear>
 <lb n="32"/>μακάριον βίον ἀνη
 <lb n="33" break="no"/>κόντων χρησιμεύου
-<lb n="34" break="no"/>σ<unclear>α</unclear>. Διόπερ ο<supplied reason="lost"><unclear>ὐ</unclear>δὲ</supplied> το<supplied reason="lost">ύ</supplied>των<note xml:lang="en">?</note>
+<lb n="34" break="no"/>σ<unclear>α</unclear>. Διόπερ ο<supplied reason="lost"><unclear>ὐ</unclear>δὲ</supplied> το<supplied reason="lost" cert="low">ύ</supplied>των
 <lb n="35"/>ζεκτονω<gap reason="illegible" quantity="7" unit="character"/> ισι
 </ab></div>
 <div n="18" corresp="#FR5795" subtype="column" type="textpart"><ab>
@@ -2254,12 +2254,12 @@
 <lb n="28" break="no"/><supplied reason="lost">βού</supplied>λευεν ὡς οὐχὶ <unclear>τ</unclear> <gap reason="illegible" quantity="1" unit="character"/>
 <lb n="29"/><gap reason="illegible" quantity="3" unit="character"/> τατην εξα <gap reason="illegible" quantity="1" unit="character"/> νασ <gap reason="illegible" quantity="2" unit="character"/>
 <lb n="30"/><gap reason="lost" quantity="4" unit="character"/> <supplied reason="lost">ε</supplied>ὐθὺς εισο <gap reason="illegible" quantity="2" unit="character"/> τα <gap reason="illegible" quantity="1" unit="character"/>
-<lb n="31"/><gap reason="illegible" quantity="4" unit="character"/> νος ἐπαιδε<supplied reason="lost">ύο</supplied>μεν<note xml:lang="en">?</note>
+<lb n="31"/><gap reason="illegible" quantity="4" unit="character"/> νος ἐπαιδε<supplied reason="lost" cert="low">ύο</supplied>μεν
 <lb n="32"/><gap reason="illegible" quantity="3" unit="character"/> καθάπερ οὔτε τα
 <lb n="33"/><gap reason="illegible" quantity="3" unit="character"/>εραις ἔστ<supplied reason="lost">ι</supplied> θηρεύ
 <lb n="34" break="no"/><supplied reason="lost">ειν</supplied> <supplied reason="lost"><unclear>θ</unclear></supplied>ύννον οὔ<supplied reason="lost">τε</supplied> <supplied reason="lost">τ</supplied>οῖς τού
 <lb n="35" break="no"/><supplied reason="lost">του</supplied> δικτύοις ἀ<supplied reason="lost">φύ</supplied>ας, οὕ
-<lb n="36" break="no"/><supplied reason="lost">τως</supplied> οὐδὲ τὰς τ<supplied reason="lost">ῶν</supplied> <supplied reason="lost">ῥη<unclear>τ</unclear></supplied>ό<supplied reason="lost">ρων<note xml:lang="en">?</note></supplied>
+<lb n="36" break="no"/><supplied reason="lost">τως</supplied> οὐδὲ τὰς τ<supplied reason="lost">ῶν</supplied> <supplied reason="lost">ῥη<unclear>τ</unclear></supplied>ό<supplied reason="lost" cert="low">ρων</supplied>
 </ab></div>
 <div n="19" corresp="#FR5796" subtype="column" type="textpart"><ab>
 <lb n="1"/><unclear>π</unclear>ερ<unclear>α</unclear> <gap reason="illegible" quantity="5" unit="character"/>
@@ -2533,7 +2533,7 @@
 <lb n="26"/>ὠφελ <gap reason="illegible" quantity="1" unit="character"/>
 <lb n="27"/><gap reason="illegible" quantity="2" unit="character"/> ετη<unclear>ν</unclear> μεαι <gap reason="illegible" quantity="2" unit="character"/> ιδετι <gap reason="illegible" quantity="1" unit="character"/>
 <lb n="28"/><gap reason="illegible" quantity="1" unit="character"/> μ <gap reason="illegible" quantity="1" unit="character"/> ευλος ἐστ<supplied reason="lost">ι</supplied>ν ἐπιχει
-<lb n="29" break="no"/><supplied reason="lost">ρ</supplied>εῖν<note xml:lang="en">?</note> αιαρδα <gap reason="illegible" quantity="3" unit="character"/> ν καλὰ
+<lb n="29" break="no"/><supplied reason="lost" cert="low">ρ</supplied>εῖν αιαρδα <gap reason="illegible" quantity="3" unit="character"/> ν καλὰ
 <lb n="30"/>παραδοθ<unclear>ῆ</unclear><supplied reason="lost">ναι</supplied>, <supplied reason="lost">ο</supplied>ὐ μᾶλλον
 <lb n="31"/>ὠφελεῖσθαι δ<supplied reason="lost">ι<unclear>ὰ</unclear></supplied> τὴν ῥητο
 <lb n="32" break="no"/>ρικήν. Ὁ γὰρ πείθων τοὺς
@@ -2653,7 +2653,7 @@
 <lb n="21"/>πρὸ<supplied reason="lost">ς</supplied> <supplied reason="lost">βῆ</supplied>μα κεκ<supplied reason="lost">ο</supplied>μισμέ
 <lb n="22" break="no"/>νων, οὓς μόνους φασὶ π <gap reason="illegible" quantity="1" unit="character"/>
 <lb n="23"/><gap reason="illegible" quantity="5" unit="character"/>εισι πᾶ<supplied reason="lost">ς</supplied> ἀρ<supplied reason="lost"><unclear>ε</unclear>τ</supplied> <gap reason="lost" quantity="5" unit="character"/>
-<lb n="24"/><gap reason="lost" quantity="4" unit="character"/> <supplied reason="lost">μέ</supplied>ντοι<note xml:lang="en">?</note> κ <gap reason="illegible" quantity="8" unit="character"/> <gap reason="lost" quantity="3" unit="line"/>
+<lb n="24"/><gap reason="lost" quantity="4" unit="character"/> <supplied reason="lost" cert="low">μέ</supplied>ντοι κ <gap reason="illegible" quantity="8" unit="character"/> <gap reason="lost" quantity="3" unit="line"/>
 <lb n="28"/><gap reason="illegible" quantity="7" unit="character"/> ι δοκοῦσ<supplied reason="lost">ι</supplied> <supplied reason="lost">δ</supplied>ὲ μεί
 <lb n="29" break="no"/><supplied reason="lost">ζον</supplied>ας τῶν νοσ<supplied reason="lost">ού</supplied>ντων <supplied reason="lost">ὑ</supplied>
 <lb n="30" break="no"/><supplied reason="lost">πο</supplied>μένειν θεραπείας <supplied reason="lost">μή</supplied>
@@ -2668,7 +2668,7 @@
 <lb n="38"/>ταῦτα προσφερ<unclear>ό</unclear>ντων <supplied reason="lost">ἀλ</supplied>
 <lb n="39" break="no"/>λ' οὐχ ἅπαξ. Ὥσθ' ἕνεκα τοῦ
 <milestone rend="paragraphos" unit="undefined"/>
-<lb n="40"/>π<supplied reason="lost">λεί</supplied>στου<note xml:lang="en">?</note> λυσιτ<supplied reason="lost">ε<unclear>λ</unclear></supplied>ε<supplied reason="lost">ῖ</supplied>ς εἶνα<supplied reason="lost">ι</supplied>
+<lb n="40"/>π<supplied reason="lost" cert="low">λεί</supplied>στου λυσιτ<supplied reason="lost">ε<unclear>λ</unclear></supplied>ε<supplied reason="lost">ῖ</supplied>ς εἶνα<supplied reason="lost">ι</supplied>
 </ab></div>
 <div n="29" corresp="#FR6406" subtype="column" type="textpart"><ab>
 <lb n="1"/><gap reason="lost" quantity="11" unit="character"/> <supplied reason="lost">παυο</supplied>μ<supplied reason="lost"><unclear>έ</unclear></supplied>νω<supplied reason="lost"><unclear>ν</unclear></supplied>
@@ -2697,7 +2697,7 @@
 <lb n="21"/>προ<supplied reason="lost">β</supplied>άλλ<supplied reason="lost">εσθαι</supplied> τὸ τὴν ἡσυ
 <lb n="22" break="no"/>χίαν <supplied reason="lost"><unclear>ὑ</unclear>πάρχειν</supplied> <supplied reason="lost">κ</supplied>αὶ δικα<supplied reason="lost">ιο</supplied>
 <lb n="23" break="no"/>πρα<supplied reason="lost">γίαν</supplied> <supplied reason="lost">κ<unclear>αὶ</unclear></supplied> ἀσφά<supplied reason="lost">λειαν</supplied>
-<lb n="24"/><supplied reason="lost">ἐκ</supplied>εί<supplied reason="lost">νοις</supplied> <supplied reason="lost">ὥσπ</supplied>ερ εὐο<supplied reason="lost">δίαν<note xml:lang="en">?</note></supplied>
+<lb n="24"/><supplied reason="lost">ἐκ</supplied>εί<supplied reason="lost">νοις</supplied> <supplied reason="lost">ὥσπ</supplied>ερ εὐο<supplied reason="lost" cert="low">δίαν</supplied>
 <lb n="25"/><gap reason="illegible" quantity="10" unit="character"/> δικ<supplied reason="lost">αι</supplied>οσύν<supplied reason="lost"><unclear>η</unclear></supplied> <gap reason="lost" quantity="1" unit="character"/>
 <lb n="26"/><gap reason="illegible" quantity="11" unit="character"/> ς ει<unclear>π</unclear>ε <gap reason="illegible" quantity="2" unit="character"/> μα <gap reason="illegible" quantity="1" unit="character"/>
 <lb n="27"/><gap reason="illegible" quantity="11" unit="character"/> ιδιασ <gap reason="illegible" quantity="2" unit="character"/> ντα <gap reason="illegible" quantity="1" unit="character"/>
@@ -2711,7 +2711,7 @@
 <lb n="34"/>ὥστ <gap reason="illegible" quantity="3" unit="character"/> ινα<gap reason="lost" quantity="4" unit="character"/> <supplied reason="lost">τὸ</supplied>ν μὲν δί
 <lb n="35" break="no"/>και<unclear>ον</unclear> <supplied reason="lost">α</supplied>ἰεὶ τα<supplied reason="lost">ρα</supplied>τ<supplied reason="lost"><unclear>τ</unclear></supplied>όμενον
 <lb n="36"/>ζῆν <supplied reason="lost">ἀ</supplied>ποδέξ<supplied reason="lost">αιτ'</supplied> <supplied reason="lost">ἂ</supplied><unclear>ν</unclear> ἀδικῶ<unclear>ν</unclear>
-<lb n="37"/>ἁρπα<supplied reason="lost">γ</supplied>ὴν<note xml:lang="en">?</note> απ <gap reason="illegible" quantity="4" unit="character"/> λλ <gap reason="illegible" quantity="1" unit="character"/> ἀλλ' <supplied reason="lost">ε</supplied>ἰ
+<lb n="37"/>ἁρπα<supplied reason="lost" cert="low">γ</supplied>ὴν απ <gap reason="illegible" quantity="4" unit="character"/> λλ <gap reason="illegible" quantity="1" unit="character"/> ἀλλ' <supplied reason="lost">ε</supplied>ἰ
 <milestone rend="paragraphos" unit="undefined"/>
 <lb n="38"/>καὶ πο<supplied reason="lost">ι</supplied>κίλα φ<supplied reason="lost">ησί</supplied><unclear>ν</unclear>, οὐ πρ<supplied reason="lost">ὸς</supplied>
 <lb n="39"/>ταῦτ' ἀπηντήσ<supplied reason="lost">α</supplied>μεν α <gap reason="illegible" quantity="2" unit="character"/>
@@ -2771,7 +2771,7 @@
 <lb n="16"/>τὰ μετὰ τὴν τελ<supplied reason="lost">ευ</supplied>τὴν οὐ
 <lb n="17" break="no"/>δὲν ἔσεσθαι πρὸ<supplied reason="lost">ς</supplied> αὑτὸν
 <lb n="18"/><supplied reason="lost"><unclear>π</unclear>ε</supplied>πεισμένον. <supplied reason="lost">Ἀ</supplied>λλ' ἐπὶ
-<lb n="19"/><unclear>τ</unclear><supplied reason="lost">ὸ</supplied> <supplied reason="lost"><unclear>τ</unclear></supplied>οὺς ῥήτορας <supplied reason="lost">ὡ</supplied>σπερεὶ<note xml:lang="en">?</note>
+<lb n="19"/><unclear>τ</unclear><supplied reason="lost">ὸ</supplied> <supplied reason="lost"><unclear>τ</unclear></supplied>οὺς ῥήτορας <supplied reason="lost" cert="low">ὡ</supplied>σπερεὶ
 <lb n="20"/><gap reason="illegible" quantity="4" unit="character"/> υσ <gap reason="illegible" quantity="2" unit="character"/> οντ <gap reason="illegible" quantity="7" unit="character"/> ε<unclear>ιι</unclear>σ <gap reason="illegible" quantity="2" unit="character"/> <gap reason="lost" quantity="4" unit="line"/>
 <lb n="25"/><gap reason="illegible" quantity="3" unit="character"/> υνολυ <gap reason="illegible" quantity="7" unit="character"/> νοαυτ <gap reason="illegible" quantity="1" unit="character"/>
 <lb n="26"/><gap reason="illegible" quantity="2" unit="character"/>αδε <gap reason="illegible" quantity="6" unit="character"/> θε <gap reason="illegible" quantity="2" unit="character"/> δε<unclear>ι</unclear> <gap reason="illegible" quantity="2" unit="character"/>

--- a/DCLP/63/62498.xml
+++ b/DCLP/63/62498.xml
@@ -710,20 +710,20 @@
 <lb n="1"/><gap reason="lost" quantity="1" unit="line"/>
 <lb n="2"/>ν<unclear>οῦς</unclear><note xml:lang="en">?</note> 
 <lb n="3"/>αὐτὰ 
-<lb n="4"/><supplied reason="lost">τὰ<note xml:lang="en">?</note></supplied> ὀνόμ<supplied reason="lost">ατα<note xml:lang="en">?</note></supplied> <gap reason="illegible" quantity="4" unit="character"/> <unclear>π</unclear>ά<unclear>ντ</unclear><supplied reason="lost">α<note xml:lang="en">?</note></supplied>  
+<lb n="4"/><supplied reason="lost" cert="low">τὰ</supplied> ὀνόμ<supplied reason="lost" cert="low">ατα</supplied> <gap reason="illegible" quantity="4" unit="character"/> <unclear>π</unclear>ά<unclear>ντ</unclear><supplied reason="lost" cert="low">α</supplied>  
 <lb n="5"/><gap reason="lost" quantity="5" unit="line"/>
 <lb n="10"/><supplied reason="lost">τῶν</supplied> <unclear>δ</unclear>ιαφε<unclear>ρ</unclear><supplied reason="lost">όν</supplied>των 
 <lb n="11"/><gap reason="lost" quantity="1" unit="line"/>
-<lb n="12"/>α<unclear>ὐ</unclear>τῆι ποιοῦ<supplied reason="lost">σιν<note xml:lang="en">?</note></supplied> ὅσοι 
+<lb n="12"/>α<unclear>ὐ</unclear>τῆι ποιοῦ<supplied reason="lost" cert="low">σιν</supplied> ὅσοι 
 <lb n="13"/><unclear>ἀν</unclear><supplied reason="lost">θ</supplied>ρώπους <gap reason="illegible" quantity="7" unit="character"/>
-<lb n="14"/>φύσι<unclear>ς</unclear> οἵαν ἡμ<supplied reason="lost">ῶν<note xml:lang="en">?</note></supplied> <g type="dagger"/>3<g type="dagger"/>3 <supplied reason="lost">ῖν<note xml:lang="en">?</note></supplied>
+<lb n="14"/>φύσι<unclear>ς</unclear> οἵαν ἡμ<supplied reason="lost" cert="low">ῶν</supplied> <g type="dagger"/>3<g type="dagger"/>3 <supplied reason="lost" cert="low">ῖν</supplied>
 <lb n="15"/><gap reason="lost" quantity="9" unit="line"/> 
 </ab></div>
 
 <div n="2" subtype="fragment" type="textpart" corresp="#FR6412"><ab>
 <lb n="1"/><gap reason="lost" quantity="16" unit="line"/>
 <lb n="17"/>συντελεῖ ο συντελεῖν 
-<lb n="18"/>τῶν <unclear>ἀ</unclear>ποτελεσ<supplied reason="lost">μάτων<note xml:lang="en">?</note></supplied> <g type="dagger"/>3<g type="dagger"/>3 <supplied reason="lost">τικῶν<note xml:lang="en">?</note></supplied> 
+<lb n="18"/>τῶν <unclear>ἀ</unclear>ποτελεσ<supplied reason="lost" cert="low">μάτων</supplied> <g type="dagger"/>3<g type="dagger"/>3 <supplied reason="lost" cert="low">τικῶν</supplied> 
 <lb n="19"/><gap reason="lost" quantity="5" unit="line"/>
 </ab></div>
 
@@ -769,7 +769,7 @@
 <lb n="12"/><gap reason="lost" quantity="1" unit="line"/>
 <lb n="13"/>δυνατ<unclear>ὸν</unclear> οὐδ<supplied reason="lost">ὲ</supplied> τῶ<unclear>ν</unclear> <unclear>ἀ</unclear>ν
 <lb n="14" break="no"/>θρώπ<unclear>ων</unclear> ἰδία φύσ<supplied reason="lost">ις</supplied><gap reason="lost" quantity="2" unit="character"/>
-<lb n="15"/><gap reason="illegible" quantity="2" unit="character"/> οὐ<unclear>δ</unclear>ὲ φρό<unclear>ν</unclear><supplied reason="lost">ημα<note xml:lang="en">?</note></supplied> 
+<lb n="15"/><gap reason="illegible" quantity="2" unit="character"/> οὐ<unclear>δ</unclear>ὲ φρό<unclear>ν</unclear><supplied reason="lost" cert="low">ημα</supplied> 
 <lb n="16"/>καὶ ἀκολουθῆ<unclear>ι</unclear> 
 <lb n="17"/><gap reason="lost" quantity="1" unit="line"/>
 <lb n="18"/><unclear>κ</unclear>ατ<unclear>α</unclear>κλυσ<unclear>μ</unclear> <gap reason="lost" quantity="2" unit="character"/>
@@ -778,11 +778,11 @@
 <div n="7" subtype="fragment" type="textpart" corresp="#FR6417"><ab>   
 <lb n="1"/><gap reason="lost" quantity="8" unit="line"/>
 <lb n="9"/><expan><ex>ην</ex></expan> <gap reason="illegible" quantity="4" unit="character"/> αὐτοῖς αἰ<unclear>τιω</unclear><supplied reason="lost">μέ</supplied>  
-<lb n="10" break="no"/>νο<supplied reason="lost">ις<note xml:lang="en">?</note></supplied> <gap reason="illegible" quantity="4" unit="character"/> ωνεαλ <gap reason="illegible" quantity="5" unit="character"/>  
+<lb n="10" break="no"/>νο<supplied reason="lost" cert="low">ις</supplied> <gap reason="illegible" quantity="4" unit="character"/> ωνεαλ <gap reason="illegible" quantity="5" unit="character"/>  
 <lb n="11"/><expan>μα<ex>τ</ex></expan> <gap reason="illegible" quantity="5" unit="character"/> <unclear>ε</unclear>ὐχὴ πρὸς <gap reason="illegible" quantity="3" unit="character"/>
 <lb n="12"/>α· ὁ μὲν οὖν <expan>εσ<ex>η</ex></expan> <gap reason="illegible" quantity="3" unit="character"/>
 <milestone rend="paragraphos" unit="undefined"/>
-<lb n="13"/>πᾶσ<unclear>α</unclear>ν ἐξαδυ<unclear>ν</unclear><supplied reason="lost">α</supplied>τή<unclear>σ</unclear><supplied reason="lost">εται<note xml:lang="en">?</note></supplied>  
+<lb n="13"/>πᾶσ<unclear>α</unclear>ν ἐξαδυ<unclear>ν</unclear><supplied reason="lost">α</supplied>τή<unclear>σ</unclear><supplied reason="lost" cert="low">εται</supplied>  
 <lb n="14"/>ὡς <unclear>ὁ</unclear> παλαιό<unclear>τ</unclear>ατ<unclear>ο</unclear><supplied reason="lost">ς</supplied> Κρὴς  
 <lb n="15"/>φυ<unclear>γ</unclear><supplied reason="lost">ώ</supplied><unclear>ν</unclear> τε δι' αὐ<unclear>τὰ</unclear>ς εὐχὰς  
 <lb n="16"/>τὴ<unclear>ν</unclear> ἀκολού<unclear>θη</unclear>σιν <unclear>καὶ</unclear>  
@@ -791,12 +791,12 @@
 
 <div n="8" subtype="fragment" type="textpart" corresp="#FR6418"><ab>  
 <lb n="1"/><gap reason="lost" quantity="10" unit="line"/>
-<lb n="11"/><supplied reason="lost">ἀπο</supplied>φατικὸ<supplied reason="lost">ν<note xml:lang="en">?</note></supplied> 
+<lb n="11"/><supplied reason="lost">ἀπο</supplied>φατικὸ<supplied reason="lost" cert="low">ν</supplied> 
 <lb n="12"/><supplied reason="lost">κ</supplied>αὶ ἀδ<unclear>ύ</unclear>να
 <lb n="13" break="no"/>τον 
 <lb n="14"/><gap reason="lost" quantity="1" unit="line"/>
 <lb n="15"/><unclear>π</unclear>οιεῖ<unclear>τα</unclear><supplied reason="lost">ι</supplied>
-<lb n="16"/><unclear>κ</unclear>α<unclear>ὶ</unclear><note xml:lang="en">?</note> τἆλ<supplied reason="lost">λα<note xml:lang="en">?</note></supplied> <gap reason="illegible" quantity="2" unit="character"/> τ<unclear>ῶν</unclear> <unclear>ἄ</unclear>ς
+<lb n="16"/><unclear>κ</unclear>α<unclear>ὶ</unclear><note xml:lang="en">?</note> τἆλ<supplied reason="lost" cert="low">λα</supplied> <gap reason="illegible" quantity="2" unit="character"/> τ<unclear>ῶν</unclear> <unclear>ἄ</unclear>ς
 <lb n="17" break="no"/><unclear>τ</unclear>ρων 
 <lb n="18"/><gap reason="lost" quantity="3" unit="line"/> 
 </ab></div>
@@ -828,16 +828,16 @@
 
 <div n="13" subtype="fragment" type="textpart" corresp="#FR6422"><ab>
 <lb n="1"/><gap reason="lost" quantity="1" unit="line"/>  
-<lb n="2"/><supplied reason="lost">κ</supplied>αὶ τῆς πρ<unclear>ο</unclear><supplied reason="lost">νοίας<note xml:lang="en">?</note></supplied><gap reason="lost" quantity="2" unit="character"/>  
+<lb n="2"/><supplied reason="lost">κ</supplied>αὶ τῆς πρ<unclear>ο</unclear><supplied reason="lost" cert="low">νοίας</supplied><gap reason="lost" quantity="2" unit="character"/>  
 <lb n="3"/><gap reason="illegible" quantity="2" unit="character"/> ἐστιν ἀ<unclear>π</unclear>αγ<unclear>ο</unclear>ρεύ<unclear>μ</unclear><supplied reason="lost">α</supplied>  
-<lb n="4" break="no"/><unclear>τ</unclear>α διὰ τὸ <unclear>μ</unclear><supplied reason="lost">η</supplied><unclear>δ</unclear>' ἡμέτ<unclear>ε</unclear>ρ<supplied reason="lost">ον<note xml:lang="en">?</note></supplied> 
+<lb n="4" break="no"/><unclear>τ</unclear>α διὰ τὸ <unclear>μ</unclear><supplied reason="lost">η</supplied><unclear>δ</unclear>' ἡμέτ<unclear>ε</unclear>ρ<supplied reason="lost" cert="low">ον</supplied> 
 <lb n="5"/>ἔρ<unclear>γο</unclear>ν <unclear>εἶ</unclear>ν<supplied reason="lost">α</supplied>ι τὸ νοσε<unclear>ῖ</unclear><supplied reason="lost">ν</supplied>· 
 <lb n="6"/>τῆς μέν<unclear>τ</unclear>οι γε ἰδίας 
 <lb n="7"/>τἀνθρώπ<unclear>ο</unclear>υ φύσεως ἀ 
 <lb n="8" break="no"/>πα<unclear>γ</unclear>ο<unclear>ρ</unclear>εύ<unclear>μ</unclear>ατ' ἐστί· καὶ 
 <lb n="9"/>γὰρ παρὰ τ<unclear>ὸ</unclear> βούλημα 
 <lb n="10"/><unclear>κ</unclear>αὶ ἐναν<unclear>τ</unclear><supplied reason="lost">ί</supplied>ως αὐτῆι  
-<lb n="11"/><supplied reason="lost">ποιεῖ<note xml:lang="en">?</note></supplied>ται. τίς οὖν μὴ 
+<lb n="11"/><supplied reason="lost" cert="low">ποιεῖ</supplied>ται. τίς οὖν μὴ 
 <lb n="12"/><supplied reason="lost">μ</supplied><unclear>α</unclear>καρίζηι τὴν ο <gap reason="illegible" quantity="4" unit="character"/>
 <lb n="13"/><gap reason="lost" quantity="1" unit="line"/>
 </ab></div>
@@ -867,7 +867,7 @@
 <lb n="7"/>γίνεσ<supplied reason="lost">θ</supplied><unclear>α</unclear>ι· καὶ πο<unclear>λ</unclear><supplied reason="lost">λ</supplied>οὺ<unclear>ς</unclear>
 <milestone rend="paragraphos" unit="undefined"/>  
 <lb n="8"/>μὲν ὄ<unclear>μ</unclear>βρους καὶ κ<supplied reason="lost">α</supplied>τα 
-<lb n="9" break="no"/>στά<unclear>σ</unclear>ει<unclear>ς</unclear> <supplied reason="lost">ε</supplied>ἶνα<supplied reason="lost">ι<note xml:lang="en">?</note></supplied> <expan><ex>μ</ex>ὲν</expan><note xml:lang="en">?</note> <expan><ex>σ</ex>υ</expan> 
+<lb n="9" break="no"/>στά<unclear>σ</unclear>ει<unclear>ς</unclear> <supplied reason="lost">ε</supplied>ἶνα<supplied reason="lost" cert="low">ι</supplied> <expan><ex>μ</ex>ὲν</expan><note xml:lang="en">?</note> <expan><ex>σ</ex>υ</expan> 
 <lb n="10"/><expan><ex>υ</ex></expan> τῆς<note xml:lang="en">?</note> τ <gap reason="illegible" quantity="2" unit="character"/> ς συ<unclear>μ</unclear>βα<supplied reason="lost">ίν</supplied><unclear>ειν</unclear> 
 <lb n="11"/><gap reason="illegible" quantity="5" unit="character"/> δ' ἐπιγι<unclear>ν</unclear> <gap reason="lost" quantity="4" unit="character"/> ἡδὺς<note xml:lang="en">?</note>
 <lb n="12"/><gap reason="lost" quantity="1" unit="line"/>  
@@ -911,12 +911,12 @@
 <div n="20" subtype="fragment" type="textpart" corresp="#FR6430"><ab>
 <lb n="1"/><gap reason="lost" quantity="2" unit="line"/>  
 <lb n="3"/><gap reason="illegible" quantity="11" unit="character"/> εἰ δ' εἰς 
-<lb n="4"/><unclear>συ</unclear>στρο<supplied reason="lost">φὴν<note xml:lang="en">?</note></supplied> <gap reason="illegible" quantity="2" unit="character"/> <unclear>τ</unclear>οῖς με
+<lb n="4"/><unclear>συ</unclear>στρο<supplied reason="lost" cert="low">φὴν</supplied> <gap reason="illegible" quantity="2" unit="character"/> <unclear>τ</unclear>οῖς με
 <lb n="5" break="no"/>τεώροις ὑπ<unclear>ο</unclear>τυποῖ· με  
 <lb n="6" break="no"/><unclear>τ</unclear>εωρίζει δ' α<supplied reason="lost">ὐτ</supplied>ὰ καὶ  
 <lb n="7"/>τὸ προστιθ<unclear>έ</unclear>μενον  
 <lb n="8"/>ἐκ τοῦ π<unclear>ρ</unclear>ο<unclear>σέ</unclear>χοντος 
-<lb n="9"/>τὸν <unclear>α</unclear><supplied reason="lost">ὑ</supplied><unclear>τ</unclear><supplied reason="lost">οῦ<note xml:lang="en">?</note></supplied> νοῦν· ἐξοι<unclear>δεῖ</unclear><note xml:lang="en">?</note> 
+<lb n="9"/>τὸν <unclear>α</unclear><supplied reason="lost">ὑ</supplied><unclear>τ</unclear><supplied reason="lost" cert="low">οῦ</supplied> νοῦν· ἐξοι<unclear>δεῖ</unclear><note xml:lang="en">?</note> 
 <lb n="10"/><unclear>γ</unclear>ὰ<unclear>ρ</unclear> παραθέσε<supplied reason="lost">ι</supplied><unclear>ς</unclear> <unclear>κ</unclear>αὶ  
 <lb n="11"/><unclear>προσγ</unclear><supplied reason="lost">εν</supplied><unclear>ν</unclear>ήσε<supplied reason="lost">ι</supplied><unclear>ς</unclear><note xml:lang="en">?</note> τὸ<note xml:lang="en">?</note> σύμ  
 <lb n="12" break="no"/>παν<note xml:lang="en">?</note> <gap reason="illegible" quantity="15" unit="character"/> 
@@ -925,13 +925,13 @@
 
 <div n="21" subtype="fragment" type="textpart" corresp="#FR6431"><ab>  
 <lb n="1"/><gap reason="lost" quantity="3" unit="line"/>
-<lb n="4"/><unclear>π</unclear>άθ<unclear>ο</unclear><supplied reason="lost">ς<note xml:lang="en">?</note></supplied>  
+<lb n="4"/><unclear>π</unclear>άθ<unclear>ο</unclear><supplied reason="lost" cert="low">ς</supplied>  
 <lb n="5"/>ὀργ<unclear>ὴ</unclear><note xml:lang="en">?</note> 
 <lb n="6"/><supplied reason="lost">π</supplied>ό<unclear>ν</unclear>ους καὶ  
 <lb n="7"/><gap reason="lost" quantity="1" unit="line"/>
 <lb n="8"/>κριτικὸ<unclear>ν</unclear> 
 <lb n="9"/><supplied reason="lost">κ</supplied>αὶ ἐ<unclear>μ</unclear>βά<unclear>λ</unclear>
-<lb n="10" break="no"/><unclear>λω</unclear>ν ὑπὸ <supplied reason="lost">τ<note xml:lang="en">?</note></supplied><unclear>α</unclear>ὐτοῦ καὶ 
+<lb n="10" break="no"/><unclear>λω</unclear>ν ὑπὸ <supplied reason="lost" cert="low">τ</supplied><unclear>α</unclear>ὐτοῦ καὶ 
 <lb n="11"/><unclear>π</unclear>ραγμάτω<unclear>ν</unclear><note xml:lang="en">?</note>  
 </ab></div>
 
@@ -944,16 +944,16 @@
 
 <div n="23" subtype="fragment" type="textpart" corresp="#FR6433"><ab>   
 <lb n="1"/><gap reason="lost" quantity="2" unit="line"/>
-<lb n="3"/><gap reason="illegible" quantity="6" unit="character"/> <unclear>π</unclear>εριου<unclear>σ</unclear><supplied reason="lost">ίας<note xml:lang="en">?</note> οὐ<note xml:lang="en">?</note></supplied>  
+<lb n="3"/><gap reason="illegible" quantity="6" unit="character"/> <unclear>π</unclear>εριου<unclear>σ</unclear><supplied reason="lost" cert="low">ίας οὐ</supplied>  
 <lb n="4" break="no"/><unclear>δ</unclear>ὲ<unclear>ν</unclear> <gap reason="illegible" quantity="15" unit="character"/>
 <lb n="5"/><unclear>μᾶλλον</unclear> ὡς γεννᾶ<unclear>σ</unclear><supplied reason="lost">θαι ἡ</supplied>  
 <lb n="6"/>π<unclear>ο</unclear>ι<unclear>ό</unclear>της καθ' ὅλου <supplied reason="lost">ὥσ</supplied>  
 <lb n="7" break="no"/><supplied reason="lost">πε</supplied><unclear>ρ</unclear> <unclear>κατὰ</unclear> μέρο<unclear>ς</unclear> <unclear>ἐγέ</unclear><supplied reason="lost">νετο</supplied>· 
 <lb n="8"/>πλ<unclear>ὴ</unclear>ν γὰ<unclear>ρ</unclear> τοῦ κοιν<unclear>ω</unclear><supplied reason="lost">νεῖν</supplied> 
-<lb n="9"/>ἐξ ὧν <unclear>τῆς</unclear> δ<unclear>ι</unclear>δομέν<unclear>η</unclear><supplied reason="lost">ς ἰ<note xml:lang="en">?</note></supplied> 
+<lb n="9"/>ἐξ ὧν <unclear>τῆς</unclear> δ<unclear>ι</unclear>δομέν<unclear>η</unclear><supplied reason="lost" cert="low">ς ἰ</supplied> 
 <lb n="10" break="no"/>διω<unclear>μ</unclear>α <gap reason="illegible" quantity="6" unit="character"/> συνίστα  
 <lb n="11" break="no"/>σθαι δι<unclear>ὰ</unclear> τ<unclear>ὰ</unclear>ς διαφερού  
-<lb n="12" break="no"/><unclear>σ</unclear><supplied reason="lost">ας</supplied> <unclear>πε</unclear>ρὶ τῶν <unclear>δι</unclear>αφερου<supplied reason="lost">σῶν<note xml:lang="en">?</note></supplied>  
+<lb n="12" break="no"/><unclear>σ</unclear><supplied reason="lost">ας</supplied> <unclear>πε</unclear>ρὶ τῶν <unclear>δι</unclear>αφερου<supplied reason="lost" cert="low">σῶν</supplied>  
 <lb n="13"/><unclear>ὥσ</unclear>περ <supplied reason="lost">ὁ ἄνθ</supplied><unclear>ρ</unclear>ωπος <gap reason="illegible" quantity="4" unit="character"/>
 <lb n="14"/><gap reason="lost" quantity="2" unit="line"/>
 </ab></div>
@@ -975,7 +975,7 @@
 
 <div n="26" subtype="fragment" type="textpart" corresp="#FR6436"><ab>  
 <lb n="1"/><gap reason="lost" quantity="1" unit="line"/> 
-<lb n="2"/><supplied reason="lost">αἰχμά<note xml:lang="en">?</note></supplied>λωτα 
+<lb n="2"/><supplied reason="lost" cert="low">αἰχμά</supplied>λωτα 
 <lb n="2"/><gap reason="lost" quantity="9" unit="line"/>
 <lb n="12"/><unclear>π</unclear>ο<unclear>λ</unclear>έμο<supplied reason="lost">ι</supplied>ς 
 <lb n="13"/>ἄθ<unclear>λη</unclear>σις 
@@ -1021,7 +1021,7 @@
 
 <div n="30" subtype="fragment" type="textpart" corresp="#FR6440"><ab>  
 <lb n="1"/><gap reason="lost" quantity="3" unit="line"/> 
-<lb n="4"/>τοῖς ἰδί<supplied reason="lost">οις<note xml:lang="en">?</note></supplied> 
+<lb n="4"/>τοῖς ἰδί<supplied reason="lost" cert="low">οις</supplied> 
 <lb n="5"/><gap reason="lost" quantity="4" unit="line"/> 
 <lb n="9"/><unclear>π</unclear>ερὶ <unclear>ψ</unclear>υχ<unclear>ῆ</unclear><supplied reason="lost">ς</supplied>
 <lb n="10"/><gap reason="lost" quantity="1" unit="line"/>  
@@ -1074,26 +1074,26 @@
 <lb n="7" break="no"/>παικένα<supplied reason="lost">ι δ</supplied>ὲ κἀκεῖνο  
 <lb n="8"/>δοκοῦσι<unclear>ν</unclear> <supplied reason="lost">ἡ</supplied><unclear>μ</unclear>ῖν ὅσοι κα 
 <lb n="9" break="no"/>θάπερ τι δ<supplied reason="lost">υνα</supplied><unclear>τ</unclear>ὸν εἰσφέ 
-<lb n="10" break="no"/>ροντες ἀπ<supplied reason="lost">ήφη<note xml:lang="en">?</note></supplied>ναν, τὸ 
+<lb n="10" break="no"/>ροντες ἀπ<supplied reason="lost" cert="low">ήφη</supplied>ναν, τὸ 
 <lb n="11"/>πάντα μὲν <note xml:lang="en">?</note> <supplied reason="lost">κ</supplied><unclear>α</unclear>θ' εἱμαρ 
 <lb n="12" break="no"/>μένην οὖν <gap reason="illegible" quantity="2" unit="character"/> ΕΙΣΘΑΡΠ 
 <lb n="13"/><gap reason="illegible" quantity="3" unit="character"/> ΔΑΥΤΣ <gap reason="illegible" quantity="2" unit="character"/> ΑΙΓΑΤΑΣ  
-<lb n="14"/>πρόνοια τε <supplied reason="lost">ἐ<note xml:lang="en">?</note></supplied>πειδὴ <note xml:lang="en">?</note> καὶ 
+<lb n="14"/>πρόνοια τε <supplied reason="lost" cert="low">ἐ</supplied>πειδὴ <note xml:lang="en">?</note> καὶ 
 <lb n="15"/>τὸ πάντα <gap reason="illegible" quantity="9" unit="character"/> ΕΙΝ  
 <lb n="16"/>καθ' εἱμαρ<unclear>μ</unclear><supplied reason="lost">ένην</supplied> <gap reason="illegible" quantity="2" unit="character"/> ΖΔ <gap reason="illegible" quantity="1" unit="character"/> Α  
 <lb n="17"/>τὰς ἐνεργείας ἐστὶ καὶ 
 <lb n="18"/>τό τινα τ<unclear>ῶ</unclear>ν ἠναγκασ 
 <lb n="19" break="no"/>μένων γ<supplied reason="lost">ίνε</supplied>σθαι κατὰ 
 <lb n="20"/>πρόνοιαν <supplied reason="lost">οὐκ</supplied> ἀνόητον 
-<lb n="21"/>ὡς τὸ πάν<supplied reason="lost">τα πρὸς<note xml:lang="en">?</note></supplied> ἑκάτε  
+<lb n="21"/>ὡς τὸ πάν<supplied reason="lost" cert="low">τα πρὸς</supplied> ἑκάτε  
 <lb n="22" break="no"/><unclear>ρ</unclear>ον, καίτοι 
 <lb n="26"/><supplied reason="lost">προ</supplied>
-<lb n="27" break="no"/>νοίας τἆλλ<supplied reason="lost">α<note xml:lang="en">?</note></supplied> 
+<lb n="27" break="no"/>νοίας τἆλλ<supplied reason="lost" cert="low">α</supplied> 
 <lb n="30"/>νοῦς<note xml:lang="en">?</note>   
 <lb n="32"/><supplied reason="lost">καθ'</supplied>
-<lb n="33"/>εἰμαρμένη<supplied reason="lost">ν<note xml:lang="en">?</note></supplied>  ox1424<gap reason="illegible" quantity="30" unit="character"/>
-<lb n="34"/>μῦθος Ἀπόλ<supplied reason="lost">λωνος<note xml:lang="en">?</note></supplied>  
-<lb n="35"/>τὴν ἀπά<unclear>τ</unclear><supplied reason="lost">ην<note xml:lang="en">?</note></supplied>  
+<lb n="33"/>εἰμαρμένη<supplied reason="lost" cert="low">ν</supplied>  ox1424<gap reason="illegible" quantity="30" unit="character"/>
+<lb n="34"/>μῦθος Ἀπόλ<supplied reason="lost" cert="low">λωνος</supplied>  
+<lb n="35"/>τὴν ἀπά<unclear>τ</unclear><supplied reason="lost" cert="low">ην</supplied>  
 </ab></div>
 
 <div n="opisthograph" type="textpart" subtype="fragment">
@@ -1115,7 +1115,7 @@
 <milestone rend="paragraphos" unit="undefined"/>
 <lb n="9"/><gap reason="lost" quantity="4" unit="line"/>
 <lb n="13"/><supplied reason="lost">εἶ</supplied>
-<lb n="14" break="no"/>ναι φασὶ θεὸ<supplied reason="lost">ν<note xml:lang="en">?</note></supplied> <g type="dagger"/>3<g type="dagger"/>3 <supplied reason="lost">οὺς<note xml:lang="en">?</note></supplied>  
+<lb n="14" break="no"/>ναι φασὶ θεὸ<supplied reason="lost" cert="low">ν</supplied> <g type="dagger"/>3<g type="dagger"/>3 <supplied reason="lost" cert="low">οὺς</supplied>  
 <lb n="15"/><gap reason="lost" quantity="3" unit="line"/>
 </ab></div></div>
 
@@ -1128,10 +1128,10 @@
 
 <div n="O1423" type="textpart">
 <div n="1" subtype="fragment" type="textpart" corresp="#FR6446"><ab>
-<lb n="1"/>μόνον φύσεώς γ<supplied reason="lost">ε<note xml:lang="en">?</note></supplied>  
+<lb n="1"/>μόνον φύσεώς γ<supplied reason="lost" cert="low">ε</supplied>  
 <lb n="2"/>τὰ δ' ὑπὸ φύσεως <unclear>ἢ</unclear>  
 <lb n="3"/><supplied reason="lost">πολ</supplied><unclear>έ</unclear>μου τὰ δὲ πολέ  
-<lb n="4" break="no"/>μου μόνον, καίτ<unclear>ο</unclear><supplied reason="lost">ι<note xml:lang="en">?</note></supplied>  
+<lb n="4" break="no"/>μου μόνον, καίτ<unclear>ο</unclear><supplied reason="lost" cert="low">ι</supplied>  
 <lb n="5"/>τὰ δὲ ἀστάτως κα<supplied reason="lost">ι</supplied>  
 <lb n="6" break="no"/><supplied reason="lost">ρο</supplied>ῖς καὶ τόποις, τ<supplied reason="lost">ὰ</supplied>  
 <lb n="7"/>δ'<note xml:lang="en">?</note> ἐκ<note xml:lang="en">?</note> τῆς γενέσεως
@@ -1141,15 +1141,15 @@
 <lb n="14"/><gap reason="lost" quantity="1" unit="line"/>
 <lb n="15"/>τελετῆς 
 <lb n="16"/><gap reason="lost" quantity="7" unit="line"/> 
-<lb n="23"/><supplied reason="lost">ὥσ<note xml:lang="en">?</note></supplied>περ ἀνθρωπ<gap reason="lost" quantity="2" unit="character"/>   
+<lb n="23"/><supplied reason="lost" cert="low">ὥσ</supplied>περ ἀνθρωπ<gap reason="lost" quantity="2" unit="character"/>   
 <lb n="24"/>καὶ τὰ 
 <lb n="25"/><gap reason="illegible" quantity="6" unit="character"/> διδαχθέ<unclear>ν</unclear>
-<lb n="26" break="no"/>τ<supplied reason="lost">α<note xml:lang="en">?</note></supplied> 
+<lb n="26" break="no"/>τ<supplied reason="lost" cert="low">α</supplied> 
 <lb n="27"/><supplied reason="lost">πα</supplied><unclear>ρ</unclear>ασκευάζε<supplied reason="lost">ι</supplied>  
 <lb n="28"/>πᾶ<supplied reason="lost">σι</supplied>ν παρεγγυ<unclear>ᾶ</unclear><supplied reason="lost">ν</supplied>  
 <lb n="29"/><gap reason="illegible" quantity="2" unit="character"/> δαιμόνιον οὐ<unclear>χ</unclear> 
 <lb n="30"/>οἵαν οὕτω καὶ τὴ<supplied reason="lost">ν</supplied>
-<lb n="31"/>φ<supplied reason="lost">ύσιν<note xml:lang="en">?</note> ἔ</supplied>στιν εἰπεῖν 
+<lb n="31"/>φ<supplied reason="lost" cert="low">ύσιν</supplied> <supplied reason="lost">ἔ</supplied>στιν εἰπεῖν 
 <lb n="32"/>ὅλως ἔμαθε<unclear>ν</unclear><note xml:lang="en">?</note>  
 <lb n="33"/>ἐγένο<supplied reason="lost">ν</supplied>
 <lb n="34" break="no"/>το ἀ<supplied reason="lost">π' ἐ</supplied>μοῦ γε  

--- a/DCLP/63/62500.xml
+++ b/DCLP/63/62500.xml
@@ -4307,7 +4307,7 @@
               <lb n="14"/><gap reason="illegible" quantity="2" unit="character"/> τις <gap reason="illegible" quantity="1" unit="character"/> λυχ <gap reason="illegible" extent="unknown" unit="character"/>
               <lb n="15"/><supplied reason="lost">τ</supplied>ῶν <supplied reason="lost">ῥ</supplied>ητο<supplied reason="lost">ρικῶν·</supplied>
               <lb n="16"/><supplied reason="lost">εἰ δ</supplied>ὲ δὴ δυς <gap reason="illegible" extent="unknown" unit="character"/>
-              <lb n="17"/>ἐπί γε γραμ<supplied reason="lost">ματικῆς<note xml:lang="en">?</note></supplied> 
+              <lb n="17"/>ἐπί γε γραμ<supplied reason="lost" cert="low">ματικῆς</supplied> 
           </ab></div>
           
           <div n="3" subtype="fragment" type="textpart" corresp="#FR4138"><ab>
@@ -4355,7 +4355,7 @@
           
           <div n="5" subtype="fragment" type="textpart" corresp="#FR4140"><ab>
               <lb n="1"/><supplied reason="lost">οὐ</supplied>χὶ τῶν π<supplied reason="lost">ο</supplied>λλῶν α<supplied reason="lost">ὐτὴν ἐ</supplied>  
-              <lb n="2" break="no"/><supplied reason="lost">π</supplied><unclear>ιστ</unclear><supplied reason="lost">ή</supplied>μην καὶ τ<supplied reason="lost">έχνην<note xml:lang="en">?</note></supplied>  
+              <lb n="2" break="no"/><supplied reason="lost">π</supplied><unclear>ιστ</unclear><supplied reason="lost">ή</supplied>μην καὶ τ<supplied reason="lost" cert="low">έχνην</supplied>  
               <lb n="3"/>εἶναι συμβέβηκε<supplied reason="lost">ν. Ὁ γὰρ</supplied>
               <milestone rend="paragraphos" unit="undefined"/> 
               <lb n="4"/>λέγων τέλος εἶνα<supplied reason="lost">ι τὸ</supplied> 
@@ -4459,7 +4459,7 @@
               <lb n="1"/>ἐπιστημ <gap reason="illegible" extent="unknown" unit="character"/> 
               <lb n="2"/>ξει καὶ π <gap reason="illegible" extent="unknown" unit="character"/> 
               <lb n="3"/>τοτα ῥητ <gap reason="illegible" extent="unknown" unit="character"/>  
-              <lb n="4"/><supplied reason="lost">πρα</supplied>γμάτων<note xml:lang="en">?</note> ε <gap reason="illegible" extent="unknown" unit="character"/>
+              <lb n="4"/><supplied reason="lost" cert="low">πρα</supplied>γμάτων ε <gap reason="illegible" extent="unknown" unit="character"/>
               <lb n="5"/>καὶ φράζειν <gap reason="illegible" extent="unknown" unit="character"/> 
               <milestone rend="paragraphos" unit="undefined"/>
               <lb n="6"/>αὐτὴν δὲ <gap reason="illegible" extent="unknown" unit="character"/> 
@@ -4500,7 +4500,7 @@
               <lb n="2" break="no"/>ρι<unclear>κ</unclear>ὴν το<supplied reason="lost">ῦ</supplied> τ<supplied reason="lost">έλους φά</supplied> 
               <lb n="3" break="no"/>σ<supplied reason="lost">κ</supplied>ει τοὺς <supplied reason="lost">τέχνην μόνον</supplied> 
               <lb n="4"/>προσφερομέ<unclear>ν</unclear><supplied reason="lost">ους μὴ</supplied>  
-              <lb n="5"/><unclear>κ</unclear>υριε<supplied reason="lost">ύει</supplied>ν· δι<unclear>ὰ</unclear> <supplied reason="lost">παντὸς<note xml:lang="en">?</note></supplied>  
+              <lb n="5"/><unclear>κ</unclear>υριε<supplied reason="lost">ύει</supplied>ν· δι<unclear>ὰ</unclear> <supplied reason="lost" cert="low">παντὸς</supplied>  
               <lb n="6"/>γάρ, ὡς ἤδη π<supplied reason="lost">ολλάκις</supplied> 
               <lb n="7"/>εἴπαμεν, π<unclear>ο</unclear><supplied reason="lost">λλοὺς ἐν ταῖς</supplied>  
               <lb n="8"/>ἐπιστήμαις <supplied reason="lost">ἐξηπά</supplied> 


### PR DESCRIPTION
As discussed with @HolgerEssler, the digital editions of some Herculaneum papyri use `<note xml:lang="en">?</note>` somewhat liberally, in an attempt to reproduce the contents of the printed reference edition. 

In several cases, there exists better XML that is already supported by PN XSLT and that would render the data more machine-readable. I have noted instances where `<note xml:lang="en">?</note>` is used where PN would employ the Leiden+ `|ed|` or `|reg|`, or where the SoSOL `Commentary` function would be more appropriate. 

In this PR, however, I focus primarily on instances of supplied text followed by `<note xml:lang="en">?</note>`, which is more properly rendered by adding `@cert="low"` to the element `<supplied>`. Please wait for Holger's approval before merging.