### PR TITLE
Add <del rend="cross-strokes">

### DIFF
--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.105.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.105.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> με<gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> με<gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
 
     <lb n="2"/><expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Βαρατιτ <gap reason="lost" extent="unknown" unit="character"/>
 
@@ -53,7 +53,7 @@
 
     <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀ<unclear>ν</unclear><supplied reason="lost">όμ<ex>ατος</ex></supplied></expan> <gap reason="lost" extent="unknown" unit="character"/>
 
-    <lb n="5"/><expan>ἀρτ<ex>άβην</ex></expan> <num value="1">μί<supplied reason="lost">αν</supplied></num> <gap reason="lost" extent="unknown" unit="character"/>
+    <lb n="5"/><expan>ἀρτ<ex>άβην</ex></expan> <num value="1">μί<supplied reason="lost">αν</supplied></num> <gap reason="lost" extent="unknown" unit="character"/></del>
 
     <lb n="6" rend="indent"/><unclear>ω</unclear><supplied reason="lost">ευρευεξ.</supplied>
 

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.107.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.107.xml
@@ -45,11 +45,11 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex cert="low">ἔτους</ex></expan> <num value="11"><unclear>ια</unclear></num> <unclear><g type="slanting-stroke"/></unclear><unclear><g type="slanting-stroke"/></unclear> <unclear>Φαρμουθι</unclear>  <num value="23">κ<unclear>γ</unclear></num>
+<lb n="1"/><del rend="cross-strokes"><expan><ex cert="low">ἔτους</ex></expan> <num value="11"><unclear>ια</unclear></num> <unclear><g type="slanting-stroke"/></unclear><unclear><g type="slanting-stroke"/></unclear> <unclear>Φαρμουθι</unclear>  <num value="23">κ<unclear>γ</unclear></num>
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Α<gap reason="illegible" atLeast="4" atMost="5" unit="character"/> <expan><unclear>ὑ</unclear>π<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Λαβα
 
-<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γί<ex>νεται</ex></expan> <expan><unclear>μ</unclear><ex>άτια</ex></expan> <num value="5"><unclear>ε</unclear></num>.
+<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γί<ex>νεται</ex></expan> <expan><unclear>μ</unclear><ex>άτια</ex></expan> <num value="5"><unclear>ε</unclear></num></del>.
 
 <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.17.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.17.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="11">ια</num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="11">ια</num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <app type="alternative"><lem>Νου<unclear>α</unclear>τ</lem><rdg>Νου<unclear>ε</unclear>τ</rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
     <lb n="3"/>Δουκα<unclear>ιν</unclear>ως <expan>πυρ<ex>οῦ</ex></expan>
 
-    <lb n="4"/><expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <hi rend="supraline">ε</hi>.
+    <lb n="4"/><expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <hi rend="supraline">ε</hi></del>.
 
     <lb n="5" rend="indent"/>ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.19.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.19.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Α<unclear>γ</unclear>ιεν <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
     <lb n="3"/>Ινκενετ <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέν
 
-    <lb n="4" break="no"/>τε</num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>.
+    <lb n="4" break="no"/>τε</num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>.
 
     <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab></div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.20.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.20.xml
@@ -47,11 +47,11 @@ line 4 indented</change>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <app type="alternative"><lem>Α<unclear>γ</unclear>ιε<unclear>ν</unclear></lem><rdg>Α<unclear>τ</unclear>ιε<unclear>ν</unclear></rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <app type="alternative"><lem>Α<unclear>τ</unclear>ιου</lem><rdg>Α<unclear>γ</unclear>ιου</rdg></app>
 
-    <lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>.
+    <lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num></del>.
 
     <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.21.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.21.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμου<hi rend="supraline">θι</hi> <num value="22"><hi rend="supraline">κβ</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμου<hi rend="supraline">θι</hi> <num value="22"><hi rend="supraline">κβ</hi></num>.
 
     <lb n="2"/><expan>μέτρη<ex>σον</ex></expan> <app type="alternative"><lem>Α<unclear>γ</unclear>διεν</lem><rdg>Α<unclear>υ</unclear>διεν</rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
     <lb n="3"/>Γοδως <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>,
 
-    <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+    <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
     <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.22.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.22.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμου<hi rend="supraline">θι</hi> <num value="22"><hi rend="supraline">κβ</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμου<hi rend="supraline">θι</hi> <num value="22"><hi rend="supraline">κβ</hi></num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Αδιννοου <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
@@ -53,7 +53,7 @@
 
     <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="10">ι</num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Αὐρηλίου
 
-    <lb n="5"/><expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex cert="low">πυροῦ ἀρτάβη</ex></expan> <num value="1">α</num> <num value="1/2"><supplied reason="omitted">ἥμισυ</supplied></num>.
+    <lb n="5"/><expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex cert="low">πυροῦ ἀρτάβη</ex></expan> <num value="1">α</num> <num value="1/2"><supplied reason="omitted">ἥμισυ</supplied></num></del>.
 
     <lb n="6" rend="indent"/> <subst><add place="inline">ωε<unclear>υρ</unclear>ευεξ</add><del rend="corrected">ωε<unclear>υρ</unclear>εξεξ</del></subst>. 
 

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.23.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.23.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κβ</num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κβ</num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Αδιννοου
 
@@ -55,7 +55,7 @@
 
     <lb n="5"/><expan>ὀνόμ<ex>ατος</ex></expan> Κεστεκ <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan>
 
-    <lb n="6"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γ<ex>ίνεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+    <lb n="6"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γ<ex>ίνεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
     <lb n="7" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.24.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.24.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Αδιννοου <expan>ὑπ<ex>ὲρ</ex></expan>
 
     <lb n="3"/><expan>ὀνόμ<ex>ατος</ex></expan> <unclear>Ι</unclear>νχ<gap reason="illegible" atLeast="5" atMost="7" unit="character"/> <expan>πυρ<ex>οῦ</ex></expan>
 
-    <lb n="4"/><expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>.
+    <lb n="4"/><expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num></del>.
 
     <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.25.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.25.xml
@@ -46,7 +46,7 @@ By finalization, indent line 6.</change>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
     <lb n="2"/><expan><supplied reason="lost">μέτρ</supplied><ex>ησον</ex></expan> Αει <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Μασακι <expan>πυρ<ex>οῦ</ex></expan>
 
@@ -56,7 +56,7 @@ By finalization, indent line 6.</change>
 
     <lb n="5"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig><supplied reason="lost">ἥ</supplied>μισου</orig></choice></num> <del rend="erasure"><gap reason="illegible" atLeast="2" atMost="3" unit="character"/></del> ωε<unclear>υρ</unclear>ευεξ.
 
-    <lb n="6" rend="indent"/> <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+    <lb n="6" rend="indent"/> <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 </ab>
       </div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.26.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.26.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <unclear>Αει</unclear> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <app type="alternative"><lem><unclear>Πα</unclear>τε<gap reason="illegible" quantity="1" unit="character"/><unclear>υ</unclear><gap reason="illegible" quantity="1" unit="character"/>ου</lem><rdg><unclear>Πα</unclear>τε<unclear>τ</unclear> υ<unclear>ἱ</unclear>οῦ</rdg></app>
 
@@ -53,7 +53,7 @@
 
     <lb n="4"/>καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Αβου <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>,
 
-    <lb n="5"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>· <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβη</ex></expan> <num value="1">α</num>.
+    <lb n="5"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>· <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβη</ex></expan> <num value="1">α</num></del>.
 
     <lb n="6"/>ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.27.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.27.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22"><hi rend="supraline">κβ</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22"><hi rend="supraline">κβ</hi></num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <app type="alternative"><lem>Αι<gap reason="illegible" quantity="3" unit="character"/></lem><rdg>Αι<unclear>γ</unclear><gap reason="illegible" quantity="2" unit="character"/></rdg><rdg>Αι<unclear>ν</unclear><gap reason="illegible" quantity="2" unit="character"/></rdg></app> <expan>ὀνόμ<ex>ατος</ex></expan>
 
     <lb n="3"/><app type="alternative"><lem>Μεν<unclear>α</unclear>ρε<unclear>τ</unclear></lem><rdg>Μεν<unclear>ε</unclear>ρε<unclear>τ</unclear></rdg><rdg>Μεν<unclear>α</unclear>ρε<unclear>γ</unclear></rdg><rdg>Μεν<unclear>ε</unclear>ρε<unclear>γ</unclear></rdg></app> <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan>
 
-    <lb n="4"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig><subst><add place="inline">ἥμισου</add><del rend="corrected">μμισου</del></subst></orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+    <lb n="4"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig><subst><add place="inline">ἥμισου</add><del rend="corrected">μμισου</del></subst></orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
     <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.28.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.28.xml
@@ -45,11 +45,11 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan><unclear>μ</unclear><supplied reason="lost">έτρ<ex>ησον</ex></supplied></expan>
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan><unclear>μ</unclear><supplied reason="lost">έτρ<ex>ησον</ex></supplied></expan>
 
     <lb n="2"/>Αννακι <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Μα<unclear>μο</unclear><supplied reason="lost">υ <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan></supplied>
 
-    <lb n="3"/><num value="5">πέντε</num> <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>. ωε<supplied reason="lost">υρευεξ.</supplied>
+    <lb n="3"/><num value="5">πέντε</num> <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>. ωε<supplied reason="lost">υρευεξ.</supplied>
 </ab>
       </div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.30.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.30.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κβ</num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κβ</num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Αννακι <expan>ὑπ<ex>ὲρ</ex></expan>
 
@@ -53,7 +53,7 @@
 
     <lb n="4"/><expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>,
 
-    <lb n="5"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+    <lb n="5"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
     <lb n="6"/>ωε<unclear>υρ</unclear>ευεξ. 
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.31.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.31.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κβ</num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κβ</num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Αννακι <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
     <lb n="3"/><app type="alternative"><lem>Μαουε<unclear>τ</unclear>ι</lem><rdg>Μαουε<unclear>γ</unclear>ι</rdg></app> <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>
 
-    <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>.
+    <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>.
 
     <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab> </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.32.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.32.xml
@@ -47,13 +47,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Αννακι <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
     <lb n="3"/><app type="alternative"><lem>Β<unclear>α</unclear><gap reason="illegible" atLeast="1" atMost="2" unit="character"/><unclear>α</unclear><gap reason="illegible" atLeast="1" atMost="2" unit="character"/><unclear>ρ</unclear>ου</lem><rdg>Βα<unclear>μα</unclear> <surplus><unclear>πυ</unclear>ροῦ</surplus><certainty match=".." locus="value"/></rdg></app> <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="7">ἑπτὰ</num>
 
-    <lb n="4"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig><unclear>ἥμισου</unclear></orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="7">ζ</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+    <lb n="4"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig><unclear>ἥμισου</unclear></orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="7">ζ</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
     <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.33.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.33.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κβ</num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κβ</num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Αννακι <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
     <lb n="3"/>Τυραννι <expan>πυρ<ex>οῦ</ex></expan> <subst><add place="inline"><expan>μάτ<ex>ια</ex></expan></add><del rend="corrected"><expan>αρατ<ex>ια</ex></expan></del></subst> <num value="5">πέντε</num>,
 
-    <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>.
+    <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>.
 
     <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.34.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.34.xml
@@ -45,9 +45,9 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
 <lb n="2"/>Αν<gap reason="illegible" atLeast="6" atMost="8" unit="character"/> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Δουκακε
-<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan><unclear>μάτ</unclear><ex>ια</ex></expan> <num value="5"><unclear>πέντε</unclear></num>, <expan><unclear>γ</unclear><ex>ίνεται</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>
+<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan><unclear>μάτ</unclear><ex>ια</ex></expan> <num value="5"><unclear>πέντε</unclear></num>, <expan><unclear>γ</unclear><ex>ίνεται</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>.
 <lb n="4" rend="indent"/> <supplied reason="lost">ω</supplied><unclear>ευ</unclear>ρευεξ.
 </ab>
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.35.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.35.xml
@@ -43,11 +43,11 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμου<hi rend="supraline">θι</hi> <num value="22"><hi rend="supraline">κβ</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμου<hi rend="supraline">θι</hi> <num value="22"><hi rend="supraline">κβ</hi></num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Α<unclear>συμο</unclear> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Ανητ
 
-    <lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+    <lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
     <lb n="4" rend="indent"/>ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.36.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.36.xml
@@ -47,13 +47,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <app type="alternative"><lem>Βεκ<gap reason="illegible" quantity="2" unit="character"/>βιε</lem><rdg>Βεκ<unclear>ρα</unclear>βιε</rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
     <lb n="3"/>Ἀπριανοῦ <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>,
 
-    <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>.
+    <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>.
 
     <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.37.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.37.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <app type="alternative"><lem>Bετε<unclear>τ</unclear></lem><rdg>Bετε<unclear>γ</unclear></rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
     <lb n="3"/><app type="alternative"><lem>Α<unclear>γ</unclear>ω</lem><rdg>Α<unclear>τ</unclear>ω</rdg></app> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>,
 
-    <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+    <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 </ab>
       </div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.38.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.38.xml
@@ -45,10 +45,10 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan><g type="slanting-stroke"/> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμου<hi rend="supraline">θι </hi><num value="22"><hi rend="supraline">κβ</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan><g type="slanting-stroke"/> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμου<hi rend="supraline">θι </hi><num value="22"><hi rend="supraline">κβ</hi></num>.
 <lb n="2"/><expan>μέτ<ex>ρησον</ex></expan> <app type="alternative"><lem>Γα<unclear>ρ</unclear>α<unclear>π</unclear></lem><rdg>Γα<unclear>ρ</unclear>α<unclear>ν</unclear></rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 <lb n="3"/>Αβερ<gap reason="illegible" quantity="2" unit="character"/><unclear>λ</unclear>ι <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμι<lb n="4" break="no"/>συ</reg><orig>ἥμι
-<lb n="4" break="no"/>σου</orig></choice></num>, <expan>γ<ex>ίνεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="4" break="no"/>σου</orig></choice></num>, <expan>γ<ex>ίνεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 <lb n="5"/>ωε<unclear>υρ</unclear>ευεξ
 </ab>
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.39.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.39.xml
@@ -47,13 +47,13 @@ line 5 indented.</change>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-    <lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+    <lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
     <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <app type="alternative"><lem>Γοδεν<unclear>α</unclear>τ</lem><rdg>Γοδεν<unclear>ε</unclear>τ</rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
     <lb n="3"/>Ἀπριανοῦ <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan>
 
-    <lb n="4"/><num value="5">πέντε</num>, <supplied reason="lost"><expan>γί<ex>νεται</ex></expan></supplied> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>
+    <lb n="4"/><num value="5">πέντε</num>, <supplied reason="lost"><expan>γί<ex>νεται</ex></expan></supplied> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num></del>.
 
     <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.40.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.40.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Εμπορε<unclear>τ</unclear> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Αδαπ
 <lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>,
 <lb n="4"/>καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <gap reason="illegible" quantity="6" unit="character"/>ε<unclear>τ</unclear> <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>,
@@ -53,7 +53,7 @@
 <lb n="6"/><expan>γί<ex>νεται</ex></expan> μ<expan><ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <choice><reg>Αναψα</reg><orig>Α<unclear>νναψ</unclear>α</orig></choice>
 <lb n="7"/><expan>πυρ<ex>οῦ</ex></expan> μάτ<expan><ex>ια</ex></expan> <num value="7">ἑπτὰ</num> <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="8"/><expan>καὶ ὑπ<ex>ὲρ</ex></expan> ὀνόμ<expan><ex>ατος</ex></expan> <choice><reg>Κνιω</reg><orig>Κ<unclear>ε</unclear>νιω</orig></choice> πυρ<expan><ex>οῦ</ex></expan> <gap reason="lost" extent="unknown" unit="character"/>
-<lb n="9"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="7">ζ</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
+<lb n="9"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="7">ζ</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/></del>
 <lb n="10"/><gap reason="lost" extent="unknown" unit="line"/>
 </ab></div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.41.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.41.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
 
 <lb n="2"/><app type="alternative"><lem>Εντουα<unclear>τ</unclear></lem><rdg>Εντουα<unclear>ς</unclear></rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <app type="alternative"><lem>Μενενα<unclear>τ</unclear>ι</lem><rdg>Μενενα<unclear>γ</unclear>ι</rdg></app> <expan>πυρ<ex>οῦ</ex></expan>
 
@@ -53,7 +53,7 @@
 
 <lb n="4"/>Ἐπαγάθου <expan>ἀρτ<ex>άβης</ex></expan> <choice><reg><num value="1/2">ἥμισυ</num></reg><orig>ἥμισου</orig></choice>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
 
-<lb n="5" rend="indent"/> <app type="alternative"><lem>αλου<unclear>ε</unclear>νε</lem><rdg>αλου<unclear>α</unclear>νε</rdg></app>.
+<lb n="5" rend="indent"/> <app type="alternative"><lem>αλου<unclear>ε</unclear>νε</lem><rdg>αλου<unclear>α</unclear>νε</rdg></app></del>.
 
 <lb n="6" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.42.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.42.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Ζε<unclear>στο</unclear>υ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Συροβα
 <lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>,
 <lb n="4" rend="indent"/> καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Ικτωε<unclear>ι</unclear> <expan>ἀρτ<ex>άβης</ex></expan>
 <lb n="5" rend="indent"/> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan>
 <lb n="6"/><expan>ὀνόμ<ex>ατος</ex></expan> Σακκα <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>
-<lb n="7"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>. <expan><ex>ἀρτάβη</ex></expan> <num value="1"><hi rend="supraline">α</hi></num> <expan>μ<ex>άτια</ex></expan> <num value="1">α</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="7"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>. <expan><ex>ἀρτάβη</ex></expan> <num value="1"><hi rend="supraline">α</hi></num> <expan>μ<ex>άτια</ex></expan> <num value="1">α</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 </ab>
       </div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.44.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.44.xml
@@ -45,10 +45,10 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Ἡρακλείᾳ
 <lb n="3"/><expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Ιακνητ <expan>πυρ<ex>οῦ</ex></expan>
-<lb n="4"/><expan>μάτ<ex>ια</ex></expan> <num value="3">τρία</num> <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num>.
+<lb n="4"/><expan>μάτ<ex>ια</ex></expan> <num value="3">τρία</num> <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num></del>.
 <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>   </div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.45.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.45.xml
@@ -47,10 +47,10 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Ἡρακλείᾳ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <app type="alternative"><lem>Με<unclear>γ</unclear>α
 <lb n="3" break="no"/>λως</lem><rdg>Με<unclear>τ</unclear>α<lb n="3" break="no"/>λως</rdg></app> <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>,
-<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>. ωε<unclear>υρ</unclear>ευεξ.
+<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>. ωε<unclear>υρ</unclear>ευεξ</del>.
 </ab>
       </div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.46.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.46.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Ἡρακλείᾳ <expan>ὑπ<ex>ὲρ</ex></expan>
 
 <lb n="3"/><expan>ὀνόμ<ex>ατος</ex></expan> Διοσκόρου <expan>πυρ<ex>οῦ</ex></expan>
 
-<lb n="4"/><expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="4"/><expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
 <lb n="5"/>ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.48.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.48.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Ἡρακλεί<supplied reason="omitted">ᾳ</supplied> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
 <lb n="3"/><app type="alternative"><lem>Ταφτ<unclear>α</unclear>φ</lem><rdg>Ταφτα<surplus>φ</surplus></rdg></app> <expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num> 
 
-<lb n="4"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="4"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
 </ab>
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.49.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.49.xml
@@ -45,9 +45,9 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
 <lb n="2"/>Ἡρακλείᾳ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Βαμα<unclear>ς</unclear> <expan>πυρ<ex>οῦ</ex></expan>
-<lb n="3"/><supplied reason="omitted"><expan>μάτ<ex>ια</ex></expan></supplied> <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>. <subst><add place="inline">ωε<unclear>υρ</unclear>ευεξ</add><del rend="corrected">ωε<unclear>υρ</unclear>εξεξ</del></subst>.
+<lb n="3"/><supplied reason="omitted"><expan>μάτ<ex>ια</ex></expan></supplied> <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>. <subst><add place="inline">ωε<unclear>υρ</unclear>ευεξ</add><del rend="corrected">ωε<unclear>υρ</unclear>εξεξ</del></subst></del>.
 </ab>
       </div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.50.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.50.xml
@@ -46,7 +46,7 @@ By finalization indent line 7.</change>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <unclear>Ἡρ</unclear>ακλείᾳ <expan>ὑπ<ex>ὲρ</ex></expan>
 
@@ -58,7 +58,7 @@ By finalization indent line 7.</change>
 
 <lb n="6"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
 
-<lb n="7" rend="indent"/> <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="11">ι<hi rend="supraline">α</hi></num>.
+<lb n="7" rend="indent"/> <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="11">ι<hi rend="supraline">α</hi></num></del>.
 
 <lb n="8"/>ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.51.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.51.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρη<ex>σον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρη<ex>σον</ex></expan>
 
 <lb n="2"/>Ἡρακλ<unclear>ε</unclear>ίᾳ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <unclear>Σ</unclear>αμοχερυ
 
 <lb n="3" break="no"/><unclear>ατ</unclear>επ <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>,
 
-<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>. ωε<unclear>υρ</unclear>ευεξ.
+<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>. ωε<unclear>υρ</unclear>ευεξ</del>.
 
 </ab>
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.52.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.52.xml
@@ -45,9 +45,9 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 <lb n="2"/><expan>μέτρη<ex>σον</ex></expan> Ἡρ<unclear>ακ</unclear>λείᾳ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <hi rend="diaeresis">Ι</hi>εροβα
-<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>, <choice><reg><expan>γίν<ex>εται</ex></expan></reg><orig><expan>γείν<ex>εται</ex></expan></orig></choice> μάτια <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>.
+<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>, <choice><reg><expan>γίν<ex>εται</ex></expan></reg><orig><expan>γείν<ex>εται</ex></expan></orig></choice> μάτια <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num></del>.
 <lb n="4"/>ωε<unclear>υρ</unclear>ευεξ.
 </ab>
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.53.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.53.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Ιανεν <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
 <lb n="3"/>Ιανως <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>,
 
-<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
 <lb n="5"/>ωε<unclear>υρ</unclear>ευεξ.
 

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.54.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.54.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κβ</num>. <expan>μέτρ<ex>ησον</ex></expan> Ιαντατως
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κβ</num>. <expan>μέτρ<ex>ησον</ex></expan> Ιαντατως
 
 <lb n="2"/><expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Ταμοδορα πυροῦ <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>,
 
@@ -53,7 +53,7 @@
 
 <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Α<unclear>ν</unclear>ης <expan>μάτ<ex>ια</ex></expan> <num value="7">ἑπτὰ</num>
 
-<lb n="5"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="7">ζ</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>. <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβη</ex></expan> <num value="1">α</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num> <expan>μ<ex>άτια</ex></expan> <num value="1">α</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="5"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="7">ζ</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>. <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβη</ex></expan> <num value="1">α</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num> <expan>μ<ex>άτια</ex></expan> <num value="1">α</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
 <lb n="6" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.55.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.55.xml
@@ -45,11 +45,11 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22"><hi rend="supraline">κβ</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22"><hi rend="supraline">κβ</hi></num>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Ιαν<unclear>τ</unclear>ατως 
 <lb n="3"/><expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <gap reason="illegible" quantity="4" unit="character"/>βασοκ 
 <lb n="4"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτι<ex>α</ex></expan> <num value="5">πέντε</num>,
-<lb n="5"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>.
+<lb n="5"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>.
 <lb n="6" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.56.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.56.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <subst><add place="inline"><num value="22">κ<hi rend="supraline">β</hi></num></add><del rend="corrected"><num><gap reason="illegible" quantity="1" unit="character"/><hi rend="supraline">β</hi></num></del></subst>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <subst><add place="inline"><num value="22">κ<hi rend="supraline">β</hi></num></add><del rend="corrected"><num><gap reason="illegible" quantity="1" unit="character"/><hi rend="supraline">β</hi></num></del></subst>.
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <choice><reg cert="low">Χοβσατι </reg><orig>Κοβ<unclear>σατ</unclear></orig></choice> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
 <lb n="3"/>Σ<unclear>ο</unclear>τορβα <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>,
 
-<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
 <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.57.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.57.xml
@@ -45,9 +45,9 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. 
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Μασαδ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Βαδιτ
-<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.58.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.58.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 
 <lb n="2"/><expan>μέτρη<ex>σον</ex></expan> Μουνχ<unclear>α</unclear><gap reason="illegible" quantity="1" unit="character"/> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνό<supplied reason="lost">μ<ex>ατος</ex></supplied></expan>
 
 <lb n="3"/>αὐ<unclear>τ</unclear>ῆς <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβας</ex></expan> <num value="2">δύο</num> <expan>μάτ<ex>ιον</ex></expan> <num value="1">ἕν</num>,
 
-<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβας</ex></expan> <num value="2">β</num> <expan>μάτ<ex>ιον</ex></expan> <num value="1">α</num>. ωε<unclear>υρ</unclear>ευεξ.
+<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβας</ex></expan> <num value="2">β</num> <expan>μάτ<ex>ιον</ex></expan> <num value="1">α</num>. ωε<unclear>υρ</unclear>ευεξ</del>.
 </ab>
       </div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.59.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.59.xml
@@ -45,10 +45,10 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex cert="low">ἔτους</ex></expan> <num value="11"><unclear>ια</unclear></num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι κ<hi rend="supraline">β</hi>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex cert="low">ἔτους</ex></expan> <num value="11"><unclear>ια</unclear></num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι κ<hi rend="supraline">β</hi>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <unclear>Ν</unclear>αει<unclear>λ</unclear>α <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 <lb n="3"/><gap reason="illegible" quantity="3" unit="character"/><unclear>ει</unclear>τ<gap reason="illegible" quantity="4" unit="character"/>ς <expan>πυρ<ex>οῦ</ex></expan>
-<lb n="4"/><expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <gap reason="illegible" quantity="2" unit="character"/> <expan><ex>ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="4"/><expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <gap reason="illegible" quantity="2" unit="character"/> <expan><ex>ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 <lb n="5"/><space quantity="1" unit="line"/>
 <lb n="6"/>ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.61.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.61.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22"><hi rend="supraline">κβ</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22"><hi rend="supraline">κβ</hi></num>.
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Σινγεν <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
 <lb n="3"/>Αμου <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>,
 
-<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
 <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.62.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.62.xml
@@ -45,11 +45,11 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
 
 <lb n="2"/>Σ<unclear>καπιε</unclear>ν <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισο<supplied reason="lost">υ</supplied></orig></choice></num>,
 
-<lb n="3"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="3"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
 <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.64.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.64.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρη<ex>σον</ex></expan> Τβοχι
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>. <expan>μέτρη<ex>σον</ex></expan> Τβοχι
 
 <lb n="2" break="no"/>νι <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <app type="alternative"><lem><unclear>Αβμα</unclear></lem><rdg><unclear>Αει</unclear> <surplus><expan><unclear>μά</unclear><ex>τια</ex></expan></surplus></rdg></app> <expan><unclear>πυρ</unclear><ex>οῦ</ex></expan> ἀρτάβην
 
@@ -55,7 +55,7 @@
 
 <lb n="5"/><num value="5">πέν<supplied reason="lost">τε</supplied></num><supplied reason="lost">, <expan>γί<ex>νεται</ex></expan></supplied> <expan>μάτ<ex>ια</ex></expan> <num value="5">ε</num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Τβοχινι
 
-<lb n="6"/><expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="6"/><expan>ἀρτ<ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 </ab>
       </div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.65.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.65.xml
@@ -45,10 +45,10 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <abbr><unclear>Τει</unclear>κ</abbr> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 <lb n="3"/>Ιεμαρ <expan>πυρ<ex>οῦ</ex></expan> μάτια
-<lb n="4"/><num value="3">τρία</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num>.
+<lb n="4"/><num value="3">τρία</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num></del>.
 </ab>
 
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.66.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.66.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22"><hi rend="supraline">κβ</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22"><hi rend="supraline">κβ</hi></num>.
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Φαδα <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
@@ -53,7 +53,7 @@
 
 <lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num>.
 
-<lb n="5" rend="indent"/> <subst><add place="inline">ωε<unclear>υ</unclear>ρευεξ</add><del rend="corrected">ωε<unclear>υ</unclear>ρερεξ</del></subst>.
+<lb n="5" rend="indent"/> <subst><add place="inline">ωε<unclear>υ</unclear>ρευεξ</add><del rend="corrected">ωε<unclear>υ</unclear>ρερεξ</del></subst></del>.
 </ab>
       </div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.67.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.67.xml
@@ -45,9 +45,9 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Φαδα <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Α<unclear>τ</unclear>ιου
-<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.69.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.69.xml
@@ -45,14 +45,14 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="22">κ<hi rend="supraline">β</hi></num>.
 <lb n="2"/><expan>μέτρη<ex>σον</ex></expan> Χοβσατι <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 <lb n="3"/><app type="alternative"><lem>Θα<unclear>γ</unclear>ε<unclear>τ</unclear></lem><rdg>Θα<unclear>τ</unclear>ε<unclear>τ</unclear></rdg><rdg>Θα<unclear>γ</unclear>ε<unclear>γ</unclear></rdg><rdg>Θα<unclear>τ</unclear>ε<unclear>γ</unclear></rdg></app> πυροῦ μάτια <num value="10">δέκα</num>,
 <lb n="4"/><expan>γί<ex>νεται</ex></expan> <surplus><expan><ex>πυροῦ ἀρτάβη</ex></expan></surplus> <expan>μάτ<ex>ια</ex></expan> <num value="10">ι</num>. ωε<unclear>υρ</unclear>ευεξ.
 <lb n="5"/>καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <subst><add place="inline">Παρε<unclear>ιρ</unclear>α</add><del rend="corrected">Πα<gap reason="illegible" quantity="1" unit="character"/>ε<unclear>ιρ</unclear>α</del></subst> πυροῦ <expan>ἀρτ<ex>άβης</ex></expan>
 <lb n="6"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 <lb n="7"/><app type="alternative"><lem>Σ<unclear>α</unclear>ι<unclear>τω</unclear><gap reason="illegible" atLeast="1" atMost="2" unit="character"/></lem><rdg>Σ<unclear>α</unclear>ι<unclear>τωτι</unclear></rdg></app> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>.
-<lb n="8" rend="indent"/> <expan><ex>πυροῦ ἀρτάβη</ex></expan> <num value="1">α</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan> <expan>μάτ<ex>ια</ex></expan></num> <subst><add place="inline"><num value="3">γ</num></add><del rend="corrected"><num value="1">α</num></del></subst>.
+<lb n="8" rend="indent"/> <expan><ex>πυροῦ ἀρτάβη</ex></expan> <num value="1">α</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan> <expan>μάτ<ex>ια</ex></expan></num> <subst><add place="inline"><num value="3">γ</num></add><del rend="corrected"><num value="1">α</num></del></subst></del>.
 </ab></div>
       </body>
   </text>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.71.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.71.xml
@@ -45,11 +45,11 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="23">κ<hi rend="supraline">γ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="23">κ<hi rend="supraline">γ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
 
 <lb n="2"/><app type="alternative"><lem>Αυ<unclear>σ</unclear>ενκ<unclear>ους</unclear></lem><rdg>Αυ<unclear>τ</unclear>ενκ<unclear>ου</unclear>ς</rdg></app> <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num>
 
-<lb n="3"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num>.
+<lb n="3"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num></del>.
 
 <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.74.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.74.xml
@@ -45,10 +45,10 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="23">κ<hi rend="supraline">γ</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="23">κ<hi rend="supraline">γ</hi></num>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <unclear>Σ</unclear>ερεχεμ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνομάτω<ex>ν</ex></expan>
 <lb n="3"/><unclear>Σ</unclear>υρ<unclear>ο</unclear>ς ἐ<unclear>π</unclear>ιβαλλόντων <expan>πυρ<ex>οῦ</ex></expan>
-<lb n="4"/><expan>ἀρτ<ex>άβας</ex></expan> <num value="2">δύο</num> μάτια <num value="2">δύο</num>, <expan>γί<ex>νονται</ex></expan> <expan><ex>πυροῦ ἀρτάβαι</ex></expan> <num value="2">β</num> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num>.
+<lb n="4"/><expan>ἀρτ<ex>άβας</ex></expan> <num value="2">δύο</num> μάτια <num value="2">δύο</num>, <expan>γί<ex>νονται</ex></expan> <expan><ex>πυροῦ ἀρτάβαι</ex></expan> <num value="2">β</num> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num></del>.
 <lb n="5"/><space quantity="1" unit="line"/>  
 <lb n="6" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.75.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.75.xml
@@ -46,13 +46,13 @@ By finalization indent line 5.</change>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/> Φαρμουθι <num value="23"><hi rend="supraline">κγ</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/> Φαρμουθι <num value="23"><hi rend="supraline">κγ</hi></num>.
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Μασακιν
 
 <lb n="3"/><expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Χεμμιν <expan>πυρ<ex>οῦ</ex></expan>
 
-<lb n="4"/><expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>.
+<lb n="4"/><expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num></del>.
 
 <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.76.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.76.xml
@@ -45,11 +45,11 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρ<unclear>μουθι</unclear> <num value="23">κ<hi rend="supraline">γ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρ<unclear>μουθι</unclear> <num value="23">κ<hi rend="supraline">γ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
 
 <lb n="2"/><app type="alternative"><lem>Σαβα<unclear>τ</unclear>αν<gap reason="illegible" quantity="4" unit="character"/></lem><rdg>Σαβα<unclear>γ</unclear>αν<gap reason="illegible" quantity="4" unit="character"/></rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Ινκουικ
 
-<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5"><supplied reason="lost">πέ</supplied><unclear>ν</unclear>τε</num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>.
+<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5"><supplied reason="lost">πέ</supplied><unclear>ν</unclear>τε</num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>.
 
 <lb n="4" rend="indent"/> <unclear>ωε</unclear>υρ<unclear>ευεξ</unclear>.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.78.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.78.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/> Φαρμουθι <num value="23">κ<hi rend="supraline">γ</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/> Φαρμουθι <num value="23">κ<hi rend="supraline">γ</hi></num>.
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Τερπου <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
 <lb n="3"/>Δω <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>,
 
-<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>.
+<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num></del>.
 
 <lb n="4"/><space quantity="1" unit="line"/>
 

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.80.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.80.xml
@@ -45,10 +45,10 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="23">κ<hi rend="supraline">γ</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="23">κ<hi rend="supraline">γ</hi></num>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Τερπου <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 <lb n="3"/>Ιαριμ <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>,
-<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>.
+<lb n="4"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num></del>.
 <lb n="4"/><space quantity="1" unit="line"/>
 <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.81.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.81.xml
@@ -45,13 +45,13 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="23">κ<hi rend="supraline">γ</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="23">κ<hi rend="supraline">γ</hi></num>.
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Χοβηρ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
 <lb n="3"/>Αν<unclear>ν</unclear>υ<unclear>ε</unclear>νε<unclear>τ</unclear> <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέν
 
-<lb n="4" break="no"/>τε</num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>.
+<lb n="4" break="no"/>τε</num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>.
 
 <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.82.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.82.xml
@@ -45,11 +45,11 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="24">κ<hi rend="supraline">δ</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="24">κ<hi rend="supraline">δ</hi></num>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Σογοδ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <app type="alternative"><lem>Ψε<unclear>ν</unclear>μενρου</lem><rdg>Ψεμενρου<certainty match=".." locus="value"/></rdg></app>
 <lb n="3"/><expan>μάτ<ex>ια</ex></expan> <num value="10">δέκα</num>, <expan><unclear>γ</unclear><ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="10"><hi rend="supraline">ι</hi></num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 <lb n="4"/>Σογοδ <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβην</ex></expan> <num value="1">μίαν</num> <expan>μάτ<ex>ια</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num>,
-<lb n="5"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβη</ex></expan> <num value="1">α</num> <expan>μ<ex>άτια</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num>, <expan>γί<ex>νονται</ex></expan> <expan><ex>πυροῦ ἀρτάβαι</ex></expan> <num value="2"><hi rend="supraline">β</hi></num> <expan>μάτ<ex>ιον</ex></expan> <num value="1"><hi rend="supraline">α</hi></num>.
+<lb n="5"/><expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβη</ex></expan> <num value="1">α</num> <expan>μ<ex>άτια</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num>, <expan>γί<ex>νονται</ex></expan> <expan><ex>πυροῦ ἀρτάβαι</ex></expan> <num value="2"><hi rend="supraline">β</hi></num> <expan>μάτ<ex>ιον</ex></expan> <num value="1"><hi rend="supraline">α</hi></num></del>.
 <lb n="6" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.83.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.83.xml
@@ -46,7 +46,7 @@ I am unsure about the apparatus entries in lines 4 and 5.</change>
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="25">κ<hi rend="supraline">ε</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="25">κ<hi rend="supraline">ε</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
 
 <lb n="2"/><app type="alternative"><lem>Ενγοσ<unclear>α</unclear>ρεκ</lem><rdg>Ενγοσ<unclear>ε</unclear>ρεκ</rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Μακακ <expan>πυρ<ex>οῦ</ex></expan>
 
@@ -58,7 +58,7 @@ I am unsure about the apparatus entries in lines 4 and 5.</change>
 
 <lb n="6"/><expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Ινκνετ <expan>μάτ<ex>ια</ex></expan>
 
-<lb n="7"/><num value="3">τρία</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="3">γ</num>, <supplied reason="omitted"><expan>γί<ex>νονται</ex></expan></supplied> <expan><ex>πυροῦ ἀρτάβαι</ex></expan> <num value="2">β</num> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num>.
+<lb n="7"/><num value="3">τρία</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="3">γ</num>, <supplied reason="omitted"><expan>γί<ex>νονται</ex></expan></supplied> <expan><ex>πυροῦ ἀρτάβαι</ex></expan> <num value="2">β</num> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num></del>.
 
 <lb n="8" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.85.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.85.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num> <g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρ<supplied reason="omitted">μου</supplied>θι <num value="25">κ<hi rend="supraline">ε</hi></num>. <expan>μέτρη<ex>σον</ex></expan> <app type="alternative"><lem>Kω<unclear>τ</unclear>ω</lem><rdg>Kω<unclear>γ</unclear>ω</rdg></app>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num> <g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρ<supplied reason="omitted">μου</supplied>θι <num value="25">κ<hi rend="supraline">ε</hi></num>. <expan>μέτρη<ex>σον</ex></expan> <app type="alternative"><lem>Kω<unclear>τ</unclear>ω</lem><rdg>Kω<unclear>γ</unclear>ω</rdg></app>
 
 <lb n="2"/><expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Κωκω <expan>μάτ<ex>ια</ex></expan> <num value="6">ἓξ</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="6">ϛ</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>,
 
@@ -63,7 +63,7 @@
 
 <lb n="9"/><subst><add place="inline"><unclear>Α</unclear>μοκουρτα</add><del rend="corrected"><unclear>ο</unclear>μοκουρτα</del></subst> <expan>μάτ<ex>ια</ex></expan> <num value="3">τρία</num> <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Τερπου
 
-<lb n="10"/><supplied reason="lost"><expan>μάτ<ex>ια</ex></expan></supplied><g type="slanting-stroke"/> <num value="5"><supplied reason="lost">πέν</supplied>τε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <unclear>Σαλη</unclear>μ <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num>
+<lb n="10"/><supplied reason="lost"><expan>μάτ<ex>ια</ex></expan></supplied><g type="slanting-stroke"/> <num value="5"><supplied reason="lost">πέν</supplied>τε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>, καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <unclear>Σαλη</unclear>μ <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num></del>.
 </ab>
       </div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.86.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.86.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><supplied reason="lost"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/>Φαρ</supplied>μουθι <num value="25">κ<hi rend="supraline">ε</hi></num>. <expan>μέτρ<ex>ησον</ex></expan> Σου<unclear>γ</unclear>ωτ
+<lb n="1"/><del rend="cross-strokes"><supplied reason="lost"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/>Φαρ</supplied>μουθι <num value="25">κ<hi rend="supraline">ε</hi></num>. <expan>μέτρ<ex>ησον</ex></expan> Σου<unclear>γ</unclear>ωτ
 
 <lb n="2"/><supplied reason="lost"><expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan></supplied> <gap reason="lost" extent="unknown" unit="character"/> <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num> <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>
 
@@ -53,7 +53,7 @@
 
 <lb n="4"/><gap reason="lost" extent="unknown" unit="character"/> <supplied reason="lost"><expan>πυρ<ex>οῦ</ex></expan></supplied> <expan><supplied reason="lost">ἀρ</supplied><unclear>τ</unclear><ex>άβης</ex></expan> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>,
 
-<lb n="5"/><gap reason="illegible" quantity="2" unit="character"/><gap reason="lost" quantity="7" unit="character" precision="low"/><gap reason="illegible" quantity="10" unit="character" precision="low"/> <space extent="unknown" unit="character"/> 
+<lb n="5"/><gap reason="illegible" quantity="2" unit="character"/><gap reason="lost" quantity="7" unit="character" precision="low"/><gap reason="illegible" quantity="10" unit="character" precision="low"/> <space extent="unknown" unit="character"/></del> 
 
 <lb n="6" rend="indent"/> ω<supplied reason="lost">ευρευεξ</supplied>.
 

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.87.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.87.xml
@@ -45,7 +45,7 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="25">κ<hi rend="supraline">ε</hi></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="25">κ<hi rend="supraline">ε</hi></num>.
 
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> <app type="alternative"><lem><unclear>Σο</unclear>υπταου</lem><rdg><unclear>Συ</unclear>πταου</rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
 
@@ -59,7 +59,7 @@
 
 <lb n="7" break="no"/>καινος <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5">ε</num>,
 
-<lb n="8" rend="indent"/> <expan><ex>ἀρτάβαι</ex></expan> <num value="2">β</num> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>.
+<lb n="8" rend="indent"/> <expan><ex>ἀρτάβαι</ex></expan> <num value="2">β</num> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>.
 
 <lb n="9"/>ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.89.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.89.xml
@@ -45,11 +45,11 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="26">κ<hi rend="supraline">ϛ</hi></num> <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="26">κ<hi rend="supraline">ϛ</hi></num> <expan>μέτρ<ex>ησον</ex></expan>
 
 <lb n="2"/>Ακασα <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <app type="alternative"><lem>Α<unclear>γ</unclear>ω</lem><rdg>Α<unclear>τ</unclear>ω</rdg></app> <expan>πυρ<ex>οῦ</ex></expan> <expan>ἀρτ<ex>άβης</ex></expan>
 
-<lb n="3"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="3"/><num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 
 <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.90.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.90.xml
@@ -45,9 +45,9 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num> Φαρμουθι <num value="26">κ<hi rend="supraline">ϛ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num> Φαρμουθι <num value="26">κ<hi rend="supraline">ϛ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
 <lb n="2"/>Ανουκ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Αχουα<unclear>μ</unclear>
-<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <supplied reason="omitted"><expan>ἀρτ<ex>άβης</ex></expan></supplied> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <supplied reason="omitted"><expan>ἀρτ<ex>άβης</ex></expan></supplied> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβης</ex></expan> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.91.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.91.xml
@@ -45,11 +45,11 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/> Φαρμουθι <num value="26">κ<hi rend="supraline">ϛ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/> Φαρμουθι <num value="26">κ<hi rend="supraline">ϛ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
 
 <lb n="2"/><unclear>Β</unclear>οειτ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <unclear>Ταφτουφ</unclear> <expan>πυρ<ex>οῦ</ex></expan>
 
-<lb n="3"/><supplied reason="lost"><expan>ἀρτ<ex>άβην</ex></expan></supplied> <num value="1">μίαν</num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβην</ex></expan> <supplied reason="lost"><num value="1">α</num></supplied>.
+<lb n="3"/><supplied reason="lost"><expan>ἀρτ<ex>άβην</ex></expan></supplied> <num value="1">μίαν</num>, <expan>γί<ex>νεται</ex></expan> <expan><ex>πυροῦ ἀρτάβην</ex></expan> <supplied reason="lost"><num value="1">α</num></supplied></del>.
 
 <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.96.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.96.xml
@@ -45,9 +45,9 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num> Φαρμουθι <num value="26">κ<hi rend="supraline"><unclear>ϛ</unclear></hi><certainty match="../@value" locus="value"/></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num> Φαρμουθι <num value="26">κ<hi rend="supraline"><unclear>ϛ</unclear></hi><certainty match="../@value" locus="value"/></num>. <expan>μέτρ<ex>ησον</ex></expan>
 <lb n="2"/>Τεμνουκ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Θη<del rend="erasure"><unclear>σ</unclear>η <expan>ὑπ<ex>ὲρ</ex></expan></del>πλωχ
-<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>.
+<lb n="3"/><expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>.
 <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab></div>
       </body>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.97.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.97.xml
@@ -45,9 +45,9 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num> Φαρμουθι <num value="26">κ<hi rend="supraline"><unclear>ϛ</unclear></hi><certainty match="../@value" locus="value"/></num>.
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num> Φαρμουθι <num value="26">κ<hi rend="supraline"><unclear>ϛ</unclear></hi><certainty match="../@value" locus="value"/></num>.
 <lb n="2"/><expan>μέτρ<ex>ησον</ex></expan> Τεμνουκ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan>
-<lb n="3"/><choice><reg>Κλαυδίου</reg><orig>Κλαύδις</orig></choice> <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num>.
+<lb n="3"/><choice><reg>Κλαυδίου</reg><orig>Κλαύδις</orig></choice> <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="5">πέντε</num>, <expan>γ<ex>ίνεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num></del>.
 <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ. 
 </ab>
       </div>

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.98.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.98.xml
@@ -46,10 +46,10 @@
          <div xml:lang="grc" type="edition" xml:space="preserve">
 
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="27">κ<hi rend="supraline">ζ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="27">κ<hi rend="supraline">ζ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
 <lb n="2"/>Αβαιτ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Ταμοδορα <subst><add place="inline"><expan>μάτ<ex>ια</ex></expan></add><del rend="corrected">αρτ</del></subst>
 <lb n="3"/><num value="5">πέντε</num> <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="5"><hi rend="supraline">ε</hi></num> καὶ <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> Κουει <expan>μάτ<ex>ια</ex></expan>
-<lb n="4"/><num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="7">ζ</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>.
+<lb n="4"/><num value="2">δύο</num> <num value="1/2"><choice><reg>ἥμισυ</reg><orig>ἥμισου</orig></choice></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="2">β</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num>, <expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="7">ζ</num> <num value="1/2"><expan><ex>ἥμισυ</ex></expan></num></del>.
 <lb n="5" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 
 </ab> 

--- a/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.99.xml
+++ b/DDB_EpiDoc_XML/o.blemmyes/o.blemmyes.99.xml
@@ -45,9 +45,9 @@
          <head xml:lang="en"/>
          <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
-<lb n="1"/><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="27">κ<hi rend="supraline">ζ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
+<lb n="1"/><del rend="cross-strokes"><expan><ex>ἔτους</ex></expan> <num value="11">ια</num><g type="slanting-stroke"/><g type="slanting-stroke"/> Φαρμουθι <num value="27">κ<hi rend="supraline">ζ</hi></num>. <expan>μέτρ<ex>ησον</ex></expan>
 <lb n="2"/><app type="alternative"><lem>Ταχου<unclear>μ</unclear></lem><rdg>Ταχπι<unclear>σα</unclear><certainty match=".." locus="value"/></rdg></app> <expan>ὑπ<ex>ὲρ</ex></expan> <expan>ὀνόμ<ex>ατος</ex></expan> <app type="alternative"><lem><gap reason="illegible" quantity="2" unit="character"/>χορε<unclear>ι</unclear></lem><rdg><unclear>Σα</unclear>χορε<unclear>ι</unclear></rdg></app> <expan>πυρ<ex>οῦ</ex></expan> <expan>μάτ<ex>ια</ex></expan> <num value="3">τρία</num>, 
-<lb n="3"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num>.
+<lb n="3"/><expan>γί<ex>νεται</ex></expan> <expan>μ<ex>άτια</ex></expan> <num value="3"><hi rend="supraline">γ</hi></num></del>.
 <lb n="4" rend="indent"/> ωε<unclear>υρ</unclear>ευεξ.
 </ab>
       </div>


### PR DESCRIPTION
As reported by in O.Blemmyes: "Tous les bons de Xèron sans exception sont cancelés au moyen d’une grande decussis pour éviter que le même tesson serve plusieurs fois" (p. 107). This pull adds the appropriate markup.