### PR TITLE
Various HGV/Biblio/APIS for Johnson ZPE 206 (2018) x2

### DIFF
--- a/APIS/yale/xml/yale.apis.0050440000.xml
+++ b/APIS/yale/xml/yale.apis.0050440000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0050440000</idno>
             <idno type="controlNo">(CtY)5044</idno>
+            <idno type="TM">754940</idno>
+            <idno type="HGV">754940</idno>
+            <idno type="ddb-hybrid">zpe;206;154</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0050580000.xml
+++ b/APIS/yale/xml/yale.apis.0050580000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0050580000</idno>
             <idno type="controlNo">(CtY)5058</idno>
+            <idno type="TM">754941</idno>
+            <idno type="HGV">754941</idno>
+            <idno type="ddb-hybrid">zpe;206;159</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0050590000.xml
+++ b/APIS/yale/xml/yale.apis.0050590000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0050590000</idno>
             <idno type="controlNo">(CtY)5059</idno>
+            <idno type="TM">754942</idno>
+            <idno type="HGV">754942</idno>
+            <idno type="ddb-hybrid">zpe;206;163</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0050600000.xml
+++ b/APIS/yale/xml/yale.apis.0050600000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0050600000</idno>
             <idno type="controlNo">(CtY)5060</idno>
+            <idno type="TM">754943</idno>
+            <idno type="HGV">754943</idno>
+            <idno type="ddb-hybrid">zpe;206;166</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0050610000.xml
+++ b/APIS/yale/xml/yale.apis.0050610000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0050610000</idno>
             <idno type="controlNo">(CtY)5061 qua</idno>
+            <idno type="TM">754944</idno>
+            <idno type="HGV">754944</idno>
+            <idno type="ddb-hybrid">zpe;206;167</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0050620000.xml
+++ b/APIS/yale/xml/yale.apis.0050620000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0050620000</idno>
             <idno type="controlNo">(CtY)5062</idno>
+            <idno type="TM">754945</idno>
+            <idno type="HGV">754945</idno>
+            <idno type="ddb-hybrid">zpe;206;171</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0050630000.xml
+++ b/APIS/yale/xml/yale.apis.0050630000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0050630000</idno>
             <idno type="controlNo">(CtY)5063</idno>
+            <idno type="TM">754946</idno>
+            <idno type="HGV">754946</idno>
+            <idno type="ddb-hybrid">zpe;206;176</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/Biblio/97/96246.xml
+++ b/Biblio/97/96246.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96246" type="article" subtype="journal" xml:lang="en">
+  <title level="a" type="main">Isidora to Apollonia: a Private Letter in the Beinecke Collection (P.CtYBR inv. 5044)</title>
+  <author n="1">
+    <forename>W.A.</forename>
+    <surname>Johnson</surname>
+  </author>
+  <date>2018</date>
+  <biblScope type="pp" from="154" to="156">154-156</biblScope>
+  <relatedItem type="appearsIn" n="1">
+    <bibl>
+      <ptr target="https://papyri.info/biblio/511"/>
+      <!-- ignore - start, i.e. SoSOL users may not edit this -->
+      <!-- ignore - stop -->
+    </bibl>
+  </relatedItem>
+  <biblScope type="issue">206</biblScope>
+  <idno type="pi">96246</idno>
+  <idno type="bp">2018-0139</idno>
+  <seg type="original" subtype="index" resp="#BP">141.4    364 Epistulae</seg>
+  <seg type="original" subtype="indexBis" resp="#BP">141.4 P. Yale Inv. 5044</seg>
+  <seg type="original" subtype="titre" resp="#BP">William A. Johnson, Isidora to Apollonia: a Private Letter in the Beinecke Collection (P.CtYBR inv. 5044).</seg>
+  <seg type="original" subtype="publication" resp="#BP">ZPE 206 (2018) pp. 154-156, fig.</seg>
+  <seg type="original" subtype="resume" resp="#BP">Provenance unknown, 1st c. AD.</seg>
+</bibl>

--- a/HGV_meta_EpiDoc/HGV755/754940.xml
+++ b/HGV_meta_EpiDoc/HGV755/754940.xml
@@ -39,7 +39,7 @@
             </msDesc>
             <listBibl>
                <bibl type="SB">
-                  <ptr target="https://papyri.info/biblio/95897"/>
+                  <ptr target="https://papyri.info/biblio/96246"/>
                   <biblScope type="pp">154</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV755/754941.xml
+++ b/HGV_meta_EpiDoc/HGV755/754941.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition (legal complaint)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">754941</idno>
+        <idno type="TM">754941</idno>
+        <idno type="ddb-filename">zpe.206.159</idno>
+        <idno type="ddb-hybrid">zpe;206;159</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 5058</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+               <origPlace>Herakleopolites, Egypt</origPlace>
+               <origDate notBefore="-0185" notAfter="-0125">ca. 185 - 125 v.Chr.
+                <precision match="../@notBefore" degree="0.5"/>
+               </origDate>
+            </origin>
+            <provenance type="located">
+               <p>
+                  <placeName n="1"
+                             type="ancient"
+                             subtype="nome"
+                             ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+                  <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+               </p>
+            </provenance>
+         </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95897"/>
+            <biblScope type="pp">159</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Antrag</term>
+          <term n="2">Klage</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-11-10" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">ZPE</title>
+            <biblScope type="volume">206</biblScope>
+            <biblScope type="fascicle">(2018)</biblScope>
+            <biblScope type="pages">S. 159</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 160</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="http://hdl.handle.net/10079/digcoll/2768145"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV755/754942.xml
+++ b/HGV_meta_EpiDoc/HGV755/754942.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition (legal complaint)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">754942</idno>
+        <idno type="TM">754942</idno>
+        <idno type="ddb-filename">zpe.206.163</idno>
+        <idno type="ddb-hybrid">zpe;206;163</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 5059</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+                <origPlace>Herakleopolites, Egypt</origPlace>
+                <origDate notBefore="-0225" notAfter="-0176" precision="low">Ende III - Anfang II v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+                <p>
+                   <placeName n="1"
+                              type="ancient"
+                              subtype="nome"
+                              ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+                   <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                </p>
+             </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95897"/>
+            <biblScope type="pp">163</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Antrag</term>
+          <term n="2">Klage</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-11-10" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">ZPE</title>
+            <biblScope type="volume">206</biblScope>
+            <biblScope type="fascicle">(2018)</biblScope>
+            <biblScope type="pages">S. 163</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 162</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="http://hdl.handle.net/10079/digcoll/2768524"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV755/754943.xml
+++ b/HGV_meta_EpiDoc/HGV755/754943.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">754943</idno>
+        <idno type="TM">754943</idno>
+        <idno type="ddb-filename">zpe.206.166</idno>
+        <idno type="ddb-hybrid">zpe;206;166</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 5060</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="-0225" notAfter="-0176" precision="low">Ende III - Anfang II v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95897"/>
+            <biblScope type="pp">166</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Antrag (?)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-11-10" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">ZPE</title>
+            <biblScope type="volume">206</biblScope>
+            <biblScope type="fascicle">(2018)</biblScope>
+            <biblScope type="pages">S. 166</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 166</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="http://hdl.handle.net/10079/digcoll/2768144"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV755/754944.xml
+++ b/HGV_meta_EpiDoc/HGV755/754944.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Official Correspondence</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">754944</idno>
+        <idno type="TM">754944</idno>
+        <idno type="ddb-filename">zpe.206.167</idno>
+        <idno type="ddb-hybrid">zpe;206;167</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 5061 qua</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="-0225" notAfter="-0176" precision="low">Ende III - Anfang II v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="region">Egypt</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95897"/>
+            <biblScope type="pp">167</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Antrag (?)</term>
+          <term n="2">Einwohner</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-11-10" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">ZPE</title>
+            <biblScope type="volume">206</biblScope>
+            <biblScope type="fascicle">(2018)</biblScope>
+            <biblScope type="pages">S. 167</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 168</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="http://hdl.handle.net/10079/digcoll/2768391"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV755/754945.xml
+++ b/HGV_meta_EpiDoc/HGV755/754945.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition to Travel</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">754945</idno>
+        <idno type="TM">754945</idno>
+        <idno type="ddb-filename">zpe.206.171</idno>
+        <idno type="ddb-hybrid">zpe;206;171</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 5062</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+               <origPlace>Ankyropolis ? (Herakleopolites, Egypt)</origPlace>
+               <origDate notBefore="-0225" notAfter="-0176" precision="low">Ende III - Anfang II v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+               <p>
+                  <placeName n="1"
+                             type="ancient"
+                             cert="low"
+                             ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Ankyropolis</placeName>
+                  <placeName n="2"
+                             type="ancient"
+                             subtype="nome"
+                             ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+                  <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+               </p>
+            </provenance>
+         </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95897"/>
+            <biblScope type="pp">171</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Antrag auf Registrierung</term>
+          <term n="2">Deklaration</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-11-10" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">ZPE</title>
+            <biblScope type="volume">206</biblScope>
+            <biblScope type="fascicle">(2018)</biblScope>
+            <biblScope type="pages">S. 171</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 170</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="http://hdl.handle.net/10079/digcoll/2768390"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV755/754946.xml
+++ b/HGV_meta_EpiDoc/HGV755/754946.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Official Correspondence</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">754946</idno>
+        <idno type="TM">754946</idno>
+        <idno type="ddb-filename">zpe.206.176</idno>
+        <idno type="ddb-hybrid">zpe;206;176</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 5063</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+               <origPlace>Arsinoites, Egypt</origPlace>
+               <origDate n="1" xml:id="dateAlternativeX" when="-0209">209 v.Chr.</origDate>
+               <origDate n="2" xml:id="dateAlternativeY" when="-0192">192 v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+               <p>
+                  <placeName n="1"
+                             type="ancient"
+                             subtype="nome"
+                             ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                  <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+               </p>
+            </provenance>
+         </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/95897"/>
+            <biblScope type="pp">176</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Amtliche Korrespondenz in Form einer Enteuxis</term>
+          <term n="2">Brief</term>
+          <term n="3">Entwurf</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2022-11-10" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">ZPE</title>
+            <biblScope type="volume">206</biblScope>
+            <biblScope type="fascicle">(2018)</biblScope>
+            <biblScope type="pages">S. 176</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 174, 175</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="http://hdl.handle.net/10079/digcoll/2768382"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
In the course of Xwalking metadata for Johnson's second article in ZPE 206, I noticed that his first article in that volume was absent from the biblio and that the HGV record for it was pointing incorrectly to the biblio record for his second article. So, I've tidied up that mixup, and have also updated the relevant APIS records for the purposes of aggregation.