### PR TITLE
RZUSER GV0 image urls

### DIFF
--- a/DCLP/64/63493.xml
+++ b/DCLP/64/63493.xml
@@ -85,7 +85,10 @@
             <listBibl>
                <bibl type="printed">ed. princ., pl.18</bibl>
                <bibl type="online">
-                  <ptr target="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Verstreutes/0845_Reiter/0845_Reiter.html"/>
+                  <ptr target="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Verstreutes/0845_Reiter/0845_Reiter.html"/>
+               </bibl>
+               <bibl type="online">
+                  <ptr target="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/15917/15917.html"/>
                </bibl>
             </listBibl>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/133.xml
+++ b/HGV_meta_EpiDoc/HGV1/133.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_23"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/003/VBP_II_3.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/219.xml
+++ b/HGV_meta_EpiDoc/HGV1/219.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1302"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/004/VBP_II_4.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/229.xml
+++ b/HGV_meta_EpiDoc/HGV1/229.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1300"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/010/VBP_II_10.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/248.xml
+++ b/HGV_meta_EpiDoc/HGV1/248.xml
@@ -121,6 +121,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1285"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/04637/04637.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/253.xml
+++ b/HGV_meta_EpiDoc/HGV1/253.xml
@@ -142,6 +142,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1280"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/04638/04638.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/286.xml
+++ b/HGV_meta_EpiDoc/HGV1/286.xml
@@ -110,6 +110,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1301"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Dryton/031/P.Dryton_31.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/291.xml
+++ b/HGV_meta_EpiDoc/HGV1/291.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1291"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/006/VBP_II_6.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/303.xml
+++ b/HGV_meta_EpiDoc/HGV1/303.xml
@@ -94,6 +94,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1287"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/016/VBP_II_16.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/462.xml
+++ b/HGV_meta_EpiDoc/HGV1/462.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1279"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/007/VBP_II_7.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/463.xml
+++ b/HGV_meta_EpiDoc/HGV1/463.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1310"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/008/VBP_II_8.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/464.xml
+++ b/HGV_meta_EpiDoc/HGV1/464.xml
@@ -125,6 +125,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1289"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/009/VBP_II_9.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/641.xml
+++ b/HGV_meta_EpiDoc/HGV1/641.xml
@@ -90,6 +90,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1320"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Dryton/042/P.Dryton_42.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/642a.xml
+++ b/HGV_meta_EpiDoc/HGV1/642a.xml
@@ -93,6 +93,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_314"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Dryton/043/P.Dryton_43.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/642b.xml
+++ b/HGV_meta_EpiDoc/HGV1/642b.xml
@@ -90,6 +90,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_314"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Dryton/043/P.Dryton_43.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/643.xml
+++ b/HGV_meta_EpiDoc/HGV1/643.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_315"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Dryton/044/P.Dryton_44.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/644.xml
+++ b/HGV_meta_EpiDoc/HGV1/644.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_313"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Dryton/020/P.Dryton_20.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/77.xml
+++ b/HGV_meta_EpiDoc/HGV1/77.xml
@@ -108,6 +108,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1278"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Verstreutes/1278_GerGra/1278_GerGra.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV102/101308.xml
+++ b/HGV_meta_EpiDoc/HGV102/101308.xml
@@ -84,6 +84,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1702"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/043/VBP_II_44.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV102/101309.xml
+++ b/HGV_meta_EpiDoc/HGV102/101309.xml
@@ -83,6 +83,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1703"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/043/VBP_II_45.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11467.xml
+++ b/HGV_meta_EpiDoc/HGV12/11467.xml
@@ -110,6 +110,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3091"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/235/P.Heid._III_235.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11468.xml
+++ b/HGV_meta_EpiDoc/HGV12/11468.xml
@@ -101,6 +101,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2076"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/239/P.Heid._III_239.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11469.xml
+++ b/HGV_meta_EpiDoc/HGV12/11469.xml
@@ -110,6 +110,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_124_b"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/240/P.Heid._III_240.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11470.xml
+++ b/HGV_meta_EpiDoc/HGV12/11470.xml
@@ -111,6 +111,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_223_c"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/241/P.Heid._III_241.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11471.xml
+++ b/HGV_meta_EpiDoc/HGV12/11471.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1696"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/298/P.Heid._IV_298.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11472.xml
+++ b/HGV_meta_EpiDoc/HGV12/11472.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_852"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/300/P.Heid._IV_300.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11473.xml
+++ b/HGV_meta_EpiDoc/HGV12/11473.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1768"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/302/P.Heid._IV_302.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11474.xml
+++ b/HGV_meta_EpiDoc/HGV12/11474.xml
@@ -99,7 +99,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/P.Heid._IV/302/P.Heid._IV_302.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/302/P.Heid._IV_302.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV12/11475.xml
+++ b/HGV_meta_EpiDoc/HGV12/11475.xml
@@ -108,6 +108,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_94"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/311/P.Heid._IV_311.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11476.xml
+++ b/HGV_meta_EpiDoc/HGV12/11476.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_524"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/316/P.Heid._IV_316.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11477.xml
+++ b/HGV_meta_EpiDoc/HGV12/11477.xml
@@ -109,6 +109,9 @@
                <figure n="2">
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_865"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/318/P.Heid._IV_318.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11478.xml
+++ b/HGV_meta_EpiDoc/HGV12/11478.xml
@@ -122,6 +122,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_230"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/319/P.Heid._IV_319.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11479.xml
+++ b/HGV_meta_EpiDoc/HGV12/11479.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_576"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/329/P.Heid._IV_329.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV12/11480.xml
+++ b/HGV_meta_EpiDoc/HGV12/11480.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_108"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/399/P.Heid._VII_399.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV15/14252.xml
+++ b/HGV_meta_EpiDoc/HGV15/14252.xml
@@ -122,6 +122,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1987"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/219/P.Heid._II_219.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV15/14253.xml
+++ b/HGV_meta_EpiDoc/HGV15/14253.xml
@@ -128,6 +128,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2091"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/220/P.Heid._II_220.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV15/14254.xml
+++ b/HGV_meta_EpiDoc/HGV15/14254.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1756"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/223/P.Heid._II_223.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV15/14926.xml
+++ b/HGV_meta_EpiDoc/HGV15/14926.xml
@@ -112,6 +112,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_512"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/15038/15038.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV16/15146.xml
+++ b/HGV_meta_EpiDoc/HGV16/15146.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1710"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/023/VBP_II_23.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV16/15147.xml
+++ b/HGV_meta_EpiDoc/HGV16/15147.xml
@@ -112,7 +112,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_II/029/VBP_II_29.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/029/VBP_II_29.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV16/15148.xml
+++ b/HGV_meta_EpiDoc/HGV16/15148.xml
@@ -115,6 +115,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2077"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_VI/169/VBP_VI_169.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV16/15149.xml
+++ b/HGV_meta_EpiDoc/HGV16/15149.xml
@@ -108,6 +108,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1992"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_VI/170/VBP_VI_170.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17029.xml
+++ b/HGV_meta_EpiDoc/HGV18/17029.xml
@@ -117,6 +117,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_168"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/040/VBP_II_40.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17030.xml
+++ b/HGV_meta_EpiDoc/HGV18/17030.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_83"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/038/VBP_II_38.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17045.xml
+++ b/HGV_meta_EpiDoc/HGV18/17045.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_200_a"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09706/09706.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17048.xml
+++ b/HGV_meta_EpiDoc/HGV18/17048.xml
@@ -112,7 +112,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/SB/09707/09707.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09707/09707.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV18/17052.xml
+++ b/HGV_meta_EpiDoc/HGV18/17052.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_161"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09708/09708.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17086.xml
+++ b/HGV_meta_EpiDoc/HGV18/17086.xml
@@ -133,6 +133,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_65_a"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09712/09712.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17087.xml
+++ b/HGV_meta_EpiDoc/HGV18/17087.xml
@@ -115,6 +115,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_168"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09713/09713.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17088.xml
+++ b/HGV_meta_EpiDoc/HGV18/17088.xml
@@ -146,6 +146,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_212_b"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09714/09714.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17091.xml
+++ b/HGV_meta_EpiDoc/HGV18/17091.xml
@@ -119,6 +119,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_373"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09715/09715.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17092.xml
+++ b/HGV_meta_EpiDoc/HGV18/17092.xml
@@ -131,6 +131,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_373"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09715/09715.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17094.xml
+++ b/HGV_meta_EpiDoc/HGV18/17094.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_65_b"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09716/09716.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17105.xml
+++ b/HGV_meta_EpiDoc/HGV18/17105.xml
@@ -110,6 +110,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_48_b"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09717/09717.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17107.xml
+++ b/HGV_meta_EpiDoc/HGV18/17107.xml
@@ -134,6 +134,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_87"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/036/VBP_II_36.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17108.xml
+++ b/HGV_meta_EpiDoc/HGV18/17108.xml
@@ -101,7 +101,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_II/036/VBP_II_36.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/036/VBP_II_36.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV18/17109.xml
+++ b/HGV_meta_EpiDoc/HGV18/17109.xml
@@ -101,6 +101,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_22"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/039/VBP_II_39.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17110.xml
+++ b/HGV_meta_EpiDoc/HGV18/17110.xml
@@ -106,7 +106,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_II/039/VBP_II_39.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/039/VBP_II_39.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV18/17111.xml
+++ b/HGV_meta_EpiDoc/HGV18/17111.xml
@@ -128,7 +128,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_II/039/VBP_II_39.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/039/VBP_II_39.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV18/17115.xml
+++ b/HGV_meta_EpiDoc/HGV18/17115.xml
@@ -138,6 +138,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_40"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/037/VBP_II_37.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17116.xml
+++ b/HGV_meta_EpiDoc/HGV18/17116.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_223_a"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09722/09722.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17130.xml
+++ b/HGV_meta_EpiDoc/HGV18/17130.xml
@@ -110,6 +110,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_60_b"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09723/09723.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17133.xml
+++ b/HGV_meta_EpiDoc/HGV18/17133.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_42"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09724/09724.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17147.xml
+++ b/HGV_meta_EpiDoc/HGV18/17147.xml
@@ -122,6 +122,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_52"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/213/P.Heid._II_213.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17641.xml
+++ b/HGV_meta_EpiDoc/HGV18/17641.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_99"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._V/352/P.Heid._V_352.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17642.xml
+++ b/HGV_meta_EpiDoc/HGV18/17642.xml
@@ -111,6 +111,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2206"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._V/357/P.Heid._V_357.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV18/17643.xml
+++ b/HGV_meta_EpiDoc/HGV18/17643.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1666"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._V/358/P.Heid._V_358.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV2/1848.xml
+++ b/HGV_meta_EpiDoc/HGV2/1848.xml
@@ -101,6 +101,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1832"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09796/09796.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV2/1849.xml
+++ b/HGV_meta_EpiDoc/HGV2/1849.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1834"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09797/09797.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV2/1904.xml
+++ b/HGV_meta_EpiDoc/HGV2/1904.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1891"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_VI/176/VBP_VI_176.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19061.xml
+++ b/HGV_meta_EpiDoc/HGV20/19061.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1919"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/222/P.Heid._II_222.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19062.xml
+++ b/HGV_meta_EpiDoc/HGV20/19062.xml
@@ -129,6 +129,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2070"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/224/P.Heid._II_224.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19314.xml
+++ b/HGV_meta_EpiDoc/HGV20/19314.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_25_a"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/018/VBP_II_18.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19315.xml
+++ b/HGV_meta_EpiDoc/HGV20/19315.xml
@@ -108,7 +108,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_II/019a/VBP_II_19a.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/019a/VBP_II_19a.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV20/19316.xml
+++ b/HGV_meta_EpiDoc/HGV20/19316.xml
@@ -118,7 +118,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_II/019b/VBP_II_19b.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/019b/VBP_II_19b.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV20/19317.xml
+++ b/HGV_meta_EpiDoc/HGV20/19317.xml
@@ -101,6 +101,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_192_c"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/020/VBP_II_20.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19318.xml
+++ b/HGV_meta_EpiDoc/HGV20/19318.xml
@@ -116,7 +116,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_II/020/VBP_II_20.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/020/VBP_II_20.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV20/19319.xml
+++ b/HGV_meta_EpiDoc/HGV20/19319.xml
@@ -93,6 +93,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_146"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/021/VBP_II_21.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19320.xml
+++ b/HGV_meta_EpiDoc/HGV20/19320.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1706"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/022/VBP_II_22.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19321.xml
+++ b/HGV_meta_EpiDoc/HGV20/19321.xml
@@ -87,6 +87,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1711"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/024/VBP_II_24.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19322.xml
+++ b/HGV_meta_EpiDoc/HGV20/19322.xml
@@ -153,6 +153,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_213"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/026/VBP_II_26.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19323.xml
+++ b/HGV_meta_EpiDoc/HGV20/19323.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_218"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/026/VBP_II_26.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19324.xml
+++ b/HGV_meta_EpiDoc/HGV20/19324.xml
@@ -112,6 +112,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_213"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/026/VBP_II_26.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19325.xml
+++ b/HGV_meta_EpiDoc/HGV20/19325.xml
@@ -111,7 +111,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_II/026/VBP_II_26.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/026/VBP_II_26.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV20/19327.xml
+++ b/HGV_meta_EpiDoc/HGV20/19327.xml
@@ -110,6 +110,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1331"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/027/VBP_II_27.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19328.xml
+++ b/HGV_meta_EpiDoc/HGV20/19328.xml
@@ -103,6 +103,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_296"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/028/VBP_II_28.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19329.xml
+++ b/HGV_meta_EpiDoc/HGV20/19329.xml
@@ -112,6 +112,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_185"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/030/VBP_II_30.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19330.xml
+++ b/HGV_meta_EpiDoc/HGV20/19330.xml
@@ -129,6 +129,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_81"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/035/VBP_II_35.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19331.xml
+++ b/HGV_meta_EpiDoc/HGV20/19331.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_107"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/041/VBP_II_41.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19332.xml
+++ b/HGV_meta_EpiDoc/HGV20/19332.xml
@@ -117,6 +117,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_607"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/072/VBP_IV_72.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19333.xml
+++ b/HGV_meta_EpiDoc/HGV20/19333.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_605"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/074/VBP_IV_74.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19334.xml
+++ b/HGV_meta_EpiDoc/HGV20/19334.xml
@@ -118,6 +118,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_68"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/075a/VBP_IV_75a.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19335.xml
+++ b/HGV_meta_EpiDoc/HGV20/19335.xml
@@ -137,6 +137,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_604"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/075b/VBP_IV_75b.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19336.xml
+++ b/HGV_meta_EpiDoc/HGV20/19336.xml
@@ -96,7 +96,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_IV/083/VBP_IV_83.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/083/VBP_IV_83.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV20/19337.xml
+++ b/HGV_meta_EpiDoc/HGV20/19337.xml
@@ -96,7 +96,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_IV/083/VBP_IV_83.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/083/VBP_IV_83.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV20/19338.xml
+++ b/HGV_meta_EpiDoc/HGV20/19338.xml
@@ -91,6 +91,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1298"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/089/VBP_IV_89.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19339.xml
+++ b/HGV_meta_EpiDoc/HGV20/19339.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_7"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/091/VBP_IV_91.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV20/19340.xml
+++ b/HGV_meta_EpiDoc/HGV20/19340.xml
@@ -103,7 +103,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_IV/091/VBP_IV_91.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/091/VBP_IV_91.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV22/21090.xml
+++ b/HGV_meta_EpiDoc/HGV22/21090.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_159"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/238/P.Heid._III_238.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21091.xml
+++ b/HGV_meta_EpiDoc/HGV22/21091.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_652"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/244/P.Heid._III_244.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21092.xml
+++ b/HGV_meta_EpiDoc/HGV22/21092.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3078"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/247/P.Heid._III_247.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21093.xml
+++ b/HGV_meta_EpiDoc/HGV22/21093.xml
@@ -112,6 +112,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_689"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/297/P.Heid._IV_297.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21094.xml
+++ b/HGV_meta_EpiDoc/HGV22/21094.xml
@@ -100,7 +100,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/P.Heid._IV/299/P.Heid._IV_299.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/299/P.Heid._IV_299.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV22/21095.xml
+++ b/HGV_meta_EpiDoc/HGV22/21095.xml
@@ -106,7 +106,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/P.Heid._IV/301/P.Heid._IV_301.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/301/P.Heid._IV_301.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV22/21096.xml
+++ b/HGV_meta_EpiDoc/HGV22/21096.xml
@@ -98,7 +98,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/P.Heid._IV/301/P.Heid._IV_301.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/301/P.Heid._IV_301.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV22/21097.xml
+++ b/HGV_meta_EpiDoc/HGV22/21097.xml
@@ -101,6 +101,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2249"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/305/P.Heid._IV_305.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21098.xml
+++ b/HGV_meta_EpiDoc/HGV22/21098.xml
@@ -95,6 +95,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1032"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/306/P.Heid._IV_306.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21099.xml
+++ b/HGV_meta_EpiDoc/HGV22/21099.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_286"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/307/P.Heid._IV_307.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21100.xml
+++ b/HGV_meta_EpiDoc/HGV22/21100.xml
@@ -110,6 +110,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_231"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/308/P.Heid._IV_308.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21101.xml
+++ b/HGV_meta_EpiDoc/HGV22/21101.xml
@@ -95,6 +95,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_699"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/312/P.Heid._IV_312.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21102.xml
+++ b/HGV_meta_EpiDoc/HGV22/21102.xml
@@ -101,7 +101,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/P.Heid._IV/312/P.Heid._IV_312.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/312/P.Heid._IV_312.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV22/21103.xml
+++ b/HGV_meta_EpiDoc/HGV22/21103.xml
@@ -93,6 +93,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1991"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/312/P.Heid._IV_312.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21104.xml
+++ b/HGV_meta_EpiDoc/HGV22/21104.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1998"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/317/P.Heid._IV_317.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21105.xml
+++ b/HGV_meta_EpiDoc/HGV22/21105.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_654"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/320/P.Heid._IV_320.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21106.xml
+++ b/HGV_meta_EpiDoc/HGV22/21106.xml
@@ -124,6 +124,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_618"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/076/VBP_IV_76.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21107.xml
+++ b/HGV_meta_EpiDoc/HGV22/21107.xml
@@ -128,6 +128,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_620"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/081/VBP_IV_81.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21108.xml
+++ b/HGV_meta_EpiDoc/HGV22/21108.xml
@@ -101,6 +101,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_407_a-c"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/323/P.Heid._IV_323.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21109.xml
+++ b/HGV_meta_EpiDoc/HGV22/21109.xml
@@ -119,6 +119,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1960"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/324/P.Heid._IV_324.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21110.xml
+++ b/HGV_meta_EpiDoc/HGV22/21110.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_577"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/325/P.Heid._IV_325.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21111.xml
+++ b/HGV_meta_EpiDoc/HGV22/21111.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_687"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/326/P.Heid._IV_326.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21112.xml
+++ b/HGV_meta_EpiDoc/HGV22/21112.xml
@@ -120,6 +120,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_639"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/086/VBP_IV_86.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21113.xml
+++ b/HGV_meta_EpiDoc/HGV22/21113.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1064"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/331/P.Heid._IV_331.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21114.xml
+++ b/HGV_meta_EpiDoc/HGV22/21114.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_24"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/336/P.Heid._IV_336.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21115.xml
+++ b/HGV_meta_EpiDoc/HGV22/21115.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_163"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/337/P.Heid._IV_337.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21116.xml
+++ b/HGV_meta_EpiDoc/HGV22/21116.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_299"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/338/P.Heid._IV_338.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21117.xml
+++ b/HGV_meta_EpiDoc/HGV22/21117.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1017"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/339/P.Heid._IV_339.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21118.xml
+++ b/HGV_meta_EpiDoc/HGV22/21118.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1207"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/340/P.Heid._IV_340.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21119.xml
+++ b/HGV_meta_EpiDoc/HGV22/21119.xml
@@ -95,6 +95,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_771"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/341/P.Heid._IV_341.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21120.xml
+++ b/HGV_meta_EpiDoc/HGV22/21120.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1837"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/342/P.Heid._IV_342.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21449.xml
+++ b/HGV_meta_EpiDoc/HGV22/21449.xml
@@ -110,6 +110,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2143"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./008/P.Neph._8.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21454.xml
+++ b/HGV_meta_EpiDoc/HGV22/21454.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2149"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./032/P.Neph._32.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21456.xml
+++ b/HGV_meta_EpiDoc/HGV22/21456.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1632"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./043/P.Neph._43.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21457.xml
+++ b/HGV_meta_EpiDoc/HGV22/21457.xml
@@ -127,6 +127,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_702"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./044/P.Neph._44.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21458.xml
+++ b/HGV_meta_EpiDoc/HGV22/21458.xml
@@ -115,6 +115,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_702"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./045/P.Neph._45.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21459.xml
+++ b/HGV_meta_EpiDoc/HGV22/21459.xml
@@ -108,6 +108,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1509"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./048/P.Neph._48.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21661.xml
+++ b/HGV_meta_EpiDoc/HGV22/21661.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1828"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/396/P.Heid._VII_396.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21662.xml
+++ b/HGV_meta_EpiDoc/HGV22/21662.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_316"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/397/P.Heid._VII_397.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21663.xml
+++ b/HGV_meta_EpiDoc/HGV22/21663.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_316"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/398/P.Heid._VII_398.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21664.xml
+++ b/HGV_meta_EpiDoc/HGV22/21664.xml
@@ -114,6 +114,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1707"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/401/P.Heid._VII_401.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21666.xml
+++ b/HGV_meta_EpiDoc/HGV22/21666.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_587"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/403/P.Heid._VII_403.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV22/21668.xml
+++ b/HGV_meta_EpiDoc/HGV22/21668.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_535"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/405/P.Heid._VII_405.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV23/22281.xml
+++ b/HGV_meta_EpiDoc/HGV23/22281.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1966"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_VI/172/VBP_VI_172.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV24/23259.xml
+++ b/HGV_meta_EpiDoc/HGV24/23259.xml
@@ -133,7 +133,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV24/23263.xml
+++ b/HGV_meta_EpiDoc/HGV24/23263.xml
@@ -124,7 +124,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV24/23566.xml
+++ b/HGV_meta_EpiDoc/HGV24/23566.xml
@@ -160,10 +160,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="http://www.psi-online.it/documents/p-flor-i-56"/>
                </figure>
                <figure>
-                  <graphic url="http://www.psi-online.it/documents/p-flor-i-56"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV24/23840.xml
+++ b/HGV_meta_EpiDoc/HGV24/23840.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_921"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/14983/14983.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV24/23841.xml
+++ b/HGV_meta_EpiDoc/HGV24/23841.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_923"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/14984/14984.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV24/23889.xml
+++ b/HGV_meta_EpiDoc/HGV24/23889.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_98"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/15136/15136.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV24/23890.xml
+++ b/HGV_meta_EpiDoc/HGV24/23890.xml
@@ -94,6 +94,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1669"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/15137/15137.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV24/23891.xml
+++ b/HGV_meta_EpiDoc/HGV24/23891.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1898"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/15038/15038.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV26/25300.xml
+++ b/HGV_meta_EpiDoc/HGV26/25300.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1818"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/07551/07551.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV26/25449.xml
+++ b/HGV_meta_EpiDoc/HGV26/25449.xml
@@ -112,6 +112,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2032"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/211/P.Heid._II_211.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV26/25455.xml
+++ b/HGV_meta_EpiDoc/HGV26/25455.xml
@@ -103,6 +103,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_48_a"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/034/VBP_II_34.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV26/25456.xml
+++ b/HGV_meta_EpiDoc/HGV26/25456.xml
@@ -103,6 +103,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_621"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/071/VBP_IV_71.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV26/25862.xml
+++ b/HGV_meta_EpiDoc/HGV26/25862.xml
@@ -92,6 +92,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4126"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/234/P.Heid._III_234.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV28/27180.xml
+++ b/HGV_meta_EpiDoc/HGV28/27180.xml
@@ -103,6 +103,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_378_b"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/10727/10727.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV28/27278.xml
+++ b/HGV_meta_EpiDoc/HGV28/27278.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1818"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09127/09127.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV28/27857.xml
+++ b/HGV_meta_EpiDoc/HGV28/27857.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_208_a"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/032/VBP_II_32.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV28/27858.xml
+++ b/HGV_meta_EpiDoc/HGV28/27858.xml
@@ -92,7 +92,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_II/033/VBP_II_33.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/033/VBP_II_33.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV28/27859.xml
+++ b/HGV_meta_EpiDoc/HGV28/27859.xml
@@ -101,6 +101,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1708"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/042/VBP_II_42.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV28/27860.xml
+++ b/HGV_meta_EpiDoc/HGV28/27860.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_26"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/073/VBP_IV_73.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV28/27861.xml
+++ b/HGV_meta_EpiDoc/HGV28/27861.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_794"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/077/VBP_IV_77.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV28/27862.xml
+++ b/HGV_meta_EpiDoc/HGV28/27862.xml
@@ -94,6 +94,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_609"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/078/VBP_IV_78.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV28/27863.xml
+++ b/HGV_meta_EpiDoc/HGV28/27863.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_17"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/080/VBP_IV_80.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV28/27864.xml
+++ b/HGV_meta_EpiDoc/HGV28/27864.xml
@@ -116,7 +116,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_IV/084/VBP_IV_84.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/084/VBP_IV_84.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV28/27865.xml
+++ b/HGV_meta_EpiDoc/HGV28/27865.xml
@@ -116,7 +116,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_IV/084/VBP_IV_84.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/084/VBP_IV_84.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV28/27866.xml
+++ b/HGV_meta_EpiDoc/HGV28/27866.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_630_a"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/085a/VBP_IV_85a.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV28/27867.xml
+++ b/HGV_meta_EpiDoc/HGV28/27867.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_630_b"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/085b/VBP_IV_85b.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV29/28717.xml
+++ b/HGV_meta_EpiDoc/HGV29/28717.xml
@@ -101,6 +101,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_91"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/242/P.Heid._III_242.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV29/28718.xml
+++ b/HGV_meta_EpiDoc/HGV29/28718.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_613"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/303/P.Heid._IV_303.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV29/28719.xml
+++ b/HGV_meta_EpiDoc/HGV29/28719.xml
@@ -87,6 +87,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2247"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/304/P.Heid._IV_304.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV29/28720.xml
+++ b/HGV_meta_EpiDoc/HGV29/28720.xml
@@ -121,6 +121,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_918"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/310/P.Heid._IV_310.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV29/28721.xml
+++ b/HGV_meta_EpiDoc/HGV29/28721.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_744"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/332/P.Heid._IV_332.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV29/28722.xml
+++ b/HGV_meta_EpiDoc/HGV29/28722.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1396"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/334/P.Heid._IV_334.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV29/28723.xml
+++ b/HGV_meta_EpiDoc/HGV29/28723.xml
@@ -103,6 +103,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_582_a"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/335/P.Heid._IV_335.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV29/28976.xml
+++ b/HGV_meta_EpiDoc/HGV29/28976.xml
@@ -91,6 +91,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_900"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/400/P.Heid._VII_400.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV3/2656.xml
+++ b/HGV_meta_EpiDoc/HGV3/2656.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1191"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/001/VBP_II_1.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV3/2815.xml
+++ b/HGV_meta_EpiDoc/HGV3/2815.xml
@@ -101,6 +101,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4047"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/226/P.Heid._III_226.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31107.xml
+++ b/HGV_meta_EpiDoc/HGV32/31107.xml
@@ -115,6 +115,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1700"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/214/P.Heid._II_214.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31108.xml
+++ b/HGV_meta_EpiDoc/HGV32/31108.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1756"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/215/P.Heid._II_215.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31109.xml
+++ b/HGV_meta_EpiDoc/HGV32/31109.xml
@@ -114,6 +114,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1718"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/216/P.Heid._II_216.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31110.xml
+++ b/HGV_meta_EpiDoc/HGV32/31110.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1779"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/221/P.Heid._II_221.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31140.xml
+++ b/HGV_meta_EpiDoc/HGV32/31140.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_411"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/025/VBP_II_25.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31141.xml
+++ b/HGV_meta_EpiDoc/HGV32/31141.xml
@@ -94,6 +94,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1709"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/043/VBP_II_43.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31142.xml
+++ b/HGV_meta_EpiDoc/HGV32/31142.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_69"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/087/VBP_IV_87.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31143.xml
+++ b/HGV_meta_EpiDoc/HGV32/31143.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_37"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/090/VBP_IV_90.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31479.xml
+++ b/HGV_meta_EpiDoc/HGV32/31479.xml
@@ -131,6 +131,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1755"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/237/P.Heid._III_237.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31480.xml
+++ b/HGV_meta_EpiDoc/HGV32/31480.xml
@@ -85,6 +85,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_527"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/245/P.Heid._III_245.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31481.xml
+++ b/HGV_meta_EpiDoc/HGV32/31481.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_577"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/325/P.Heid._IV_325.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV32/31482.xml
+++ b/HGV_meta_EpiDoc/HGV32/31482.xml
@@ -111,6 +111,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1448"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/328/P.Heid._IV_328.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV33/32206.xml
+++ b/HGV_meta_EpiDoc/HGV33/32206.xml
@@ -114,6 +114,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1892"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_VI/171/VBP_VI_171.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33128.xml
+++ b/HGV_meta_EpiDoc/HGV34/33128.xml
@@ -106,6 +106,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_154"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/031/VBP_II_31.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33129.xml
+++ b/HGV_meta_EpiDoc/HGV34/33129.xml
@@ -112,6 +112,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_611"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/053/VBP_IV_53.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33130.xml
+++ b/HGV_meta_EpiDoc/HGV34/33130.xml
@@ -83,7 +83,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_IV/096/VBP_IV_96.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/096/VBP_IV_96.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV34/33465.xml
+++ b/HGV_meta_EpiDoc/HGV34/33465.xml
@@ -89,6 +89,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1749"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/309/P.Heid._IV_309.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33466.xml
+++ b/HGV_meta_EpiDoc/HGV34/33466.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1543"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/315/P.Heid._IV_315.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33557.xml
+++ b/HGV_meta_EpiDoc/HGV34/33557.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2142"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./003/P.Neph._3.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33558.xml
+++ b/HGV_meta_EpiDoc/HGV34/33558.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2140"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./004/P.Neph._4.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33559.xml
+++ b/HGV_meta_EpiDoc/HGV34/33559.xml
@@ -116,6 +116,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2141"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./005/P.Neph._5.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33561.xml
+++ b/HGV_meta_EpiDoc/HGV34/33561.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2144"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./007/P.Neph._7.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33564.xml
+++ b/HGV_meta_EpiDoc/HGV34/33564.xml
@@ -91,6 +91,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2145"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./011/P.Neph._11.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33565.xml
+++ b/HGV_meta_EpiDoc/HGV34/33565.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2146"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./012/P.Neph._12.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33568.xml
+++ b/HGV_meta_EpiDoc/HGV34/33568.xml
@@ -90,6 +90,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2147"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./017/P.Neph._17.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33571.xml
+++ b/HGV_meta_EpiDoc/HGV34/33571.xml
@@ -114,6 +114,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2148"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./020/P.Neph._20.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33579.xml
+++ b/HGV_meta_EpiDoc/HGV34/33579.xml
@@ -85,6 +85,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2156"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./035/P.Neph._35.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33580.xml
+++ b/HGV_meta_EpiDoc/HGV34/33580.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2150"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./036/P.Neph._36.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33586.xml
+++ b/HGV_meta_EpiDoc/HGV34/33586.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1209"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./046/P.Neph._46.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33587.xml
+++ b/HGV_meta_EpiDoc/HGV34/33587.xml
@@ -86,6 +86,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1083"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./047/P.Neph._47.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33588.xml
+++ b/HGV_meta_EpiDoc/HGV34/33588.xml
@@ -94,6 +94,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1353"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./049/P.Neph._49.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33619.xml
+++ b/HGV_meta_EpiDoc/HGV34/33619.xml
@@ -91,6 +91,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_587"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/402/P.Heid._VII_402.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV34/33812.xml
+++ b/HGV_meta_EpiDoc/HGV34/33812.xml
@@ -130,6 +130,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1355"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/02266/02266.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV35/34180.xml
+++ b/HGV_meta_EpiDoc/HGV35/34180.xml
@@ -101,6 +101,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_35"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/052/VBP_IV_52.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV36/35095.xml
+++ b/HGV_meta_EpiDoc/HGV36/35095.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_933"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._V/355/P.Heid._V_355.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV36/35227.xml
+++ b/HGV_meta_EpiDoc/HGV36/35227.xml
@@ -104,7 +104,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_IV/054/VBP_IV_54.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/054/VBP_IV_54.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV36/35228.xml
+++ b/HGV_meta_EpiDoc/HGV36/35228.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_30"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/092/VBP_IV_92.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV36/35229.xml
+++ b/HGV_meta_EpiDoc/HGV36/35229.xml
@@ -105,7 +105,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_IV/094/VBP_IV_94.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/094/VBP_IV_94.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV36/35410.xml
+++ b/HGV_meta_EpiDoc/HGV36/35410.xml
@@ -88,6 +88,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1624"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/246/P.Heid._III_246.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV36/35411.xml
+++ b/HGV_meta_EpiDoc/HGV36/35411.xml
@@ -111,6 +111,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1699"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/313/P.Heid._IV_313.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV36/35412.xml
+++ b/HGV_meta_EpiDoc/HGV36/35412.xml
@@ -114,6 +114,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1791"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/314/P.Heid._IV_314.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV36/35413.xml
+++ b/HGV_meta_EpiDoc/HGV36/35413.xml
@@ -103,6 +103,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1427"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/333/P.Heid._IV_333.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV36/35783.xml
+++ b/HGV_meta_EpiDoc/HGV36/35783.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1402"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/15183/15183.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV37/36176.xml
+++ b/HGV_meta_EpiDoc/HGV37/36176.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1069"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._V/345/P.Heid._V_345.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV37/36179.xml
+++ b/HGV_meta_EpiDoc/HGV37/36179.xml
@@ -92,6 +92,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1801"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._V/348/P.Heid._V_348.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV37/36182.xml
+++ b/HGV_meta_EpiDoc/HGV37/36182.xml
@@ -89,6 +89,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1329"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._V/354/P.Heid._V_354.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV37/36183.xml
+++ b/HGV_meta_EpiDoc/HGV37/36183.xml
@@ -111,6 +111,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1895"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._V/359/P.Heid._V_359.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV37/36184.xml
+++ b/HGV_meta_EpiDoc/HGV37/36184.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_995"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._V/360/P.Heid._V_360.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV37/36854.xml
+++ b/HGV_meta_EpiDoc/HGV37/36854.xml
@@ -122,6 +122,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5139"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/055/VBP_IV_55.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV37/36855.xml
+++ b/HGV_meta_EpiDoc/HGV37/36855.xml
@@ -148,6 +148,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/095/VBP_IV_95.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV38/37271.xml
+++ b/HGV_meta_EpiDoc/HGV38/37271.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1964"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/248/P.Heid._III_248.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV38/37272.xml
+++ b/HGV_meta_EpiDoc/HGV38/37272.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_586"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IV/330/P.Heid._IV_330.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV39/38162.xml
+++ b/HGV_meta_EpiDoc/HGV39/38162.xml
@@ -103,6 +103,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1930"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_VI/168/VBP_VI_168.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV39/38163.xml
+++ b/HGV_meta_EpiDoc/HGV39/38163.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1732"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_VI/173/VBP_VI_173.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV39/38388.xml
+++ b/HGV_meta_EpiDoc/HGV39/38388.xml
@@ -94,6 +94,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_311"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/06000/06000.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV39/38834.xml
+++ b/HGV_meta_EpiDoc/HGV39/38834.xml
@@ -114,6 +114,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_57"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/093/VBP_IV_93.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV39/38835.xml
+++ b/HGV_meta_EpiDoc/HGV39/38835.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_141"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/097/VBP_IV_97.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3059.xml
+++ b/HGV_meta_EpiDoc/HGV4/3059.xml
@@ -132,6 +132,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2192"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/362/P.Heid._VI_362.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3060.xml
+++ b/HGV_meta_EpiDoc/HGV4/3060.xml
@@ -114,6 +114,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2186"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/363/P.Heid._VI_363.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3061.xml
+++ b/HGV_meta_EpiDoc/HGV4/3061.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2181"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/364/P.Heid._VI_364.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3062.xml
+++ b/HGV_meta_EpiDoc/HGV4/3062.xml
@@ -89,6 +89,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2196"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/365/P.Heid._VI_365.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3063.xml
+++ b/HGV_meta_EpiDoc/HGV4/3063.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2177"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/366/P.Heid._VI_366.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3064a.xml
+++ b/HGV_meta_EpiDoc/HGV4/3064a.xml
@@ -119,6 +119,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2195"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/367/P.Heid._VI_367.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3064b.xml
+++ b/HGV_meta_EpiDoc/HGV4/3064b.xml
@@ -121,6 +121,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2195"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/367/P.Heid._VI_367.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3065.xml
+++ b/HGV_meta_EpiDoc/HGV4/3065.xml
@@ -103,6 +103,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2187"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/368/P.Heid._VI_368.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3066.xml
+++ b/HGV_meta_EpiDoc/HGV4/3066.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2173"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/369/P.Heid._VI_369.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3067.xml
+++ b/HGV_meta_EpiDoc/HGV4/3067.xml
@@ -124,6 +124,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2183"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/370/P.Heid._VI_370.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3068.xml
+++ b/HGV_meta_EpiDoc/HGV4/3068.xml
@@ -88,6 +88,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2182"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/371/P.Heid._VI_371.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3069.xml
+++ b/HGV_meta_EpiDoc/HGV4/3069.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2189"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/372/P.Heid._VI_372.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3070.xml
+++ b/HGV_meta_EpiDoc/HGV4/3070.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2174"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/373/P.Heid._VI_373.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3071.xml
+++ b/HGV_meta_EpiDoc/HGV4/3071.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2184"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/374/P.Heid._VI_374.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3072.xml
+++ b/HGV_meta_EpiDoc/HGV4/3072.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2194"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/375/P.Heid._VI_375.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3073.xml
+++ b/HGV_meta_EpiDoc/HGV4/3073.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2171"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/376/P.Heid._VI_376.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3074.xml
+++ b/HGV_meta_EpiDoc/HGV4/3074.xml
@@ -86,6 +86,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2188"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/377/P.Heid._VI_377.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3075.xml
+++ b/HGV_meta_EpiDoc/HGV4/3075.xml
@@ -101,6 +101,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2185"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/378/P.Heid._VI_378.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3076.xml
+++ b/HGV_meta_EpiDoc/HGV4/3076.xml
@@ -124,6 +124,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2176"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/379/P.Heid._VI_379.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3077.xml
+++ b/HGV_meta_EpiDoc/HGV4/3077.xml
@@ -133,6 +133,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2197"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/380/P.Heid._VI_380.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3078.xml
+++ b/HGV_meta_EpiDoc/HGV4/3078.xml
@@ -108,6 +108,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2193"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/381/P.Heid._VI_381.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3079.xml
+++ b/HGV_meta_EpiDoc/HGV4/3079.xml
@@ -116,6 +116,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2172"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/382/P.Heid._VI_382.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3080.xml
+++ b/HGV_meta_EpiDoc/HGV4/3080.xml
@@ -111,6 +111,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2191"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/383/P.Heid._VI_383.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3081.xml
+++ b/HGV_meta_EpiDoc/HGV4/3081.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2175"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/384/P.Heid._VI_384.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3082.xml
+++ b/HGV_meta_EpiDoc/HGV4/3082.xml
@@ -90,6 +90,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2178"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/385/P.Heid._VI_385.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV4/3083.xml
+++ b/HGV_meta_EpiDoc/HGV4/3083.xml
@@ -89,6 +89,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2180"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VI/386/P.Heid._VI_386.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV41/40983.xml
+++ b/HGV_meta_EpiDoc/HGV41/40983.xml
@@ -94,6 +94,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_70"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._V/350/P.Heid._V_350.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV41/40984.xml
+++ b/HGV_meta_EpiDoc/HGV41/40984.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_824"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._V/361/P.Heid._V_361.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV42/41101.xml
+++ b/HGV_meta_EpiDoc/HGV42/41101.xml
@@ -93,6 +93,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_243"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/404/P.Heid._VII_404.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV42/41366.xml
+++ b/HGV_meta_EpiDoc/HGV42/41366.xml
@@ -112,7 +112,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV42/41502.xml
+++ b/HGV_meta_EpiDoc/HGV42/41502.xml
@@ -108,6 +108,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_226"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/15913/15913.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV42/41516.xml
+++ b/HGV_meta_EpiDoc/HGV42/41516.xml
@@ -84,6 +84,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1282"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/017/VBP_II_17.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV42/41529.xml
+++ b/HGV_meta_EpiDoc/HGV42/41529.xml
@@ -110,6 +110,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1090"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/393/P.Heid._VII_393.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV42/41530.xml
+++ b/HGV_meta_EpiDoc/HGV42/41530.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_438"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/388/P.Heid._VII_388.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV42/41531.xml
+++ b/HGV_meta_EpiDoc/HGV42/41531.xml
@@ -114,6 +114,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1105"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/389/P.Heid._VII_389.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV42/41532.xml
+++ b/HGV_meta_EpiDoc/HGV42/41532.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1218_a"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/390/P.Heid._VII_390.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV42/41546.xml
+++ b/HGV_meta_EpiDoc/HGV42/41546.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1462"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Hamb._IV/272/P.Hamb._IV_272.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV44/43228.xml
+++ b/HGV_meta_EpiDoc/HGV44/43228.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_209"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/15750/15750.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV44/43310.xml
+++ b/HGV_meta_EpiDoc/HGV44/43310.xml
@@ -94,6 +94,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1106"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/015/VBP_II_15.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV44/43483.xml
+++ b/HGV_meta_EpiDoc/HGV44/43483.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_389"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/099/VBP_IV_99.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV44/43672.xml
+++ b/HGV_meta_EpiDoc/HGV44/43672.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_32"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/049/VBP_IV_49.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV44/43995.xml
+++ b/HGV_meta_EpiDoc/HGV44/43995.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_400"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/014/VBP_II_14.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44107.xml
+++ b/HGV_meta_EpiDoc/HGV45/44107.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1316"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/005/VBP_II_5.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44617.xml
+++ b/HGV_meta_EpiDoc/HGV45/44617.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4927"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Polit.Iud./01/P.Polit.Iud._1.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44618.xml
+++ b/HGV_meta_EpiDoc/HGV45/44618.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4877"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Polit.Iud./01/P.Polit.Iud._2.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44620.xml
+++ b/HGV_meta_EpiDoc/HGV45/44620.xml
@@ -125,6 +125,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4931"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Polit.Iud./01/P.Polit.Iud._4.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44626.xml
+++ b/HGV_meta_EpiDoc/HGV45/44626.xml
@@ -108,6 +108,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4928"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Polit.Iud./01/P.Polit.Iud._10.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44627.xml
+++ b/HGV_meta_EpiDoc/HGV45/44627.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4934"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Polit.Iud./01/P.Polit.Iud._11.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44717.xml
+++ b/HGV_meta_EpiDoc/HGV45/44717.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4876"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Phrur.Diosk./01/P.Phrur.Diosk._1.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44720.xml
+++ b/HGV_meta_EpiDoc/HGV45/44720.xml
@@ -115,6 +115,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4878_a-b"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Phrur.Diosk./04/P.Phrur.Diosk._4.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44722.xml
+++ b/HGV_meta_EpiDoc/HGV45/44722.xml
@@ -106,6 +106,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4925"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Phrur.Diosk./06/P.Phrur.Diosk._6.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44729.xml
+++ b/HGV_meta_EpiDoc/HGV45/44729.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4930"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Phrur.Diosk./14/P.Phrur.Diosk._14.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44731.xml
+++ b/HGV_meta_EpiDoc/HGV45/44731.xml
@@ -89,6 +89,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4926"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Phrur.Diosk./16/P.Phrur.Diosk._16.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV45/44733.xml
+++ b/HGV_meta_EpiDoc/HGV45/44733.xml
@@ -93,6 +93,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4868"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Phrur.Diosk./18/P.Phrur.Diosk._18.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV46/45289.xml
+++ b/HGV_meta_EpiDoc/HGV46/45289.xml
@@ -94,7 +94,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/P.Neph./029/P.Neph._29.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Neph./029/P.Neph._29.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV48/47290.xml
+++ b/HGV_meta_EpiDoc/HGV48/47290.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3897"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VIII/412/P.Heid._VIII_412.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV48/47291.xml
+++ b/HGV_meta_EpiDoc/HGV48/47291.xml
@@ -111,6 +111,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3912"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VIII/413/P.Heid._VIII_413.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV48/47292.xml
+++ b/HGV_meta_EpiDoc/HGV48/47292.xml
@@ -130,6 +130,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3927"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VIII/414/P.Heid._VIII_414.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV48/47293.xml
+++ b/HGV_meta_EpiDoc/HGV48/47293.xml
@@ -94,6 +94,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3932"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VIII/415/P.Heid._VIII_415.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV48/47294.xml
+++ b/HGV_meta_EpiDoc/HGV48/47294.xml
@@ -119,6 +119,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3899"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VIII/416/P.Heid._VIII_416.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV48/47295.xml
+++ b/HGV_meta_EpiDoc/HGV48/47295.xml
@@ -112,6 +112,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3924"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VIII/417/P.Heid._VIII_417.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV48/47296.xml
+++ b/HGV_meta_EpiDoc/HGV48/47296.xml
@@ -204,6 +204,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3914"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VIII/418/P.Heid._VIII_418.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV48/47297.xml
+++ b/HGV_meta_EpiDoc/HGV48/47297.xml
@@ -93,6 +93,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3906"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VIII/419/P.Heid._VIII_419.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV48/47298.xml
+++ b/HGV_meta_EpiDoc/HGV48/47298.xml
@@ -146,6 +146,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3923"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VIII/420/P.Heid._VIII_420.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV48/47299.xml
+++ b/HGV_meta_EpiDoc/HGV48/47299.xml
@@ -107,6 +107,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3904"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VIII/421/P.Heid._VIII_421.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV48/47364.xml
+++ b/HGV_meta_EpiDoc/HGV48/47364.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_3074"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/218/P.Heid._II_218.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV5/4133.xml
+++ b/HGV_meta_EpiDoc/HGV5/4133.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1281"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/12528/12528.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV5/4204.xml
+++ b/HGV_meta_EpiDoc/HGV5/4204.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1281"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/07377/07377.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV6/5128.xml
+++ b/HGV_meta_EpiDoc/HGV6/5128.xml
@@ -90,7 +90,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV6/5134.xml
+++ b/HGV_meta_EpiDoc/HGV6/5134.xml
@@ -89,6 +89,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4047"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/225/P.Heid._III_225.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV6/5136.xml
+++ b/HGV_meta_EpiDoc/HGV6/5136.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2073"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/231/P.Heid._III_231.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV6/5137.xml
+++ b/HGV_meta_EpiDoc/HGV6/5137.xml
@@ -119,6 +119,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2088"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/232/P.Heid._III_232.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV6/5703.xml
+++ b/HGV_meta_EpiDoc/HGV6/5703.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_442"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/07632/07632.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV6/5776.xml
+++ b/HGV_meta_EpiDoc/HGV6/5776.xml
@@ -112,6 +112,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1705"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/212/P.Heid._II_212.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV6/5830.xml
+++ b/HGV_meta_EpiDoc/HGV6/5830.xml
@@ -128,6 +128,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_603"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/048/VBP_IV_48.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV6/5831.xml
+++ b/HGV_meta_EpiDoc/HGV6/5831.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_670"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/082/VBP_IV_82.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV6/5957.xml
+++ b/HGV_meta_EpiDoc/HGV6/5957.xml
@@ -107,6 +107,12 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1122"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/013/VBP_II_13.html"/>
+               </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/09800b/09800b.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV64/63493.xml
+++ b/HGV_meta_EpiDoc/HGV64/63493.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_845"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/15917/15917.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV65/64870.xml
+++ b/HGV_meta_EpiDoc/HGV65/64870.xml
@@ -137,6 +137,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1101"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/12719/12719.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV7/6228.xml
+++ b/HGV_meta_EpiDoc/HGV7/6228.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2072"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/210/P.Heid._II_210.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV7/6229.xml
+++ b/HGV_meta_EpiDoc/HGV7/6229.xml
@@ -121,6 +121,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_2089"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._II/217/P.Heid._II_217.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV70/69044.xml
+++ b/HGV_meta_EpiDoc/HGV70/69044.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1386"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/13728/13728.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV79/78288.xml
+++ b/HGV_meta_EpiDoc/HGV79/78288.xml
@@ -87,7 +87,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/P.Hamb._IV/273/P.Hamb._IV_273.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Hamb._IV/273/P.Hamb._IV_273.html"/>
                </figure>
             </p>
         </div>

--- a/HGV_meta_EpiDoc/HGV79/78313.xml
+++ b/HGV_meta_EpiDoc/HGV79/78313.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4083"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/227/P.Heid._III_227.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV79/78314.xml
+++ b/HGV_meta_EpiDoc/HGV79/78314.xml
@@ -92,6 +92,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4013"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/228/P.Heid._III_228.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV79/78315.xml
+++ b/HGV_meta_EpiDoc/HGV79/78315.xml
@@ -84,6 +84,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1312"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/229/P.Heid._III_229.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV79/78316.xml
+++ b/HGV_meta_EpiDoc/HGV79/78316.xml
@@ -106,6 +106,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_4001"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/230/P.Heid._III_230.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV79/78317.xml
+++ b/HGV_meta_EpiDoc/HGV79/78317.xml
@@ -86,6 +86,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_443"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._III/233/P.Heid._III_233.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV79/78356.xml
+++ b/HGV_meta_EpiDoc/HGV79/78356.xml
@@ -93,7 +93,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/P.Heid._VII/391/P.Heid._VII_391.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/391/P.Heid._VII_391.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV79/78357.xml
+++ b/HGV_meta_EpiDoc/HGV79/78357.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1094"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/394/P.Heid._VII_394.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV79/78358.xml
+++ b/HGV_meta_EpiDoc/HGV79/78358.xml
@@ -86,6 +86,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1091"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/395/P.Heid._VII_395.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV79/78801.xml
+++ b/HGV_meta_EpiDoc/HGV79/78801.xml
@@ -92,6 +92,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_59"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Thomas/24/P.Thomas_24.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV8/7241a.xml
+++ b/HGV_meta_EpiDoc/HGV8/7241a.xml
@@ -112,7 +112,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV8/7245.xml
+++ b/HGV_meta_EpiDoc/HGV8/7245.xml
@@ -108,7 +108,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV80/79211.xml
+++ b/HGV_meta_EpiDoc/HGV80/79211.xml
@@ -87,6 +87,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_44"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/15869/15869.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV80/79239.xml
+++ b/HGV_meta_EpiDoc/HGV80/79239.xml
@@ -114,6 +114,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_73"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/15915/15915.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV80/79325.xml
+++ b/HGV_meta_EpiDoc/HGV80/79325.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_389"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/16122/16122.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV80/79326.xml
+++ b/HGV_meta_EpiDoc/HGV80/79326.xml
@@ -103,6 +103,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_389"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/16123/16123.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV80/79327.xml
+++ b/HGV_meta_EpiDoc/HGV80/79327.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_376"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/SB/16124/16124.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80102.xml
+++ b/HGV_meta_EpiDoc/HGV81/80102.xml
@@ -84,6 +84,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1284"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/012/VBP_II_12.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80103.xml
+++ b/HGV_meta_EpiDoc/HGV81/80103.xml
@@ -111,7 +111,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_II/026/VBP_II_26.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/026/VBP_II_26.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV81/80105.xml
+++ b/HGV_meta_EpiDoc/HGV81/80105.xml
@@ -104,7 +104,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/VBP_IV/050/VBP_IV_50.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/050/VBP_IV_50.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV81/80106.xml
+++ b/HGV_meta_EpiDoc/HGV81/80106.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_33"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/051/VBP_IV_51.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80115.xml
+++ b/HGV_meta_EpiDoc/HGV81/80115.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_27"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/70/VBP_IV70.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80116.xml
+++ b/HGV_meta_EpiDoc/HGV81/80116.xml
@@ -104,6 +104,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_387"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/098/VBP_IV_98.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80117.xml
+++ b/HGV_meta_EpiDoc/HGV81/80117.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_519"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/100/VBP_IV_100.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80118.xml
+++ b/HGV_meta_EpiDoc/HGV81/80118.xml
@@ -109,6 +109,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_522"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/101/VBP_IV_101.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80119.xml
+++ b/HGV_meta_EpiDoc/HGV81/80119.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_521"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/102/VBP_IV_102.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80120.xml
+++ b/HGV_meta_EpiDoc/HGV81/80120.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_369"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/103/VBP_IV_103.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80121.xml
+++ b/HGV_meta_EpiDoc/HGV81/80121.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_524"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/104/VBP_IV_104.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80122.xml
+++ b/HGV_meta_EpiDoc/HGV81/80122.xml
@@ -110,6 +110,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_58"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/105/VBP_IV_105.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80123.xml
+++ b/HGV_meta_EpiDoc/HGV81/80123.xml
@@ -114,6 +114,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_68"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/106/VBP_IV_106.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80124.xml
+++ b/HGV_meta_EpiDoc/HGV81/80124.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_60"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/107/VBP_IV_107.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80125.xml
+++ b/HGV_meta_EpiDoc/HGV81/80125.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_75"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/108/VBP_IV_108.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80126.xml
+++ b/HGV_meta_EpiDoc/HGV81/80126.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_129"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/109/VBP_IV_109.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV81/80127.xml
+++ b/HGV_meta_EpiDoc/HGV81/80127.xml
@@ -100,6 +100,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/o_g_395"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/110/VBP_IV_110.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV9/8140.xml
+++ b/HGV_meta_EpiDoc/HGV9/8140.xml
@@ -105,6 +105,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_171"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/002/VBP_II_2.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV9/8141.xml
+++ b/HGV_meta_EpiDoc/HGV9/8141.xml
@@ -119,6 +119,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_12"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/047/VBP_IV_47.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV9/8173.xml
+++ b/HGV_meta_EpiDoc/HGV9/8173.xml
@@ -106,6 +106,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_204"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/011/VBP_II_11.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV9/8736.xml
+++ b/HGV_meta_EpiDoc/HGV9/8736.xml
@@ -119,6 +119,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_6"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_IV/079/VBP_IV_79.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV9/8761.xml
+++ b/HGV_meta_EpiDoc/HGV9/8761.xml
@@ -114,6 +114,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_436"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._VII/387/P.Heid._VII_387.html"/>
+               </figure>
             </p>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89277.xml
+++ b/HGV_meta_EpiDoc/HGV90/89277.xml
@@ -102,6 +102,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5004"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/422/P.Heid._IX_422.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89279.xml
+++ b/HGV_meta_EpiDoc/HGV90/89279.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5006"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/424/P.Heid._IX_424.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89280.xml
+++ b/HGV_meta_EpiDoc/HGV90/89280.xml
@@ -108,6 +108,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5007"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/425/P.Heid._IX_425.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89281.xml
+++ b/HGV_meta_EpiDoc/HGV90/89281.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5008"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/426/P.Heid._IX_426.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89282.xml
+++ b/HGV_meta_EpiDoc/HGV90/89282.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5009"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/427/P.Heid._IX_427.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89283.xml
+++ b/HGV_meta_EpiDoc/HGV90/89283.xml
@@ -110,6 +110,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5010"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/428/P.Heid._IX_428.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89284.xml
+++ b/HGV_meta_EpiDoc/HGV90/89284.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5011"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/429/P.Heid._IX_429.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89285.xml
+++ b/HGV_meta_EpiDoc/HGV90/89285.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5012"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/430/P.Heid._IX_430.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89286.xml
+++ b/HGV_meta_EpiDoc/HGV90/89286.xml
@@ -113,6 +113,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5013"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/431/P.Heid._IX_431.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89287.xml
+++ b/HGV_meta_EpiDoc/HGV90/89287.xml
@@ -108,7 +108,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/P.Heid._IX/432/P.Heid._IX_432.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/432/P.Heid._IX_432.html"/>
                </figure>
             </p>
         </div>

--- a/HGV_meta_EpiDoc/HGV90/89288.xml
+++ b/HGV_meta_EpiDoc/HGV90/89288.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5015"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/433/P.Heid._IX_433.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89289.xml
+++ b/HGV_meta_EpiDoc/HGV90/89289.xml
@@ -96,7 +96,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/P.Heid._IX/434/P.Heid._IX_434.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/434/P.Heid._IX_434.html"/>
                </figure>
             </p>
         </div>

--- a/HGV_meta_EpiDoc/HGV90/89290.xml
+++ b/HGV_meta_EpiDoc/HGV90/89290.xml
@@ -99,6 +99,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5018"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/435/P.Heid._IX_435.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89291.xml
+++ b/HGV_meta_EpiDoc/HGV90/89291.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5019"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/436/P.Heid._IX_436.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89292.xml
+++ b/HGV_meta_EpiDoc/HGV90/89292.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5021"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/437/P.Heid._IX_437.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89293.xml
+++ b/HGV_meta_EpiDoc/HGV90/89293.xml
@@ -98,6 +98,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5030"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/438/P.Heid._IX_438.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89294.xml
+++ b/HGV_meta_EpiDoc/HGV90/89294.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5006_a"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/439/P.Heid._IX_439.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89295.xml
+++ b/HGV_meta_EpiDoc/HGV90/89295.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5022"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/440/P.Heid._IX_440.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89296.xml
+++ b/HGV_meta_EpiDoc/HGV90/89296.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5031"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/441/P.Heid._IX_441.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89297.xml
+++ b/HGV_meta_EpiDoc/HGV90/89297.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5049"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/442/P.Heid._IX_442.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89298.xml
+++ b/HGV_meta_EpiDoc/HGV90/89298.xml
@@ -96,6 +96,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5048"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/443/P.Heid._IX_443.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89299.xml
+++ b/HGV_meta_EpiDoc/HGV90/89299.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5071"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/444/P.Heid._IX_444.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV90/89300.xml
+++ b/HGV_meta_EpiDoc/HGV90/89300.xml
@@ -97,6 +97,9 @@
                <figure>
                   <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_5082"/>
                </figure>
+               <figure>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Heid._IX/445/P.Heid._IX_445.html"/>
+               </figure>
             </p>
         </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV98/97066.xml
+++ b/HGV_meta_EpiDoc/HGV98/97066.xml
@@ -94,7 +94,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV98/97067.xml
+++ b/HGV_meta_EpiDoc/HGV98/97067.xml
@@ -85,7 +85,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV98/97068.xml
+++ b/HGV_meta_EpiDoc/HGV98/97068.xml
@@ -93,7 +93,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV98/97069.xml
+++ b/HGV_meta_EpiDoc/HGV98/97069.xml
@@ -95,7 +95,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV98/97070.xml
+++ b/HGV_meta_EpiDoc/HGV98/97070.xml
@@ -82,7 +82,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV98/97071.xml
+++ b/HGV_meta_EpiDoc/HGV98/97071.xml
@@ -86,7 +86,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV98/97072.xml
+++ b/HGV_meta_EpiDoc/HGV98/97072.xml
@@ -88,7 +88,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV98/97073.xml
+++ b/HGV_meta_EpiDoc/HGV98/97073.xml
@@ -81,7 +81,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV98/97074.xml
+++ b/HGV_meta_EpiDoc/HGV98/97074.xml
@@ -91,7 +91,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.rzuser.uni-heidelberg.de/~gv0/Papyri/Grad.html"/>
+                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Grad.html"/>
                </figure>
             </p>
          </div>


### PR DESCRIPTION
DCLP wurde bisher noch nicht berücksichtigt; kann vermutlich mit Search and Replace erledigt werden.
