### PR TITLE
BASP 59 XWalk w/ APIS

### DIFF
--- a/APIS/michigan/xml/michigan.apis.4035.xml
+++ b/APIS/michigan/xml/michigan.apis.4035.xml
@@ -11,6 +11,9 @@
             <authority>APIS</authority>
             <idno type="apisid">michigan.apis.4035</idno>
             <idno type="controlNo">(MiU)4035</idno>
+            <idno type="TM">397807</idno>
+            <idno type="HGV">397807</idno>
+            <idno type="ddb-hybrid">basp;59;86</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/michigan/xml/michigan.apis.5008.xml
+++ b/APIS/michigan/xml/michigan.apis.5008.xml
@@ -11,6 +11,9 @@
             <authority>APIS</authority>
             <idno type="apisid">michigan.apis.5008</idno>
             <idno type="controlNo">(MiU)5008</idno>
+            <idno type="TM">970989</idno>
+            <idno type="HGV">970989</idno>
+            <idno type="ddb-hybrid">basp;59;132_2</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0003390000.xml
+++ b/APIS/yale/xml/yale.apis.0003390000.xml
@@ -10,6 +10,12 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0003390000</idno>
             <idno type="controlNo">(CtY)339</idno>
+            <idno type="TM">981677</idno>
+            <idno type="TM">981678</idno>
+            <idno type="HGV">981677</idno>
+            <idno type="HGV">981678</idno>
+            <idno type="ddb-hybrid">basp;59;142</idno>
+            <idno type="ddb-hybrid">basp;59;143</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0005720000.xml
+++ b/APIS/yale/xml/yale.apis.0005720000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0005720000</idno>
             <idno type="controlNo">(CtY)572</idno>
+            <idno type="TM">981679</idno>
+            <idno type="HGV">981679</idno>
+            <idno type="ddb-hybrid">basp;59;146</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0014110000.xml
+++ b/APIS/yale/xml/yale.apis.0014110000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0014110000</idno>
             <idno type="controlNo">(CtY)1411</idno>
+            <idno type="TM">981680</idno>
+            <idno type="HGV">981680</idno>
+            <idno type="ddb-hybrid">basp;59;149_1</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/HGV_meta_EpiDoc/HGV381/380799.xml
+++ b/HGV_meta_EpiDoc/HGV381/380799.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A Tax Receipt from Memphis in the British Museum</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">380799</idno>
+        <idno type="TM">380799</idno>
+        <idno type="ddb-filename">basp.59.135</idno>
+        <idno type="ddb-hybrid">basp;59;135</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>London</settlement>
+            </placeName>
+            <collection>British Museum</collection>
+            <idno type="invNo">EA76175</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Memphis (Memphites)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" when="0184">184</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" when="0186">186</origDate>
+            </origin>
+            <provenance type="located">
+                <p>
+                   <placeName n="1"
+                              type="ancient"
+                              ref="https://www.trismegistos.org/place/1344 https://pleiades.stoa.org/places/736963">Memphis</placeName>
+                   <placeName n="2"
+                              type="ancient"
+                              subtype="nome"
+                              ref="https://www.trismegistos.org/place/2714 https://pleiades.stoa.org/places/736964">Memphites</placeName>
+                </p>
+             </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96209"/>
+            <biblScope type="pp">135</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Kopfsteuer</term>
+          <term n="3">Geld</term>
+          <term n="4">Steuer</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 135</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="https://www.britishmuseum.org/collection/object/Y_EA76175"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV398/397807.xml
+++ b/HGV_meta_EpiDoc/HGV398/397807.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>A Repaid Loan from Heron to Heron</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">397807</idno>
+        <idno type="TM">397807</idno>
+        <idno type="ddb-filename">basp.59.86</idno>
+        <idno type="ddb-hybrid">basp;59;86</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ann Arbor</settlement>
+            </placeName>
+            <collection>Michigan University Library</collection>
+            <idno type="invNo">P.Mich. inv. 1330</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theadelpheia (Arsinoites)</origPlace>
+              <origDate when="0106-07-09">9. Juli 106</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2349 https://pleiades.stoa.org/places/737081">Theadelpheia</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96227"/>
+            <biblScope type="pp">86</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Rückzahlung (Darlehen)</term>
+          <term n="3">Heron an Heron</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 86</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 87</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="https://quod.lib.umich.edu/a/apis/x-4035"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype="mentionedDates">
+        <list>
+           <item>
+              <ref>Z. 1-3</ref>
+              <note type="comment">Datum des Darlehens</note>
+              <date type="mentioned" when="0105-03-11">11. März 105<certainty locus="value" given="#dateAlternativeX" degree="1"/>
+              </date>
+           </item>
+        </list>
+     </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873600.xml
+++ b/HGV_meta_EpiDoc/HGV874/873600.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>An Enteuxis Concerning a Dispute over Land Boundaries</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873600</idno>
+        <idno type="TM">873600</idno>
+        <idno type="ddb-filename">basp.59.46</idno>
+        <idno type="ddb-hybrid">basp;59;46</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Austin</settlement>
+            </placeName>
+            <collection>University of Texas</collection>
+            <idno type="invNo">P.Texas inv. 1</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoites</origPlace>
+              <origDate when="-0220-09-18">18. Sept. 220 v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96225"/>
+            <biblScope type="pp">46</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe (Enteuxis)</term>
+          <term n="2">Land</term>
+          <term n="3">Umfrage</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 46</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 47</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV971/970989.xml
+++ b/HGV_meta_EpiDoc/HGV971/970989.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Poll-Tax Receipt</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">970989</idno>
+        <idno type="TM">970989</idno>
+        <idno type="ddb-filename">basp.59.132_2</idno>
+        <idno type="ddb-hybrid">basp;59;132_2</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Ann Arbor</settlement>
+            </placeName>
+            <collection>Michigan University Library</collection>
+            <idno type="invNo">P.Mich. inv. 173</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+               <origPlace>Memphis (Memphites)</origPlace>
+               <origDate notBefore="0177-01-31" notAfter="0179">
+          31. Jan. 177 - 179 (Jahr unsicher)
+          <certainty locus="value" match="../year-from-date(@notBefore)"/>
+               </origDate>
+            </origin>
+            <provenance type="located">
+               <p>
+                  <placeName n="1"
+                             type="ancient"
+                             ref="https://www.trismegistos.org/place/1344 https://pleiades.stoa.org/places/736963">Memphis</placeName>
+                  <placeName n="2"
+                             type="ancient"
+                             subtype="nome"
+                             ref="https://www.trismegistos.org/place/2714 https://pleiades.stoa.org/places/736964">Memphites</placeName>
+               </p>
+            </provenance>
+         </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96208"/>
+            <biblScope type="pp">132</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Kopfsteuer</term>
+          <term n="3">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 132</biblScope>
+            <biblScope type="number">Nr. 2</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 132</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="https://quod.lib.umich.edu/a/apis/x-5008"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981663.xml
+++ b/HGV_meta_EpiDoc/HGV982/981663.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Sublease of Public Land (?)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981663</idno>
+        <idno type="TM">981663</idno>
+        <idno type="ddb-filename">basp.59.68_1</idno>
+        <idno type="ddb-hybrid">basp;59;68_1</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Berkeley</settlement>
+            </placeName>
+            <collection>Bancroft Library</collection>
+            <idno type="invNo">P.Tebt.suppl. 1072</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Tebtynis (Arsinoites)</origPlace>
+              <origDate when="0092-05-29">29. Mai 92</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">Tebtynis</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96226"/>
+            <biblScope type="pp">68</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Afterpacht</term>
+          <term n="2">Land</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 68</biblScope>
+            <biblScope type="number">Nr. 1</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 68</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981664.xml
+++ b/HGV_meta_EpiDoc/HGV982/981664.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Repayment of a Deposit</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981664</idno>
+        <idno type="TM">981664</idno>
+        <idno type="ddb-filename">basp.59.78_3</idno>
+        <idno type="ddb-hybrid">basp;59;78_3</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Berkeley</settlement>
+            </placeName>
+            <collection>Bancroft Library</collection>
+            <idno type="invNo">P.Tebt.suppl. 1073</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Tebtynis (Arsinoites)</origPlace>
+              <origDate when="0134">134</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">Tebtynis</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96226"/>
+            <biblScope type="pp">78</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Rückzahlung (Darlehen)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 78</biblScope>
+            <biblScope type="number">Nr. 3</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 79</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981666.xml
+++ b/HGV_meta_EpiDoc/HGV982/981666.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Sitologos Receipt</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981666</idno>
+        <idno type="TM">981666</idno>
+        <idno type="ddb-filename">basp.59.102_1</idno>
+        <idno type="ddb-hybrid">basp;59;102_1</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>London</settlement>
+            </placeName>
+            <collection>British Library</collection>
+            <idno type="invNo">Papyrus 1979</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+               <history>
+                  <origin>
+                        <origPlace>Tebtynis (Arsinoites)</origPlace>
+                        <origDate when="0133-07-30">30. Juli 133</origDate>
+                  </origin>
+                  <provenance type="located">
+                    <p>
+                        <placeName n="1"
+                                   type="ancient"
+                                   ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">Tebtynis</placeName>
+                        <placeName n="2"
+                                   type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                    </p>
+                  </provenance>
+               </history>
+          
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96207"/>
+            <biblScope type="pp">102</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Steuern</term>
+          <term n="3">Sitologen</term>
+          <term n="4">Getreide</term>
+          <term n="5">Land</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 102</biblScope>
+            <biblScope type="number">Nr. 1</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 103</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981667.xml
+++ b/HGV_meta_EpiDoc/HGV982/981667.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Sitologos Receipt</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981667</idno>
+        <idno type="TM">981667</idno>
+        <idno type="ddb-filename">basp.59.105_2</idno>
+        <idno type="ddb-hybrid">basp;59;105_2</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>London</settlement>
+            </placeName>
+            <collection>British Library</collection>
+            <idno type="invNo">Papyrus 2003</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+               <origPlace>Arsinoites</origPlace>
+               <origDate when="0155-07-20">20. Juli 155</origDate>
+            </origin>
+            <provenance type="located">
+               <p>
+                  <placeName type="ancient"
+                             subtype="nome"
+                             ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+               </p>
+            </provenance>
+         </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96207"/>
+            <biblScope type="pp">105</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Steuern</term>
+          <term n="3">Sitologen</term>
+          <term n="4">Getreide</term>
+          <term n="5">Land</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 105</biblScope>
+            <biblScope type="number">Nr. 2</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 107</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981668.xml
+++ b/HGV_meta_EpiDoc/HGV982/981668.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Sitologos Receipt</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981668</idno>
+        <idno type="TM">981668</idno>
+        <idno type="ddb-filename">basp.59.108_3</idno>
+        <idno type="ddb-hybrid">basp;59;108_3</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>London</settlement>
+            </placeName>
+            <collection>British Library</collection>
+            <idno type="invNo">Papyrus 1900</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Tebtynis (Arsinoites)</origPlace>
+              <origDate when="0185-06-24">24. Juni 185</origDate>
+            </origin>
+            <provenance type="located">
+                <p>
+                    <placeName n="1"
+                               type="ancient"
+                               ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">Tebtynis</placeName>
+                    <placeName n="2"
+                               type="ancient"
+                               subtype="nome"
+                               ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                </p>
+              </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96207"/>
+            <biblScope type="pp">108</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Steuern</term>
+          <term n="3">Sitologen</term>
+          <term n="4">Getreide</term>
+          <term n="5">Land</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 108</biblScope>
+            <biblScope type="number">Nr. 3</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 109</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981669.xml
+++ b/HGV_meta_EpiDoc/HGV982/981669.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for Laographia</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981669</idno>
+        <idno type="TM">981669</idno>
+        <idno type="ddb-filename">basp.59.111_4</idno>
+        <idno type="ddb-hybrid">basp;59;111_4</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>London</settlement>
+            </placeName>
+            <collection>British Library</collection>
+            <idno type="invNo">Papyrus 2425</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+               <origPlace>Arsinoe ? (Arsinoites)</origPlace>
+               <origDate when="0140">140</origDate>
+            </origin>
+            <provenance type="located">
+               <p>
+                  <placeName n="1"
+                             type="ancient"
+                             cert="low"
+                             ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">Arsinoe</placeName>
+                  <placeName n="2"
+                             type="ancient"
+                             subtype="nome"
+                             ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+               </p>
+            </provenance>
+         </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96207"/>
+            <biblScope type="pp">111</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Kopfsteuer</term>
+          <term n="3">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 111</biblScope>
+            <biblScope type="number">Nr. 4</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 111</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981670.xml
+++ b/HGV_meta_EpiDoc/HGV982/981670.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for Laographia</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981670</idno>
+        <idno type="TM">981670</idno>
+        <idno type="ddb-filename">basp.59.113_5</idno>
+        <idno type="ddb-hybrid">basp;59;113_5</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>London</settlement>
+            </placeName>
+            <collection>British Library</collection>
+            <idno type="invNo">Papyrus 2414</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+               <origPlace>Arsinoe ? (Arsinoites)</origPlace>
+               <origDate when="0167">167</origDate>
+            </origin>
+            <provenance type="located">
+               <p>
+                  <placeName n="1"
+                             type="ancient"
+                             cert="low"
+                             ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">Arsinoe</placeName>
+                  <placeName n="2"
+                             type="ancient"
+                             subtype="nome"
+                             ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+               </p>
+            </provenance>
+         </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96207"/>
+            <biblScope type="pp">113</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Kopfsteuer</term>
+          <term n="3">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 113</biblScope>
+            <biblScope type="number">Nr. 5</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 115</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981671.xml
+++ b/HGV_meta_EpiDoc/HGV982/981671.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for Laographia</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981671</idno>
+        <idno type="TM">981671</idno>
+        <idno type="ddb-filename">basp.59.116_6</idno>
+        <idno type="ddb-hybrid">basp;59;116_6</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>London</settlement>
+            </placeName>
+            <collection>British Library</collection>
+            <idno type="invNo">Papyrus 2703</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+               <origPlace>Arsinoe (Arsinoites)</origPlace>
+               <origDate when="0175-09">Sept. 175</origDate>
+            </origin>
+            <provenance type="located">
+               <p>
+                  <placeName n="1"
+                             type="ancient"
+                             ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">Arsinoe</placeName>
+                  <placeName n="2"
+                             type="ancient"
+                             subtype="nome"
+                             ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+               </p>
+            </provenance>
+         </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96207"/>
+            <biblScope type="pp">116</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Kopfsteuer</term>
+          <term n="3">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 116</biblScope>
+            <biblScope type="number">Nr. 6</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 116</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981672.xml
+++ b/HGV_meta_EpiDoc/HGV982/981672.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for Laographia</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981672</idno>
+        <idno type="TM">981672</idno>
+        <idno type="ddb-filename">basp.59.118_7</idno>
+        <idno type="ddb-hybrid">basp;59;118_7</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>London</settlement>
+            </placeName>
+            <collection>British Library</collection>
+            <idno type="invNo">Papyrus 1921</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+               <origPlace>Arsinoe (Arsinoites)</origPlace>
+               <origDate when="0180">180</origDate>
+            </origin>
+            <provenance type="located">
+               <p>
+                  <placeName n="1"
+                             type="ancient"
+                             ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">Arsinoe</placeName>
+                  <placeName n="2"
+                             type="ancient"
+                             subtype="nome"
+                             ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+               </p>
+            </provenance>
+         </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96207"/>
+            <biblScope type="pp">118</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Kopfsteuer</term>
+          <term n="3">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 118</biblScope>
+            <biblScope type="number">Nr. 7</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 118</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981677.xml
+++ b/HGV_meta_EpiDoc/HGV982/981677.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of Grain Tax</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981677</idno>
+        <idno type="TM">981677</idno>
+        <idno type="ddb-filename">basp.59.142</idno>
+        <idno type="ddb-hybrid">basp;59;142</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 339</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites</origPlace>
+              <origDate n="1" notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96210"/>
+            <biblScope type="pp">142</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+          <term n="2">Weizen</term>
+          <term n="3">Steuer</term>
+          <term n="4">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 142</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2757176"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Rückseite BASP 59, 2022, S. 143</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981678.xml
+++ b/HGV_meta_EpiDoc/HGV982/981678.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of Payments in Drachmas</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981678</idno>
+        <idno type="TM">981678</idno>
+        <idno type="ddb-filename">basp.59.143</idno>
+        <idno type="ddb-hybrid">basp;59;143</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 339</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96210"/>
+            <biblScope type="pp">143</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+          <term n="2">Namen</term>
+          <term n="3">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 143</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2757176"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Rückseite BASP 59, 2022, S. 142</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981679.xml
+++ b/HGV_meta_EpiDoc/HGV982/981679.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of Oxyrhynchite Villages</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981679</idno>
+        <idno type="TM">981679</idno>
+        <idno type="ddb-filename">basp.59.146</idno>
+        <idno type="ddb-hybrid">basp;59;146</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 572</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0176" notAfter="0200" precision="low">Ende II</origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96210"/>
+            <biblScope type="pp">146</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+          <term n="2">Weizen</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 146</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2792422"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981680.xml
+++ b/HGV_meta_EpiDoc/HGV982/981680.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Business Letter from Heron to Horion</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981680</idno>
+        <idno type="TM">981680</idno>
+        <idno type="ddb-filename">basp.59.149_1</idno>
+        <idno type="ddb-hybrid">basp;59;149_1</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 1411</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0131-05-26" notAfter="0131-06-24">26. Mai - 24. Juni 131</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96211"/>
+            <biblScope type="pp">149</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (geschäftlich)</term>
+          <term n="2">Heron an Horion</term>
+          <term n="3">Quittung</term>
+          <term n="4">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 149</biblScope>
+            <biblScope type="number">Nr. 1</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 151</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="http://hdl.handle.net/10079/digcoll/2758291"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981681.xml
+++ b/HGV_meta_EpiDoc/HGV982/981681.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter to Eisa- and Aurelius Ant-</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981681</idno>
+        <idno type="TM">981681</idno>
+        <idno type="ddb-filename">basp.59.153_2</idno>
+        <idno type="ddb-hybrid">basp;59;153_2</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Heidelberg</settlement>
+            </placeName>
+            <collection>Institut für Papyrologie</collection>
+            <idno type="invNo">P.Heid. inv. G. 1401</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96211"/>
+            <biblScope type="pp">153</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">N.N. an Eisa- und Aurelius Ant-</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 153</biblScope>
+            <biblScope type="number">Nr. 2</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 154, 155</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981682.xml
+++ b/HGV_meta_EpiDoc/HGV982/981682.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter to Panetouatis</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981682</idno>
+        <idno type="TM">981682</idno>
+        <idno type="ddb-filename">basp.59.158_3</idno>
+        <idno type="ddb-hybrid">basp;59;158_3</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Heidelberg</settlement>
+            </placeName>
+            <collection>Institut für Papyrologie</collection>
+            <idno type="invNo">P.Heid. inv. G. 783</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Ankyropolis (Herakleopolites)</origPlace>
+              <origDate notBefore="0001" notAfter="0200" precision="low">I - II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Ankyropolis</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96211"/>
+            <biblScope type="pp">158</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">N.N. an Panatouatis</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 158</biblScope>
+            <biblScope type="number">Nr. 3</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 159</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981683.xml
+++ b/HGV_meta_EpiDoc/HGV982/981683.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Accounts</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981683</idno>
+        <idno type="TM">981683</idno>
+        <idno type="ddb-filename">basp.59.165</idno>
+        <idno type="ddb-hybrid">basp;59;165</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>St. Louis</settlement>
+            </placeName>
+            <collection>St. Louis Art Museum</collection>
+            <idno type="invNo">inv. 373.23</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchus (Oxyrhynchites)</origPlace>
+              <origDate notBefore="0201" notAfter="0300" cert="low" precision="low">III (?)</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchus</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96212"/>
+            <biblScope type="pp">165</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+          <term n="2">Namen</term>
+          <term n="3">Rohstoffe</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 165</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 167</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981684.xml
+++ b/HGV_meta_EpiDoc/HGV982/981684.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter from Phoibammon to Didymos</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981684</idno>
+        <idno type="TM">981684</idno>
+        <idno type="ddb-filename">basp.59.175</idno>
+        <idno type="ddb-hybrid">basp;59;175</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Berkeley</settlement>
+            </placeName>
+            <collection>Bancroft Library</collection>
+            <idno type="invNo">P.Berk. inv. 148</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0301" notAfter="0500" precision="low">IV - V</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96213"/>
+            <biblScope type="pp">175</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+          <term n="2">Phoibammon an Didymos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 175</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 177</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981685.xml
+++ b/HGV_meta_EpiDoc/HGV982/981685.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Lease of a Vineyard</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">981685</idno>
+        <idno type="TM">981685</idno>
+        <idno type="ddb-filename">basp.59.187</idno>
+        <idno type="ddb-hybrid">basp;59;187</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>London</settlement>
+            </placeName>
+            <collection>British Library</collection>
+            <idno type="invNo">Papyrus 2871</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hermopolites</origPlace>
+              <origDate notBefore="0593-07-25" notAfter="0593-08-12">25. Juli - 12. Aug. 593</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2720 https://pleiades.stoa.org/places/756575">Hermopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+        <listBibl>
+          <bibl type="SB">
+            <ptr target="https://papyri.info/biblio/96214"/>
+            <biblScope type="pp">187</biblScope>
+          </bibl>
+        </listBibl>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag</term>
+          <term n="2">Pacht</term>
+          <term n="3">Garten (Wein)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-01-02" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">BASP</title>
+            <biblScope type="volume">59</biblScope>
+            <biblScope type="fascicle">(2022)</biblScope>
+            <biblScope type="pages">S. 187</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 189</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
XWalk of BASP 59 into HGV, including idno updates of APIS files where appropriate (though one Yale file now includes two TM numbers – for recto/verso, published with separate TM numbers – which will means that aggregation will display both together). **397807** also has a **mentionedDate**, which I have encoded but which should be checked. **Rückseite** references encoded in commentary as per usual. 