### PR TITLE
Anglicizing <language> in HGV trans

### DIFF
--- a/HGV_trans_EpiDoc/10038.xml
+++ b/HGV_trans_EpiDoc/10038.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/10049.xml
+++ b/HGV_trans_EpiDoc/10049.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/10130.xml
+++ b/HGV_trans_EpiDoc/10130.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/1022.xml
+++ b/HGV_trans_EpiDoc/1022.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/10359.xml
+++ b/HGV_trans_EpiDoc/10359.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/10367.xml
+++ b/HGV_trans_EpiDoc/10367.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/10369.xml
+++ b/HGV_trans_EpiDoc/10369.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/10427.xml
+++ b/HGV_trans_EpiDoc/10427.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/10740.xml
+++ b/HGV_trans_EpiDoc/10740.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/10764.xml
+++ b/HGV_trans_EpiDoc/10764.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/10765.xml
+++ b/HGV_trans_EpiDoc/10765.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110125.xml
+++ b/HGV_trans_EpiDoc/110125.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110188.xml
+++ b/HGV_trans_EpiDoc/110188.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110190.xml
+++ b/HGV_trans_EpiDoc/110190.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110191.xml
+++ b/HGV_trans_EpiDoc/110191.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110192.xml
+++ b/HGV_trans_EpiDoc/110192.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110193.xml
+++ b/HGV_trans_EpiDoc/110193.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110194.xml
+++ b/HGV_trans_EpiDoc/110194.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110195.xml
+++ b/HGV_trans_EpiDoc/110195.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110196.xml
+++ b/HGV_trans_EpiDoc/110196.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110197.xml
+++ b/HGV_trans_EpiDoc/110197.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110198.xml
+++ b/HGV_trans_EpiDoc/110198.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110200.xml
+++ b/HGV_trans_EpiDoc/110200.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110201.xml
+++ b/HGV_trans_EpiDoc/110201.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110205.xml
+++ b/HGV_trans_EpiDoc/110205.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110206.xml
+++ b/HGV_trans_EpiDoc/110206.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110207.xml
+++ b/HGV_trans_EpiDoc/110207.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110208.xml
+++ b/HGV_trans_EpiDoc/110208.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110209.xml
+++ b/HGV_trans_EpiDoc/110209.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110210.xml
+++ b/HGV_trans_EpiDoc/110210.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110211.xml
+++ b/HGV_trans_EpiDoc/110211.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/110214.xml
+++ b/HGV_trans_EpiDoc/110214.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/1113.xml
+++ b/HGV_trans_EpiDoc/1113.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/111774.xml
+++ b/HGV_trans_EpiDoc/111774.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/111785.xml
+++ b/HGV_trans_EpiDoc/111785.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/111786.xml
+++ b/HGV_trans_EpiDoc/111786.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/111809.xml
+++ b/HGV_trans_EpiDoc/111809.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/112467.xml
+++ b/HGV_trans_EpiDoc/112467.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/112477.xml
+++ b/HGV_trans_EpiDoc/112477.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114236.xml
+++ b/HGV_trans_EpiDoc/114236.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114237.xml
+++ b/HGV_trans_EpiDoc/114237.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114238.xml
+++ b/HGV_trans_EpiDoc/114238.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114239.xml
+++ b/HGV_trans_EpiDoc/114239.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114240.xml
+++ b/HGV_trans_EpiDoc/114240.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114241.xml
+++ b/HGV_trans_EpiDoc/114241.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114242.xml
+++ b/HGV_trans_EpiDoc/114242.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114243.xml
+++ b/HGV_trans_EpiDoc/114243.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114244.xml
+++ b/HGV_trans_EpiDoc/114244.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114245.xml
+++ b/HGV_trans_EpiDoc/114245.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114246.xml
+++ b/HGV_trans_EpiDoc/114246.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114247.xml
+++ b/HGV_trans_EpiDoc/114247.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114248.xml
+++ b/HGV_trans_EpiDoc/114248.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114249.xml
+++ b/HGV_trans_EpiDoc/114249.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114250.xml
+++ b/HGV_trans_EpiDoc/114250.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114251.xml
+++ b/HGV_trans_EpiDoc/114251.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114253.xml
+++ b/HGV_trans_EpiDoc/114253.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114254.xml
+++ b/HGV_trans_EpiDoc/114254.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114255.xml
+++ b/HGV_trans_EpiDoc/114255.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114256.xml
+++ b/HGV_trans_EpiDoc/114256.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114257.xml
+++ b/HGV_trans_EpiDoc/114257.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114258.xml
+++ b/HGV_trans_EpiDoc/114258.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114260.xml
+++ b/HGV_trans_EpiDoc/114260.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114268.xml
+++ b/HGV_trans_EpiDoc/114268.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114269.xml
+++ b/HGV_trans_EpiDoc/114269.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114270.xml
+++ b/HGV_trans_EpiDoc/114270.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114271.xml
+++ b/HGV_trans_EpiDoc/114271.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114272.xml
+++ b/HGV_trans_EpiDoc/114272.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114273.xml
+++ b/HGV_trans_EpiDoc/114273.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/114280.xml
+++ b/HGV_trans_EpiDoc/114280.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/1147.xml
+++ b/HGV_trans_EpiDoc/1147.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115532.xml
+++ b/HGV_trans_EpiDoc/115532.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115533.xml
+++ b/HGV_trans_EpiDoc/115533.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115535.xml
+++ b/HGV_trans_EpiDoc/115535.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115536.xml
+++ b/HGV_trans_EpiDoc/115536.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115537.xml
+++ b/HGV_trans_EpiDoc/115537.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115538.xml
+++ b/HGV_trans_EpiDoc/115538.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115540.xml
+++ b/HGV_trans_EpiDoc/115540.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115541.xml
+++ b/HGV_trans_EpiDoc/115541.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115545.xml
+++ b/HGV_trans_EpiDoc/115545.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115546.xml
+++ b/HGV_trans_EpiDoc/115546.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115549.xml
+++ b/HGV_trans_EpiDoc/115549.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115550.xml
+++ b/HGV_trans_EpiDoc/115550.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115551.xml
+++ b/HGV_trans_EpiDoc/115551.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115567.xml
+++ b/HGV_trans_EpiDoc/115567.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115568.xml
+++ b/HGV_trans_EpiDoc/115568.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115569.xml
+++ b/HGV_trans_EpiDoc/115569.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115570.xml
+++ b/HGV_trans_EpiDoc/115570.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115571.xml
+++ b/HGV_trans_EpiDoc/115571.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115572.xml
+++ b/HGV_trans_EpiDoc/115572.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115574.xml
+++ b/HGV_trans_EpiDoc/115574.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115575.xml
+++ b/HGV_trans_EpiDoc/115575.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115576.xml
+++ b/HGV_trans_EpiDoc/115576.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115577.xml
+++ b/HGV_trans_EpiDoc/115577.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115578.xml
+++ b/HGV_trans_EpiDoc/115578.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115579.xml
+++ b/HGV_trans_EpiDoc/115579.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/115581.xml
+++ b/HGV_trans_EpiDoc/115581.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/11620.xml
+++ b/HGV_trans_EpiDoc/11620.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/11645.xml
+++ b/HGV_trans_EpiDoc/11645.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
                 <language ident="it">Italian</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/116595.xml
+++ b/HGV_trans_EpiDoc/116595.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/118375.xml
+++ b/HGV_trans_EpiDoc/118375.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/118377.xml
+++ b/HGV_trans_EpiDoc/118377.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/118385.xml
+++ b/HGV_trans_EpiDoc/118385.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/118644.xml
+++ b/HGV_trans_EpiDoc/118644.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/118649.xml
+++ b/HGV_trans_EpiDoc/118649.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/118687.xml
+++ b/HGV_trans_EpiDoc/118687.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/11895.xml
+++ b/HGV_trans_EpiDoc/11895.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/1257.xml
+++ b/HGV_trans_EpiDoc/1257.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128285.xml
+++ b/HGV_trans_EpiDoc/128285.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128286.xml
+++ b/HGV_trans_EpiDoc/128286.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128287.xml
+++ b/HGV_trans_EpiDoc/128287.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128288.xml
+++ b/HGV_trans_EpiDoc/128288.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128289.xml
+++ b/HGV_trans_EpiDoc/128289.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128290.xml
+++ b/HGV_trans_EpiDoc/128290.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128291.xml
+++ b/HGV_trans_EpiDoc/128291.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128292.xml
+++ b/HGV_trans_EpiDoc/128292.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128293.xml
+++ b/HGV_trans_EpiDoc/128293.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128294.xml
+++ b/HGV_trans_EpiDoc/128294.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128295.xml
+++ b/HGV_trans_EpiDoc/128295.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128297.xml
+++ b/HGV_trans_EpiDoc/128297.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128299.xml
+++ b/HGV_trans_EpiDoc/128299.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128301.xml
+++ b/HGV_trans_EpiDoc/128301.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128302.xml
+++ b/HGV_trans_EpiDoc/128302.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128303.xml
+++ b/HGV_trans_EpiDoc/128303.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128304.xml
+++ b/HGV_trans_EpiDoc/128304.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128305.xml
+++ b/HGV_trans_EpiDoc/128305.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128306.xml
+++ b/HGV_trans_EpiDoc/128306.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128307.xml
+++ b/HGV_trans_EpiDoc/128307.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128308.xml
+++ b/HGV_trans_EpiDoc/128308.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128309.xml
+++ b/HGV_trans_EpiDoc/128309.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128310.xml
+++ b/HGV_trans_EpiDoc/128310.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128311.xml
+++ b/HGV_trans_EpiDoc/128311.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128312.xml
+++ b/HGV_trans_EpiDoc/128312.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128313.xml
+++ b/HGV_trans_EpiDoc/128313.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128314.xml
+++ b/HGV_trans_EpiDoc/128314.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128315.xml
+++ b/HGV_trans_EpiDoc/128315.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128316.xml
+++ b/HGV_trans_EpiDoc/128316.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128317.xml
+++ b/HGV_trans_EpiDoc/128317.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128318.xml
+++ b/HGV_trans_EpiDoc/128318.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128321.xml
+++ b/HGV_trans_EpiDoc/128321.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128322.xml
+++ b/HGV_trans_EpiDoc/128322.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128323.xml
+++ b/HGV_trans_EpiDoc/128323.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128324.xml
+++ b/HGV_trans_EpiDoc/128324.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128325.xml
+++ b/HGV_trans_EpiDoc/128325.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128352.xml
+++ b/HGV_trans_EpiDoc/128352.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128642.xml
+++ b/HGV_trans_EpiDoc/128642.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128646.xml
+++ b/HGV_trans_EpiDoc/128646.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128648.xml
+++ b/HGV_trans_EpiDoc/128648.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128649.xml
+++ b/HGV_trans_EpiDoc/128649.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128650.xml
+++ b/HGV_trans_EpiDoc/128650.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128651.xml
+++ b/HGV_trans_EpiDoc/128651.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128659.xml
+++ b/HGV_trans_EpiDoc/128659.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128660.xml
+++ b/HGV_trans_EpiDoc/128660.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128661.xml
+++ b/HGV_trans_EpiDoc/128661.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128666.xml
+++ b/HGV_trans_EpiDoc/128666.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128667.xml
+++ b/HGV_trans_EpiDoc/128667.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128668.xml
+++ b/HGV_trans_EpiDoc/128668.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128669.xml
+++ b/HGV_trans_EpiDoc/128669.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128677.xml
+++ b/HGV_trans_EpiDoc/128677.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128681.xml
+++ b/HGV_trans_EpiDoc/128681.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128699.xml
+++ b/HGV_trans_EpiDoc/128699.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128891.xml
+++ b/HGV_trans_EpiDoc/128891.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128892.xml
+++ b/HGV_trans_EpiDoc/128892.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128893.xml
+++ b/HGV_trans_EpiDoc/128893.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128894.xml
+++ b/HGV_trans_EpiDoc/128894.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128895.xml
+++ b/HGV_trans_EpiDoc/128895.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128896.xml
+++ b/HGV_trans_EpiDoc/128896.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128897.xml
+++ b/HGV_trans_EpiDoc/128897.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128898.xml
+++ b/HGV_trans_EpiDoc/128898.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128900.xml
+++ b/HGV_trans_EpiDoc/128900.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128901.xml
+++ b/HGV_trans_EpiDoc/128901.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128902.xml
+++ b/HGV_trans_EpiDoc/128902.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128903.xml
+++ b/HGV_trans_EpiDoc/128903.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128904.xml
+++ b/HGV_trans_EpiDoc/128904.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128905.xml
+++ b/HGV_trans_EpiDoc/128905.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/128906.xml
+++ b/HGV_trans_EpiDoc/128906.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12899.xml
+++ b/HGV_trans_EpiDoc/12899.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12900.xml
+++ b/HGV_trans_EpiDoc/12900.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12901.xml
+++ b/HGV_trans_EpiDoc/12901.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12902.xml
+++ b/HGV_trans_EpiDoc/12902.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12903.xml
+++ b/HGV_trans_EpiDoc/12903.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12907.xml
+++ b/HGV_trans_EpiDoc/12907.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12911.xml
+++ b/HGV_trans_EpiDoc/12911.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12912.xml
+++ b/HGV_trans_EpiDoc/12912.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12913.xml
+++ b/HGV_trans_EpiDoc/12913.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12914.xml
+++ b/HGV_trans_EpiDoc/12914.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12915.xml
+++ b/HGV_trans_EpiDoc/12915.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12916.xml
+++ b/HGV_trans_EpiDoc/12916.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12917.xml
+++ b/HGV_trans_EpiDoc/12917.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12918.xml
+++ b/HGV_trans_EpiDoc/12918.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12919.xml
+++ b/HGV_trans_EpiDoc/12919.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12920.xml
+++ b/HGV_trans_EpiDoc/12920.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12921.xml
+++ b/HGV_trans_EpiDoc/12921.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12922.xml
+++ b/HGV_trans_EpiDoc/12922.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12923.xml
+++ b/HGV_trans_EpiDoc/12923.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12924.xml
+++ b/HGV_trans_EpiDoc/12924.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12925.xml
+++ b/HGV_trans_EpiDoc/12925.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12926.xml
+++ b/HGV_trans_EpiDoc/12926.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12927.xml
+++ b/HGV_trans_EpiDoc/12927.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12928.xml
+++ b/HGV_trans_EpiDoc/12928.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12929.xml
+++ b/HGV_trans_EpiDoc/12929.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12930.xml
+++ b/HGV_trans_EpiDoc/12930.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12931.xml
+++ b/HGV_trans_EpiDoc/12931.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12932.xml
+++ b/HGV_trans_EpiDoc/12932.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12933.xml
+++ b/HGV_trans_EpiDoc/12933.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12934.xml
+++ b/HGV_trans_EpiDoc/12934.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12935.xml
+++ b/HGV_trans_EpiDoc/12935.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12936.xml
+++ b/HGV_trans_EpiDoc/12936.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12937.xml
+++ b/HGV_trans_EpiDoc/12937.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12938.xml
+++ b/HGV_trans_EpiDoc/12938.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12939.xml
+++ b/HGV_trans_EpiDoc/12939.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12940.xml
+++ b/HGV_trans_EpiDoc/12940.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12941.xml
+++ b/HGV_trans_EpiDoc/12941.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12949.xml
+++ b/HGV_trans_EpiDoc/12949.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12950.xml
+++ b/HGV_trans_EpiDoc/12950.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12951.xml
+++ b/HGV_trans_EpiDoc/12951.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12952.xml
+++ b/HGV_trans_EpiDoc/12952.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12953.xml
+++ b/HGV_trans_EpiDoc/12953.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12954.xml
+++ b/HGV_trans_EpiDoc/12954.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12955.xml
+++ b/HGV_trans_EpiDoc/12955.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12956.xml
+++ b/HGV_trans_EpiDoc/12956.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12957.xml
+++ b/HGV_trans_EpiDoc/12957.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12958.xml
+++ b/HGV_trans_EpiDoc/12958.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12959.xml
+++ b/HGV_trans_EpiDoc/12959.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12960.xml
+++ b/HGV_trans_EpiDoc/12960.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12961.xml
+++ b/HGV_trans_EpiDoc/12961.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12962.xml
+++ b/HGV_trans_EpiDoc/12962.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12963.xml
+++ b/HGV_trans_EpiDoc/12963.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12965.xml
+++ b/HGV_trans_EpiDoc/12965.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12966.xml
+++ b/HGV_trans_EpiDoc/12966.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12967.xml
+++ b/HGV_trans_EpiDoc/12967.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12968.xml
+++ b/HGV_trans_EpiDoc/12968.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12970a.xml
+++ b/HGV_trans_EpiDoc/12970a.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12971.xml
+++ b/HGV_trans_EpiDoc/12971.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12972.xml
+++ b/HGV_trans_EpiDoc/12972.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12973.xml
+++ b/HGV_trans_EpiDoc/12973.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12974.xml
+++ b/HGV_trans_EpiDoc/12974.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12977.xml
+++ b/HGV_trans_EpiDoc/12977.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12978.xml
+++ b/HGV_trans_EpiDoc/12978.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/129783.xml
+++ b/HGV_trans_EpiDoc/129783.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12979.xml
+++ b/HGV_trans_EpiDoc/12979.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/129793.xml
+++ b/HGV_trans_EpiDoc/129793.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12980.xml
+++ b/HGV_trans_EpiDoc/12980.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/129809.xml
+++ b/HGV_trans_EpiDoc/129809.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/12981.xml
+++ b/HGV_trans_EpiDoc/12981.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/129892.xml
+++ b/HGV_trans_EpiDoc/129892.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13006.xml
+++ b/HGV_trans_EpiDoc/13006.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13007.xml
+++ b/HGV_trans_EpiDoc/13007.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13008.xml
+++ b/HGV_trans_EpiDoc/13008.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13009.xml
+++ b/HGV_trans_EpiDoc/13009.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13010.xml
+++ b/HGV_trans_EpiDoc/13010.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13011.xml
+++ b/HGV_trans_EpiDoc/13011.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13017.xml
+++ b/HGV_trans_EpiDoc/13017.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13020.xml
+++ b/HGV_trans_EpiDoc/13020.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13021.xml
+++ b/HGV_trans_EpiDoc/13021.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13023.xml
+++ b/HGV_trans_EpiDoc/13023.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13051.xml
+++ b/HGV_trans_EpiDoc/13051.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13054.xml
+++ b/HGV_trans_EpiDoc/13054.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13060.xml
+++ b/HGV_trans_EpiDoc/13060.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131056.xml
+++ b/HGV_trans_EpiDoc/131056.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131058.xml
+++ b/HGV_trans_EpiDoc/131058.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131068.xml
+++ b/HGV_trans_EpiDoc/131068.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131295.xml
+++ b/HGV_trans_EpiDoc/131295.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131306.xml
+++ b/HGV_trans_EpiDoc/131306.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131338.xml
+++ b/HGV_trans_EpiDoc/131338.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131341.xml
+++ b/HGV_trans_EpiDoc/131341.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131361.xml
+++ b/HGV_trans_EpiDoc/131361.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131365.xml
+++ b/HGV_trans_EpiDoc/131365.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131369.xml
+++ b/HGV_trans_EpiDoc/131369.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131374.xml
+++ b/HGV_trans_EpiDoc/131374.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131378.xml
+++ b/HGV_trans_EpiDoc/131378.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/131405.xml
+++ b/HGV_trans_EpiDoc/131405.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13572.xml
+++ b/HGV_trans_EpiDoc/13572.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/13802.xml
+++ b/HGV_trans_EpiDoc/13802.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140873.xml
+++ b/HGV_trans_EpiDoc/140873.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140891.xml
+++ b/HGV_trans_EpiDoc/140891.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140892.xml
+++ b/HGV_trans_EpiDoc/140892.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140893.xml
+++ b/HGV_trans_EpiDoc/140893.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140895.xml
+++ b/HGV_trans_EpiDoc/140895.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140896.xml
+++ b/HGV_trans_EpiDoc/140896.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140897.xml
+++ b/HGV_trans_EpiDoc/140897.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140898.xml
+++ b/HGV_trans_EpiDoc/140898.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140899.xml
+++ b/HGV_trans_EpiDoc/140899.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140900.xml
+++ b/HGV_trans_EpiDoc/140900.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140901.xml
+++ b/HGV_trans_EpiDoc/140901.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140902.xml
+++ b/HGV_trans_EpiDoc/140902.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140903.xml
+++ b/HGV_trans_EpiDoc/140903.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140904.xml
+++ b/HGV_trans_EpiDoc/140904.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140905.xml
+++ b/HGV_trans_EpiDoc/140905.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140906.xml
+++ b/HGV_trans_EpiDoc/140906.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140907.xml
+++ b/HGV_trans_EpiDoc/140907.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140908.xml
+++ b/HGV_trans_EpiDoc/140908.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140909.xml
+++ b/HGV_trans_EpiDoc/140909.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140910.xml
+++ b/HGV_trans_EpiDoc/140910.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140912.xml
+++ b/HGV_trans_EpiDoc/140912.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140913.xml
+++ b/HGV_trans_EpiDoc/140913.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140914.xml
+++ b/HGV_trans_EpiDoc/140914.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/140915.xml
+++ b/HGV_trans_EpiDoc/140915.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/142605.xml
+++ b/HGV_trans_EpiDoc/142605.xml
@@ -24,13 +24,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
+                <language ident="fr">French</language>
                 <language ident="en">English</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/14265.xml
+++ b/HGV_trans_EpiDoc/14265.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/143371.xml
+++ b/HGV_trans_EpiDoc/143371.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/15150.xml
+++ b/HGV_trans_EpiDoc/15150.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/1517.xml
+++ b/HGV_trans_EpiDoc/1517.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/1539.xml
+++ b/HGV_trans_EpiDoc/1539.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/156830.xml
+++ b/HGV_trans_EpiDoc/156830.xml
@@ -23,13 +23,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
+                <language ident="fr">French</language>
                 <language ident="en">English</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/15701.xml
+++ b/HGV_trans_EpiDoc/15701.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/1607.xml
+++ b/HGV_trans_EpiDoc/1607.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/16583.xml
+++ b/HGV_trans_EpiDoc/16583.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/169816.xml
+++ b/HGV_trans_EpiDoc/169816.xml
@@ -24,12 +24,12 @@
       <profileDesc>
          <langUsage>
             <language ident="fr">French</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/16998.xml
+++ b/HGV_trans_EpiDoc/16998.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/17306.xml
+++ b/HGV_trans_EpiDoc/17306.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/17307a.xml
+++ b/HGV_trans_EpiDoc/17307a.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/17308.xml
+++ b/HGV_trans_EpiDoc/17308.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/17309.xml
+++ b/HGV_trans_EpiDoc/17309.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/17320.xml
+++ b/HGV_trans_EpiDoc/17320.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/17322.xml
+++ b/HGV_trans_EpiDoc/17322.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/17375.xml
+++ b/HGV_trans_EpiDoc/17375.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/17627.xml
+++ b/HGV_trans_EpiDoc/17627.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/18048.xml
+++ b/HGV_trans_EpiDoc/18048.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/18393.xml
+++ b/HGV_trans_EpiDoc/18393.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/18465.xml
+++ b/HGV_trans_EpiDoc/18465.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/18471.xml
+++ b/HGV_trans_EpiDoc/18471.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/18475.xml
+++ b/HGV_trans_EpiDoc/18475.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/18493.xml
+++ b/HGV_trans_EpiDoc/18493.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/18498.xml
+++ b/HGV_trans_EpiDoc/18498.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/18499.xml
+++ b/HGV_trans_EpiDoc/18499.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/18548.xml
+++ b/HGV_trans_EpiDoc/18548.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/18820.xml
+++ b/HGV_trans_EpiDoc/18820.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/18869.xml
+++ b/HGV_trans_EpiDoc/18869.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19341.xml
+++ b/HGV_trans_EpiDoc/19341.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/19436.xml
+++ b/HGV_trans_EpiDoc/19436.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19485.xml
+++ b/HGV_trans_EpiDoc/19485.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19486.xml
+++ b/HGV_trans_EpiDoc/19486.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19487.xml
+++ b/HGV_trans_EpiDoc/19487.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19490.xml
+++ b/HGV_trans_EpiDoc/19490.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19492.xml
+++ b/HGV_trans_EpiDoc/19492.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19494.xml
+++ b/HGV_trans_EpiDoc/19494.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19495.xml
+++ b/HGV_trans_EpiDoc/19495.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19496.xml
+++ b/HGV_trans_EpiDoc/19496.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19497.xml
+++ b/HGV_trans_EpiDoc/19497.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19498.xml
+++ b/HGV_trans_EpiDoc/19498.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19499.xml
+++ b/HGV_trans_EpiDoc/19499.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19500.xml
+++ b/HGV_trans_EpiDoc/19500.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19502.xml
+++ b/HGV_trans_EpiDoc/19502.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19505.xml
+++ b/HGV_trans_EpiDoc/19505.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19506.xml
+++ b/HGV_trans_EpiDoc/19506.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19507.xml
+++ b/HGV_trans_EpiDoc/19507.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19508.xml
+++ b/HGV_trans_EpiDoc/19508.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19511.xml
+++ b/HGV_trans_EpiDoc/19511.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19512.xml
+++ b/HGV_trans_EpiDoc/19512.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19513.xml
+++ b/HGV_trans_EpiDoc/19513.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19514.xml
+++ b/HGV_trans_EpiDoc/19514.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19515.xml
+++ b/HGV_trans_EpiDoc/19515.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19516.xml
+++ b/HGV_trans_EpiDoc/19516.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19517.xml
+++ b/HGV_trans_EpiDoc/19517.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19518.xml
+++ b/HGV_trans_EpiDoc/19518.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19519.xml
+++ b/HGV_trans_EpiDoc/19519.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19520.xml
+++ b/HGV_trans_EpiDoc/19520.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19521.xml
+++ b/HGV_trans_EpiDoc/19521.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19523.xml
+++ b/HGV_trans_EpiDoc/19523.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19525.xml
+++ b/HGV_trans_EpiDoc/19525.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19526.xml
+++ b/HGV_trans_EpiDoc/19526.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19527.xml
+++ b/HGV_trans_EpiDoc/19527.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19528.xml
+++ b/HGV_trans_EpiDoc/19528.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19531.xml
+++ b/HGV_trans_EpiDoc/19531.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/19979.xml
+++ b/HGV_trans_EpiDoc/19979.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
                 <language ident="it">Italian</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/20419.xml
+++ b/HGV_trans_EpiDoc/20419.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/20582.xml
+++ b/HGV_trans_EpiDoc/20582.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/20583.xml
+++ b/HGV_trans_EpiDoc/20583.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/20584.xml
+++ b/HGV_trans_EpiDoc/20584.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/20585.xml
+++ b/HGV_trans_EpiDoc/20585.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/20586.xml
+++ b/HGV_trans_EpiDoc/20586.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/20655.xml
+++ b/HGV_trans_EpiDoc/20655.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/20696.xml
+++ b/HGV_trans_EpiDoc/20696.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/20718.xml
+++ b/HGV_trans_EpiDoc/20718.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/20821.xml
+++ b/HGV_trans_EpiDoc/20821.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/20962.xml
+++ b/HGV_trans_EpiDoc/20962.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2106.xml
+++ b/HGV_trans_EpiDoc/2106.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/21069.xml
+++ b/HGV_trans_EpiDoc/21069.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2116.xml
+++ b/HGV_trans_EpiDoc/2116.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/21583.xml
+++ b/HGV_trans_EpiDoc/21583.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/21867.xml
+++ b/HGV_trans_EpiDoc/21867.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/21868.xml
+++ b/HGV_trans_EpiDoc/21868.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/219247.xml
+++ b/HGV_trans_EpiDoc/219247.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/220183.xml
+++ b/HGV_trans_EpiDoc/220183.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/220189.xml
+++ b/HGV_trans_EpiDoc/220189.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2229.xml
+++ b/HGV_trans_EpiDoc/2229.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/22505.xml
+++ b/HGV_trans_EpiDoc/22505.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/22900.xml
+++ b/HGV_trans_EpiDoc/22900.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/23022.xml
+++ b/HGV_trans_EpiDoc/23022.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2410.xml
+++ b/HGV_trans_EpiDoc/2410.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2411.xml
+++ b/HGV_trans_EpiDoc/2411.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2413.xml
+++ b/HGV_trans_EpiDoc/2413.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/24132.xml
+++ b/HGV_trans_EpiDoc/24132.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2414.xml
+++ b/HGV_trans_EpiDoc/2414.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2415.xml
+++ b/HGV_trans_EpiDoc/2415.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2416.xml
+++ b/HGV_trans_EpiDoc/2416.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2417.xml
+++ b/HGV_trans_EpiDoc/2417.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2418.xml
+++ b/HGV_trans_EpiDoc/2418.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2419.xml
+++ b/HGV_trans_EpiDoc/2419.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2420.xml
+++ b/HGV_trans_EpiDoc/2420.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2422.xml
+++ b/HGV_trans_EpiDoc/2422.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2423.xml
+++ b/HGV_trans_EpiDoc/2423.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2424.xml
+++ b/HGV_trans_EpiDoc/2424.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2425.xml
+++ b/HGV_trans_EpiDoc/2425.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2427.xml
+++ b/HGV_trans_EpiDoc/2427.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/244062.xml
+++ b/HGV_trans_EpiDoc/244062.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/24740.xml
+++ b/HGV_trans_EpiDoc/24740.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/24834.xml
+++ b/HGV_trans_EpiDoc/24834.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/24849.xml
+++ b/HGV_trans_EpiDoc/24849.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25083.xml
+++ b/HGV_trans_EpiDoc/25083.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25160.xml
+++ b/HGV_trans_EpiDoc/25160.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25301.xml
+++ b/HGV_trans_EpiDoc/25301.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25302.xml
+++ b/HGV_trans_EpiDoc/25302.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25385.xml
+++ b/HGV_trans_EpiDoc/25385.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25423.xml
+++ b/HGV_trans_EpiDoc/25423.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25464.xml
+++ b/HGV_trans_EpiDoc/25464.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25465.xml
+++ b/HGV_trans_EpiDoc/25465.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25469.xml
+++ b/HGV_trans_EpiDoc/25469.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25471.xml
+++ b/HGV_trans_EpiDoc/25471.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25608.xml
+++ b/HGV_trans_EpiDoc/25608.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/25611.xml
+++ b/HGV_trans_EpiDoc/25611.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/26673.xml
+++ b/HGV_trans_EpiDoc/26673.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27119.xml
+++ b/HGV_trans_EpiDoc/27119.xml
@@ -25,12 +25,12 @@
       <profileDesc>
          <langUsage>
             <language ident="fr">French</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/27329.xml
+++ b/HGV_trans_EpiDoc/27329.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27638.xml
+++ b/HGV_trans_EpiDoc/27638.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
+                <language ident="fr">French</language>
                 <language ident="en">English</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/27728.xml
+++ b/HGV_trans_EpiDoc/27728.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27880.xml
+++ b/HGV_trans_EpiDoc/27880.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27881.xml
+++ b/HGV_trans_EpiDoc/27881.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27883.xml
+++ b/HGV_trans_EpiDoc/27883.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27889.xml
+++ b/HGV_trans_EpiDoc/27889.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27890.xml
+++ b/HGV_trans_EpiDoc/27890.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27896.xml
+++ b/HGV_trans_EpiDoc/27896.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27903.xml
+++ b/HGV_trans_EpiDoc/27903.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27904.xml
+++ b/HGV_trans_EpiDoc/27904.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27905.xml
+++ b/HGV_trans_EpiDoc/27905.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/27907.xml
+++ b/HGV_trans_EpiDoc/27907.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/28357.xml
+++ b/HGV_trans_EpiDoc/28357.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/28950.xml
+++ b/HGV_trans_EpiDoc/28950.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/28963.xml
+++ b/HGV_trans_EpiDoc/28963.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/28964.xml
+++ b/HGV_trans_EpiDoc/28964.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/28965.xml
+++ b/HGV_trans_EpiDoc/28965.xml
@@ -24,13 +24,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/28966.xml
+++ b/HGV_trans_EpiDoc/28966.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/28967.xml
+++ b/HGV_trans_EpiDoc/28967.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/29815.xml
+++ b/HGV_trans_EpiDoc/29815.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/2982.xml
+++ b/HGV_trans_EpiDoc/2982.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/30319.xml
+++ b/HGV_trans_EpiDoc/30319.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/30583.xml
+++ b/HGV_trans_EpiDoc/30583.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/30585.xml
+++ b/HGV_trans_EpiDoc/30585.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/30795.xml
+++ b/HGV_trans_EpiDoc/30795.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/3093.xml
+++ b/HGV_trans_EpiDoc/3093.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/30999.xml
+++ b/HGV_trans_EpiDoc/30999.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31156.xml
+++ b/HGV_trans_EpiDoc/31156.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31157.xml
+++ b/HGV_trans_EpiDoc/31157.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31158.xml
+++ b/HGV_trans_EpiDoc/31158.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31160.xml
+++ b/HGV_trans_EpiDoc/31160.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31161.xml
+++ b/HGV_trans_EpiDoc/31161.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31164.xml
+++ b/HGV_trans_EpiDoc/31164.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31166.xml
+++ b/HGV_trans_EpiDoc/31166.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31169.xml
+++ b/HGV_trans_EpiDoc/31169.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31171.xml
+++ b/HGV_trans_EpiDoc/31171.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31172.xml
+++ b/HGV_trans_EpiDoc/31172.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31173.xml
+++ b/HGV_trans_EpiDoc/31173.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31174.xml
+++ b/HGV_trans_EpiDoc/31174.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31236.xml
+++ b/HGV_trans_EpiDoc/31236.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31327.xml
+++ b/HGV_trans_EpiDoc/31327.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/316215a.xml
+++ b/HGV_trans_EpiDoc/316215a.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/316215b.xml
+++ b/HGV_trans_EpiDoc/316215b.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/316245.xml
+++ b/HGV_trans_EpiDoc/316245.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/316247.xml
+++ b/HGV_trans_EpiDoc/316247.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/316248.xml
+++ b/HGV_trans_EpiDoc/316248.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/316249.xml
+++ b/HGV_trans_EpiDoc/316249.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/316250.xml
+++ b/HGV_trans_EpiDoc/316250.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/316254.xml
+++ b/HGV_trans_EpiDoc/316254.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/316256.xml
+++ b/HGV_trans_EpiDoc/316256.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31715.xml
+++ b/HGV_trans_EpiDoc/31715.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/31716.xml
+++ b/HGV_trans_EpiDoc/31716.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/3214.xml
+++ b/HGV_trans_EpiDoc/3214.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/32762.xml
+++ b/HGV_trans_EpiDoc/32762.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/3300.xml
+++ b/HGV_trans_EpiDoc/3300.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/3347.xml
+++ b/HGV_trans_EpiDoc/3347.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/3354.xml
+++ b/HGV_trans_EpiDoc/3354.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/3358.xml
+++ b/HGV_trans_EpiDoc/3358.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/3396.xml
+++ b/HGV_trans_EpiDoc/3396.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/3398.xml
+++ b/HGV_trans_EpiDoc/3398.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/341716.xml
+++ b/HGV_trans_EpiDoc/341716.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/3498.xml
+++ b/HGV_trans_EpiDoc/3498.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/35075.xml
+++ b/HGV_trans_EpiDoc/35075.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/35180.xml
+++ b/HGV_trans_EpiDoc/35180.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/36148.xml
+++ b/HGV_trans_EpiDoc/36148.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/36154.xml
+++ b/HGV_trans_EpiDoc/36154.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/36221.xml
+++ b/HGV_trans_EpiDoc/36221.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/36571.xml
+++ b/HGV_trans_EpiDoc/36571.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/381302.xml
+++ b/HGV_trans_EpiDoc/381302.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/382520.xml
+++ b/HGV_trans_EpiDoc/382520.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/382534.xml
+++ b/HGV_trans_EpiDoc/382534.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/383469.xml
+++ b/HGV_trans_EpiDoc/383469.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/38477.xml
+++ b/HGV_trans_EpiDoc/38477.xml
@@ -24,12 +24,12 @@
       <profileDesc>
          <langUsage>
             <language ident="fr">French</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/38688.xml
+++ b/HGV_trans_EpiDoc/38688.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/38781.xml
+++ b/HGV_trans_EpiDoc/38781.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/388477.xml
+++ b/HGV_trans_EpiDoc/388477.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/388486.xml
+++ b/HGV_trans_EpiDoc/388486.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/388495.xml
+++ b/HGV_trans_EpiDoc/388495.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/388499.xml
+++ b/HGV_trans_EpiDoc/388499.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/39584.xml
+++ b/HGV_trans_EpiDoc/39584.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/40940.xml
+++ b/HGV_trans_EpiDoc/40940.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/40942.xml
+++ b/HGV_trans_EpiDoc/40942.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/40986.xml
+++ b/HGV_trans_EpiDoc/40986.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/4127.xml
+++ b/HGV_trans_EpiDoc/4127.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/41569.xml
+++ b/HGV_trans_EpiDoc/41569.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/4174.xml
+++ b/HGV_trans_EpiDoc/4174.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/4274.xml
+++ b/HGV_trans_EpiDoc/4274.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/42855.xml
+++ b/HGV_trans_EpiDoc/42855.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/4308.xml
+++ b/HGV_trans_EpiDoc/4308.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/43304.xml
+++ b/HGV_trans_EpiDoc/43304.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/4403.xml
+++ b/HGV_trans_EpiDoc/4403.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/4405.xml
+++ b/HGV_trans_EpiDoc/4405.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/44056.xml
+++ b/HGV_trans_EpiDoc/44056.xml
@@ -22,13 +22,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/44149.xml
+++ b/HGV_trans_EpiDoc/44149.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/44538.xml
+++ b/HGV_trans_EpiDoc/44538.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/44616.xml
+++ b/HGV_trans_EpiDoc/44616.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/44721.xml
+++ b/HGV_trans_EpiDoc/44721.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>

--- a/HGV_trans_EpiDoc/44722.xml
+++ b/HGV_trans_EpiDoc/44722.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/44723.xml
+++ b/HGV_trans_EpiDoc/44723.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/45257.xml
+++ b/HGV_trans_EpiDoc/45257.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/45636.xml
+++ b/HGV_trans_EpiDoc/45636.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/4592.xml
+++ b/HGV_trans_EpiDoc/4592.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/47288.xml
+++ b/HGV_trans_EpiDoc/47288.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/47335.xml
+++ b/HGV_trans_EpiDoc/47335.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/47336.xml
+++ b/HGV_trans_EpiDoc/47336.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/4854.xml
+++ b/HGV_trans_EpiDoc/4854.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/4865.xml
+++ b/HGV_trans_EpiDoc/4865.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/48811.xml
+++ b/HGV_trans_EpiDoc/48811.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/48812.xml
+++ b/HGV_trans_EpiDoc/48812.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/48814.xml
+++ b/HGV_trans_EpiDoc/48814.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/48815.xml
+++ b/HGV_trans_EpiDoc/48815.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/4934.xml
+++ b/HGV_trans_EpiDoc/4934.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/495487.xml
+++ b/HGV_trans_EpiDoc/495487.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/495488.xml
+++ b/HGV_trans_EpiDoc/495488.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/495489.xml
+++ b/HGV_trans_EpiDoc/495489.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/5021.xml
+++ b/HGV_trans_EpiDoc/5021.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5041.xml
+++ b/HGV_trans_EpiDoc/5041.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5048.xml
+++ b/HGV_trans_EpiDoc/5048.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5139.xml
+++ b/HGV_trans_EpiDoc/5139.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5183.xml
+++ b/HGV_trans_EpiDoc/5183.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5233.xml
+++ b/HGV_trans_EpiDoc/5233.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5235.xml
+++ b/HGV_trans_EpiDoc/5235.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5284.xml
+++ b/HGV_trans_EpiDoc/5284.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5285.xml
+++ b/HGV_trans_EpiDoc/5285.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5286.xml
+++ b/HGV_trans_EpiDoc/5286.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5287.xml
+++ b/HGV_trans_EpiDoc/5287.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5291.xml
+++ b/HGV_trans_EpiDoc/5291.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5297.xml
+++ b/HGV_trans_EpiDoc/5297.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5298.xml
+++ b/HGV_trans_EpiDoc/5298.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/53.xml
+++ b/HGV_trans_EpiDoc/53.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5300.xml
+++ b/HGV_trans_EpiDoc/5300.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5301.xml
+++ b/HGV_trans_EpiDoc/5301.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5304.xml
+++ b/HGV_trans_EpiDoc/5304.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5594.xml
+++ b/HGV_trans_EpiDoc/5594.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5636.xml
+++ b/HGV_trans_EpiDoc/5636.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5641.xml
+++ b/HGV_trans_EpiDoc/5641.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5794.xml
+++ b/HGV_trans_EpiDoc/5794.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5830.xml
+++ b/HGV_trans_EpiDoc/5830.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/5836.xml
+++ b/HGV_trans_EpiDoc/5836.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/58459.xml
+++ b/HGV_trans_EpiDoc/58459.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/6236.xml
+++ b/HGV_trans_EpiDoc/6236.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/62391.xml
+++ b/HGV_trans_EpiDoc/62391.xml
@@ -24,13 +24,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/62411.xml
+++ b/HGV_trans_EpiDoc/62411.xml
@@ -24,13 +24,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/62419.xml
+++ b/HGV_trans_EpiDoc/62419.xml
@@ -24,13 +24,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
             <language ident="es">Spanish</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/62481.xml
+++ b/HGV_trans_EpiDoc/62481.xml
@@ -24,13 +24,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/62505.xml
+++ b/HGV_trans_EpiDoc/62505.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/63992.xml
+++ b/HGV_trans_EpiDoc/63992.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/641764.xml
+++ b/HGV_trans_EpiDoc/641764.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/641821.xml
+++ b/HGV_trans_EpiDoc/641821.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/64339.xml
+++ b/HGV_trans_EpiDoc/64339.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/64449.xml
+++ b/HGV_trans_EpiDoc/64449.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/64999.xml
+++ b/HGV_trans_EpiDoc/64999.xml
@@ -24,13 +24,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/65047.xml
+++ b/HGV_trans_EpiDoc/65047.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/65627a.xml
+++ b/HGV_trans_EpiDoc/65627a.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/693.xml
+++ b/HGV_trans_EpiDoc/693.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/701140.xml
+++ b/HGV_trans_EpiDoc/701140.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/703274.xml
+++ b/HGV_trans_EpiDoc/703274.xml
@@ -24,13 +24,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/703275.xml
+++ b/HGV_trans_EpiDoc/703275.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/703276.xml
+++ b/HGV_trans_EpiDoc/703276.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/703277.xml
+++ b/HGV_trans_EpiDoc/703277.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/706233.xml
+++ b/HGV_trans_EpiDoc/706233.xml
@@ -25,11 +25,11 @@
          <langUsage>
             <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/7306.xml
+++ b/HGV_trans_EpiDoc/7306.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/73151.xml
+++ b/HGV_trans_EpiDoc/73151.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/73152.xml
+++ b/HGV_trans_EpiDoc/73152.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/73153.xml
+++ b/HGV_trans_EpiDoc/73153.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/73154.xml
+++ b/HGV_trans_EpiDoc/73154.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/73168.xml
+++ b/HGV_trans_EpiDoc/73168.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/73175.xml
+++ b/HGV_trans_EpiDoc/73175.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/73182.xml
+++ b/HGV_trans_EpiDoc/73182.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
+                <language ident="fr">French</language>
                 <language ident="en">English</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>

--- a/HGV_trans_EpiDoc/7324.xml
+++ b/HGV_trans_EpiDoc/7324.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/7325.xml
+++ b/HGV_trans_EpiDoc/7325.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/7434.xml
+++ b/HGV_trans_EpiDoc/7434.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/749359.xml
+++ b/HGV_trans_EpiDoc/749359.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/749360.xml
+++ b/HGV_trans_EpiDoc/749360.xml
@@ -23,13 +23,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
+                <language ident="fr">French</language>
                 <language ident="en">English</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/754948.xml
+++ b/HGV_trans_EpiDoc/754948.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/7559.xml
+++ b/HGV_trans_EpiDoc/7559.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
             <language ident="it">Italian</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/7561.xml
+++ b/HGV_trans_EpiDoc/7561.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
             <language ident="it">Italian</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/75655.xml
+++ b/HGV_trans_EpiDoc/75655.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/75661.xml
+++ b/HGV_trans_EpiDoc/75661.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756864.xml
+++ b/HGV_trans_EpiDoc/756864.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756868.xml
+++ b/HGV_trans_EpiDoc/756868.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756872.xml
+++ b/HGV_trans_EpiDoc/756872.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756875.xml
+++ b/HGV_trans_EpiDoc/756875.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756878.xml
+++ b/HGV_trans_EpiDoc/756878.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756880.xml
+++ b/HGV_trans_EpiDoc/756880.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756883.xml
+++ b/HGV_trans_EpiDoc/756883.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756887.xml
+++ b/HGV_trans_EpiDoc/756887.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756888.xml
+++ b/HGV_trans_EpiDoc/756888.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756889.xml
+++ b/HGV_trans_EpiDoc/756889.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756890.xml
+++ b/HGV_trans_EpiDoc/756890.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/756892.xml
+++ b/HGV_trans_EpiDoc/756892.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/75695.xml
+++ b/HGV_trans_EpiDoc/75695.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/7576.xml
+++ b/HGV_trans_EpiDoc/7576.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
             <language ident="it">Italian</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/7644.xml
+++ b/HGV_trans_EpiDoc/7644.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/7651.xml
+++ b/HGV_trans_EpiDoc/7651.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/78091.xml
+++ b/HGV_trans_EpiDoc/78091.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/78284.xml
+++ b/HGV_trans_EpiDoc/78284.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/78333.xml
+++ b/HGV_trans_EpiDoc/78333.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="de">German</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/78485.xml
+++ b/HGV_trans_EpiDoc/78485.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/7856.xml
+++ b/HGV_trans_EpiDoc/7856.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/78718.xml
+++ b/HGV_trans_EpiDoc/78718.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
             <language ident="it">Italian</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/7883.xml
+++ b/HGV_trans_EpiDoc/7883.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/79.xml
+++ b/HGV_trans_EpiDoc/79.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/7944.xml
+++ b/HGV_trans_EpiDoc/7944.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80117.xml
+++ b/HGV_trans_EpiDoc/80117.xml
@@ -27,13 +27,13 @@ Attribution 3.0 License</ref>.</p>
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="de">German</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/80369.xml
+++ b/HGV_trans_EpiDoc/80369.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80370.xml
+++ b/HGV_trans_EpiDoc/80370.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80374.xml
+++ b/HGV_trans_EpiDoc/80374.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80376.xml
+++ b/HGV_trans_EpiDoc/80376.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80377.xml
+++ b/HGV_trans_EpiDoc/80377.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80468.xml
+++ b/HGV_trans_EpiDoc/80468.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="de">German</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/80483.xml
+++ b/HGV_trans_EpiDoc/80483.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="de">German</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/80492.xml
+++ b/HGV_trans_EpiDoc/80492.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="de">German</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/80493.xml
+++ b/HGV_trans_EpiDoc/80493.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="de">German</language>
             <language ident="de">German</language>
          </langUsage>

--- a/HGV_trans_EpiDoc/80494.xml
+++ b/HGV_trans_EpiDoc/80494.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="de">German</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/80498.xml
+++ b/HGV_trans_EpiDoc/80498.xml
@@ -27,13 +27,13 @@ Attribution 3.0 License</ref>.</p>
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80502.xml
+++ b/HGV_trans_EpiDoc/80502.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="de">German</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/80506.xml
+++ b/HGV_trans_EpiDoc/80506.xml
@@ -27,13 +27,13 @@
 		    </fileDesc>
 		    <profileDesc>
 			      <langUsage>
-				        <language ident="fr">Französisch</language>
-				        <language ident="en">Englisch</language>
-				        <language ident="de">Deutsch</language>
-				        <language ident="it">Italienisch</language>
-				        <language ident="es">Spanisch</language>
-				        <language ident="la">Latein</language>
-				        <language ident="el">Griechisch</language>
+				        <language ident="fr">French</language>
+				        <language ident="en">English</language>
+				        <language ident="de">German</language>
+				        <language ident="it">Italian</language>
+				        <language ident="es">Spanish</language>
+				        <language ident="la">Latin</language>
+				        <language ident="el">Modern Greek</language>
 			      </langUsage>
 		    </profileDesc>
 		    <revisionDesc>

--- a/HGV_trans_EpiDoc/80508.xml
+++ b/HGV_trans_EpiDoc/80508.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80512.xml
+++ b/HGV_trans_EpiDoc/80512.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="de">German</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/80513.xml
+++ b/HGV_trans_EpiDoc/80513.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80514.xml
+++ b/HGV_trans_EpiDoc/80514.xml
@@ -27,13 +27,13 @@ Attribution 3.0 License</ref>.</p>
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80520.xml
+++ b/HGV_trans_EpiDoc/80520.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80522.xml
+++ b/HGV_trans_EpiDoc/80522.xml
@@ -27,13 +27,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80567.xml
+++ b/HGV_trans_EpiDoc/80567.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80726.xml
+++ b/HGV_trans_EpiDoc/80726.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80727.xml
+++ b/HGV_trans_EpiDoc/80727.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80728.xml
+++ b/HGV_trans_EpiDoc/80728.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80729.xml
+++ b/HGV_trans_EpiDoc/80729.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80731.xml
+++ b/HGV_trans_EpiDoc/80731.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80733.xml
+++ b/HGV_trans_EpiDoc/80733.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80740.xml
+++ b/HGV_trans_EpiDoc/80740.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80741.xml
+++ b/HGV_trans_EpiDoc/80741.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80742.xml
+++ b/HGV_trans_EpiDoc/80742.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/80743.xml
+++ b/HGV_trans_EpiDoc/80743.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/8144.xml
+++ b/HGV_trans_EpiDoc/8144.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/818064.xml
+++ b/HGV_trans_EpiDoc/818064.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/8222.xml
+++ b/HGV_trans_EpiDoc/8222.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/869.xml
+++ b/HGV_trans_EpiDoc/869.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/8692.xml
+++ b/HGV_trans_EpiDoc/8692.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/88099.xml
+++ b/HGV_trans_EpiDoc/88099.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/8859.xml
+++ b/HGV_trans_EpiDoc/8859.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/88604.xml
+++ b/HGV_trans_EpiDoc/88604.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/88607.xml
+++ b/HGV_trans_EpiDoc/88607.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/88782.xml
+++ b/HGV_trans_EpiDoc/88782.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/8896.xml
+++ b/HGV_trans_EpiDoc/8896.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/89283.xml
+++ b/HGV_trans_EpiDoc/89283.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/9053.xml
+++ b/HGV_trans_EpiDoc/9053.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/91681.xml
+++ b/HGV_trans_EpiDoc/91681.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/91682.xml
+++ b/HGV_trans_EpiDoc/91682.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/91706.xml
+++ b/HGV_trans_EpiDoc/91706.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/927623.xml
+++ b/HGV_trans_EpiDoc/927623.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/927624.xml
+++ b/HGV_trans_EpiDoc/927624.xml
@@ -24,12 +24,12 @@
       <profileDesc>
          <langUsage>
             <language ident="fr">French</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/927625.xml
+++ b/HGV_trans_EpiDoc/927625.xml
@@ -24,12 +24,12 @@
       <profileDesc>
          <langUsage>
             <language ident="fr">French</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/942763.xml
+++ b/HGV_trans_EpiDoc/942763.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/942765.xml
+++ b/HGV_trans_EpiDoc/942765.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/942766.xml
+++ b/HGV_trans_EpiDoc/942766.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/942773.xml
+++ b/HGV_trans_EpiDoc/942773.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/942774.xml
+++ b/HGV_trans_EpiDoc/942774.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/942777.xml
+++ b/HGV_trans_EpiDoc/942777.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/942778.xml
+++ b/HGV_trans_EpiDoc/942778.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/942781.xml
+++ b/HGV_trans_EpiDoc/942781.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/942783.xml
+++ b/HGV_trans_EpiDoc/942783.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
             <language ident="de">German</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/957987.xml
+++ b/HGV_trans_EpiDoc/957987.xml
@@ -24,12 +24,12 @@
       <profileDesc>
          <langUsage>
             <language ident="fr">French</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/957988.xml
+++ b/HGV_trans_EpiDoc/957988.xml
@@ -24,12 +24,12 @@
       <profileDesc>
          <langUsage>
             <language ident="fr">French</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/957989.xml
+++ b/HGV_trans_EpiDoc/957989.xml
@@ -24,12 +24,12 @@
       <profileDesc>
          <langUsage>
             <language ident="fr">French</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/971734.xml
+++ b/HGV_trans_EpiDoc/971734.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971735.xml
+++ b/HGV_trans_EpiDoc/971735.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971736.xml
+++ b/HGV_trans_EpiDoc/971736.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971738.xml
+++ b/HGV_trans_EpiDoc/971738.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971739.xml
+++ b/HGV_trans_EpiDoc/971739.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971740.xml
+++ b/HGV_trans_EpiDoc/971740.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971741.xml
+++ b/HGV_trans_EpiDoc/971741.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971742.xml
+++ b/HGV_trans_EpiDoc/971742.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971743.xml
+++ b/HGV_trans_EpiDoc/971743.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971744.xml
+++ b/HGV_trans_EpiDoc/971744.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971746.xml
+++ b/HGV_trans_EpiDoc/971746.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971748.xml
+++ b/HGV_trans_EpiDoc/971748.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971750.xml
+++ b/HGV_trans_EpiDoc/971750.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971751.xml
+++ b/HGV_trans_EpiDoc/971751.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971752.xml
+++ b/HGV_trans_EpiDoc/971752.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971753.xml
+++ b/HGV_trans_EpiDoc/971753.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971754.xml
+++ b/HGV_trans_EpiDoc/971754.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971755.xml
+++ b/HGV_trans_EpiDoc/971755.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971756.xml
+++ b/HGV_trans_EpiDoc/971756.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971757.xml
+++ b/HGV_trans_EpiDoc/971757.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971759.xml
+++ b/HGV_trans_EpiDoc/971759.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
-                <language ident="en">Englisch</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="fr">French</language>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971879.xml
+++ b/HGV_trans_EpiDoc/971879.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
+                <language ident="fr">French</language>
                 <language ident="en">English</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/971907.xml
+++ b/HGV_trans_EpiDoc/971907.xml
@@ -22,13 +22,13 @@
         </fileDesc>
         <profileDesc>
             <langUsage>
-                <language ident="fr">Französisch</language>
+                <language ident="fr">French</language>
                 <language ident="en">English</language>
-                <language ident="de">Deutsch</language>
-                <language ident="it">Italienisch</language>
-                <language ident="es">Spanisch</language>
-                <language ident="la">Latein</language>
-                <language ident="el">Griechisch</language>
+                <language ident="de">German</language>
+                <language ident="it">Italian</language>
+                <language ident="es">Spanish</language>
+                <language ident="la">Latin</language>
+                <language ident="el">Modern Greek</language>
                 <language ident="ar">Arabisch</language>
             </langUsage>
         </profileDesc>

--- a/HGV_trans_EpiDoc/97364.xml
+++ b/HGV_trans_EpiDoc/97364.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/9859.xml
+++ b/HGV_trans_EpiDoc/9859.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
+            <language ident="fr">French</language>
             <language ident="en">English</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/99656.xml
+++ b/HGV_trans_EpiDoc/99656.xml
@@ -23,13 +23,13 @@
       </fileDesc>
       <profileDesc>
          <langUsage>
-            <language ident="fr">Französisch</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/HGV_trans_EpiDoc/99858.xml
+++ b/HGV_trans_EpiDoc/99858.xml
@@ -24,12 +24,12 @@
       <profileDesc>
          <langUsage>
             <language ident="fr">French</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>

--- a/HGV_trans_EpiDoc/99863.xml
+++ b/HGV_trans_EpiDoc/99863.xml
@@ -24,12 +24,12 @@
       <profileDesc>
          <langUsage>
             <language ident="fr">French</language>
-            <language ident="en">Englisch</language>
-            <language ident="de">Deutsch</language>
-            <language ident="it">Italienisch</language>
-            <language ident="es">Spanisch</language>
-            <language ident="la">Latein</language>
-            <language ident="el">Griechisch</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
             <language ident="ar">Arabisch</language>
          </langUsage>
       </profileDesc>


### PR DESCRIPTION
As per discussion with Cowey, updating the contents of `<language>` in light of xslt and PN interface, which uses English terminology (i.e. 'translation') for  translations .