### PR TITLE
Correction of language attribute ident

### DIFF
--- a/DDB_EpiDoc_XML/bgu/bgu.3/bgu.3.873.xml
+++ b/DDB_EpiDoc_XML/bgu/bgu.3/bgu.3.873.xml
@@ -28,7 +28,7 @@
          <langUsage>
             <language ident="en">English</language>
             <language ident="grc">Greek</language>
-            <language ident="lat"/>
+            <language ident="lat">Latin</language>
          </langUsage>
          <handNotes>
             <handNote xml:id="m2"/>

--- a/DDB_EpiDoc_XML/bgu/bgu.3/bgu.3.873.xml
+++ b/DDB_EpiDoc_XML/bgu/bgu.3/bgu.3.873.xml
@@ -28,7 +28,7 @@
          <langUsage>
             <language ident="en">English</language>
             <language ident="grc">Greek</language>
-            <language ident="lat">Latin</language>
+            <language ident="la">Latin</language>
          </langUsage>
          <handNotes>
             <handNote xml:id="m2"/>

--- a/DDB_EpiDoc_XML/bifao/bifao.118/bifao.118.34_13.xml
+++ b/DDB_EpiDoc_XML/bifao/bifao.118/bifao.118.34_13.xml
@@ -29,7 +29,6 @@
             <language ident="en">English</language>
             <language ident="cop">Coptic</language>
             <language ident="grc">Greek</language>
-            <language ident="grec"/>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/DDB_EpiDoc_XML/cpr/cpr.4/cpr.4.198.xml
+++ b/DDB_EpiDoc_XML/cpr/cpr.4/cpr.4.198.xml
@@ -29,7 +29,6 @@
             <language ident="en">English</language>
             <language ident="cop">Coptic</language>
             <language ident="grc">Greek</language>
-            <language ident="gc"/>
          </langUsage>
          <handNotes>
             <handNote xml:id="m2"/>

--- a/DDB_EpiDoc_XML/o.douch/o.douch.1/o.douch.1.49.xml
+++ b/DDB_EpiDoc_XML/o.douch/o.douch.1/o.douch.1.49.xml
@@ -28,7 +28,7 @@
          <langUsage>
             <language ident="en">English</language>
             <language ident="cop">Coptic</language>
-            <language ident="lat">Latin</language>
+            <language ident="la">Latin</language>
             <language ident="grc">Greek</language>
          </langUsage>
       </profileDesc>

--- a/DDB_EpiDoc_XML/o.douch/o.douch.1/o.douch.1.49.xml
+++ b/DDB_EpiDoc_XML/o.douch/o.douch.1/o.douch.1.49.xml
@@ -28,7 +28,7 @@
          <langUsage>
             <language ident="en">English</language>
             <language ident="cop">Coptic</language>
-            <language ident="lat"/>
+            <language ident="lat">Latin</language>
             <language ident="grc">Greek</language>
          </langUsage>
       </profileDesc>

--- a/DDB_EpiDoc_XML/o.douch/o.douch.2/o.douch.2.183.xml
+++ b/DDB_EpiDoc_XML/o.douch/o.douch.2/o.douch.2.183.xml
@@ -28,7 +28,7 @@
          <langUsage>
             <language ident="en">English</language>
             <language ident="cop">Coptic</language>
-            <language ident="lat"/>
+            <language ident="la">Latin</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/DDB_EpiDoc_XML/sb/sb.18/sb.18.13633.xml
+++ b/DDB_EpiDoc_XML/sb/sb.18/sb.18.13633.xml
@@ -29,7 +29,7 @@
             <language ident="en">English</language>
             <language ident="cop">Coptic</language>
             <language ident="grc">Greek</language>
-            <language ident="lat"/>
+            <language ident="la">Latin</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>


### PR DESCRIPTION
Dear editors,

I realised that some files had incorrect values of the attribute `ident` in the `language` elements from `langUsage`. For example: _lat_ instead of _la_; _grec_ instead of _grc_. I corrected them in this pull request.

Kind regards