### PR TITLE
Fix minor mistake in metadata for O.Blemmyes

### DIFF
--- a/HGV_meta_EpiDoc/HGV370/369044.xml
+++ b/HGV_meta_EpiDoc/HGV370/369044.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817952.xml
+++ b/HGV_meta_EpiDoc/HGV818/817952.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-06" notAfter="-0264-04-06">6. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-06" notAfter="0264-04-06">6. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817953.xml
+++ b/HGV_meta_EpiDoc/HGV818/817953.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817954.xml
+++ b/HGV_meta_EpiDoc/HGV818/817954.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817955.xml
+++ b/HGV_meta_EpiDoc/HGV818/817955.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817956.xml
+++ b/HGV_meta_EpiDoc/HGV818/817956.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817957.xml
+++ b/HGV_meta_EpiDoc/HGV818/817957.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817958.xml
+++ b/HGV_meta_EpiDoc/HGV818/817958.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817959.xml
+++ b/HGV_meta_EpiDoc/HGV818/817959.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817960.xml
+++ b/HGV_meta_EpiDoc/HGV818/817960.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817961.xml
+++ b/HGV_meta_EpiDoc/HGV818/817961.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817962.xml
+++ b/HGV_meta_EpiDoc/HGV818/817962.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817963.xml
+++ b/HGV_meta_EpiDoc/HGV818/817963.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817964.xml
+++ b/HGV_meta_EpiDoc/HGV818/817964.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817965.xml
+++ b/HGV_meta_EpiDoc/HGV818/817965.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817966.xml
+++ b/HGV_meta_EpiDoc/HGV818/817966.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817967.xml
+++ b/HGV_meta_EpiDoc/HGV818/817967.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817968.xml
+++ b/HGV_meta_EpiDoc/HGV818/817968.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817969.xml
+++ b/HGV_meta_EpiDoc/HGV818/817969.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817971.xml
+++ b/HGV_meta_EpiDoc/HGV818/817971.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817972.xml
+++ b/HGV_meta_EpiDoc/HGV818/817972.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817973.xml
+++ b/HGV_meta_EpiDoc/HGV818/817973.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817974.xml
+++ b/HGV_meta_EpiDoc/HGV818/817974.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817975.xml
+++ b/HGV_meta_EpiDoc/HGV818/817975.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817976.xml
+++ b/HGV_meta_EpiDoc/HGV818/817976.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817977.xml
+++ b/HGV_meta_EpiDoc/HGV818/817977.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817978.xml
+++ b/HGV_meta_EpiDoc/HGV818/817978.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817979.xml
+++ b/HGV_meta_EpiDoc/HGV818/817979.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817980.xml
+++ b/HGV_meta_EpiDoc/HGV818/817980.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817981.xml
+++ b/HGV_meta_EpiDoc/HGV818/817981.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817982.xml
+++ b/HGV_meta_EpiDoc/HGV818/817982.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817983.xml
+++ b/HGV_meta_EpiDoc/HGV818/817983.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817984.xml
+++ b/HGV_meta_EpiDoc/HGV818/817984.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817985.xml
+++ b/HGV_meta_EpiDoc/HGV818/817985.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817986.xml
+++ b/HGV_meta_EpiDoc/HGV818/817986.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817987.xml
+++ b/HGV_meta_EpiDoc/HGV818/817987.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817988.xml
+++ b/HGV_meta_EpiDoc/HGV818/817988.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817989.xml
+++ b/HGV_meta_EpiDoc/HGV818/817989.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817990.xml
+++ b/HGV_meta_EpiDoc/HGV818/817990.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817991.xml
+++ b/HGV_meta_EpiDoc/HGV818/817991.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817993.xml
+++ b/HGV_meta_EpiDoc/HGV818/817993.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817994.xml
+++ b/HGV_meta_EpiDoc/HGV818/817994.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817995.xml
+++ b/HGV_meta_EpiDoc/HGV818/817995.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817996.xml
+++ b/HGV_meta_EpiDoc/HGV818/817996.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817997.xml
+++ b/HGV_meta_EpiDoc/HGV818/817997.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817998.xml
+++ b/HGV_meta_EpiDoc/HGV818/817998.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/817999.xml
+++ b/HGV_meta_EpiDoc/HGV818/817999.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV818/818000.xml
+++ b/HGV_meta_EpiDoc/HGV818/818000.xml
@@ -33,7 +33,7 @@
                <history>
                   <origin>
                      <origPlace>Xeron Pelagos</origPlace>
-                     <origDate notBefore="-0264-04-17" notAfter="-0264-04-17">17. Apr. 264 v.Chr.</origDate>
+                     <origDate notBefore="0264-04-17" notAfter="0264-04-17">17. Apr. 264</origDate>
                   </origin>
                   <provenance type="located">
                      <p>


### PR DESCRIPTION
idno[@type="ddb-hybrid"][starts-with(.,"o.blemmyes")]/../..//origDate[starts-with(@notBefore, "-0264")]

idno[@type="ddb-hybrid"][starts-with(.,"o.blemmyes")]/../..//origDate[starts-with(@notBefore, "-0264")]/@notAfter

https://github.com/Edelweiss/hgv/issues/188