### PR TITLE
MP3

### DIFF
--- a/DCLP/118/117810.xml
+++ b/DCLP/118/117810.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">117810</idno>
             <idno type="filename">117810</idno>
             <idno type="dclp-hybrid">tm;;117810</idno>
-            <idno type="MP3">2955.1</idno>
+            <idno type="MP3">02955.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/119/118694.xml
+++ b/DCLP/119/118694.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">118694</idno>
             <idno type="filename">118694</idno>
             <idno type="dclp-hybrid">tm;;118694</idno>
-            <idno type="MP3">2408.02</idno>
+            <idno type="MP3">02408.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/120/119321.xml
+++ b/DCLP/120/119321.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">119321</idno>
             <idno type="filename">119321</idno>
             <idno type="dclp-hybrid">p.oxy;74;4976</idno>
-            <idno type="MP3">2410.112</idno>
+            <idno type="MP3">02410.112</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/120/119323.xml
+++ b/DCLP/120/119323.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">119323</idno>
             <idno type="filename">119323</idno>
             <idno type="dclp-hybrid">p.oxy;74;4978</idno>
-            <idno type="MP3">2410.114</idno>
+            <idno type="MP3">02410.114</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/122/121928.xml
+++ b/DCLP/122/121928.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">121928</idno>
             <idno type="filename">121928</idno>
             <idno type="dclp-hybrid">tm;;121928</idno>
-            <idno type="MP3">2462.001</idno>
+            <idno type="MP3">02462.001</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/122/121929.xml
+++ b/DCLP/122/121929.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">121929</idno>
             <idno type="filename">121929</idno>
             <idno type="dclp-hybrid">tm;;121929</idno>
-            <idno type="MP3">2266.02</idno>
+            <idno type="MP3">02266.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/129/128973.xml
+++ b/DCLP/129/128973.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">128973</idno>
             <idno type="filename">128973</idno>
             <idno type="dclp-hybrid">p.oxy;75;5046</idno>
-            <idno type="MP3">1541.211</idno>
+            <idno type="MP3">01541.211</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/129/128974.xml
+++ b/DCLP/129/128974.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">128974</idno>
             <idno type="filename">128974</idno>
             <idno type="dclp-hybrid">p.oxy;75;5047</idno>
-            <idno type="MP3">1549.02</idno>
+            <idno type="MP3">01549.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/129/128975.xml
+++ b/DCLP/129/128975.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">128975</idno>
             <idno type="filename">128975</idno>
             <idno type="dclp-hybrid">p.oxy;75;5048</idno>
-            <idno type="MP3">1559.01</idno>
+            <idno type="MP3">01559.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/130/129739.xml
+++ b/DCLP/130/129739.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">129739</idno>
             <idno type="filename">129739</idno>
             <idno type="dclp-hybrid">psi;16;1598</idno>
-            <idno type="MP3">1274.02</idno>
+            <idno type="MP3">01274.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/132/131511.xml
+++ b/DCLP/132/131511.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">131511</idno>
             <idno type="filename">131511</idno>
             <idno type="dclp-hybrid">psi;16;1577</idno>
-            <idno type="MP3">1349</idno>
+            <idno type="MP3">01349.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/132/131664.xml
+++ b/DCLP/132/131664.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">131664</idno>
             <idno type="filename">131664</idno>
             <idno type="dclp-hybrid">tm;;131664</idno>
-            <idno type="MP3">1322.011</idno>
+            <idno type="MP3">01322.011</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/140/139884.xml
+++ b/DCLP/140/139884.xml
@@ -20,7 +20,7 @@
             .
           </p>
             </availability>
-            <idno type="MP3">0343.01</idno>
+            <idno type="MP3">00343.010</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/DCLP/141/140275.xml
+++ b/DCLP/141/140275.xml
@@ -20,7 +20,7 @@
             .
           </p>
             </availability>
-            <idno type="MP3">1984.28</idno>
+            <idno type="MP3">01984.280</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/DCLP/141/140280.xml
+++ b/DCLP/141/140280.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">140280</idno>
             <idno type="filename">140280</idno>
             <idno type="dclp-hybrid">p.oxy;76;5076</idno>
-            <idno type="MP3">1631.11</idno>
+            <idno type="MP3">01631.110</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/141/140282.xml
+++ b/DCLP/141/140282.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">140282</idno>
             <idno type="filename">140282</idno>
             <idno type="dclp-hybrid">p.oxy;76;5078</idno>
-            <idno type="MP3">1407.01</idno>
+            <idno type="MP3">01407.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/141/140283.xml
+++ b/DCLP/141/140283.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">140283</idno>
             <idno type="filename">140283</idno>
             <idno type="dclp-hybrid">p.oxy;76;5079</idno>
-            <idno type="MP3">1407.02</idno>
+            <idno type="MP3">01407.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/141/140284.xml
+++ b/DCLP/141/140284.xml
@@ -20,7 +20,7 @@
             .
           </p>
             </availability>
-            <idno type="MP3">1407.31</idno>
+            <idno type="MP3">01407.310</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/DCLP/141/140287.xml
+++ b/DCLP/141/140287.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">140287</idno>
             <idno type="filename">140287</idno>
             <idno type="dclp-hybrid">p.oxy;76;5083</idno>
-            <idno type="MP3">1392.11</idno>
+            <idno type="MP3">01392.110</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/141/140288.xml
+++ b/DCLP/141/140288.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">140288</idno>
             <idno type="filename">140288</idno>
             <idno type="dclp-hybrid">p.oxy;76;5084</idno>
-            <idno type="MP3">1392.01</idno>
+            <idno type="MP3">01392.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/141/140289.xml
+++ b/DCLP/141/140289.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">140289</idno>
             <idno type="filename">140289</idno>
             <idno type="dclp-hybrid">p.oxy;76;5085</idno>
-            <idno type="MP3">1411.01</idno>
+            <idno type="MP3">01411.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/141/140292.xml
+++ b/DCLP/141/140292.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">140292</idno>
             <idno type="filename">140292</idno>
             <idno type="dclp-hybrid">p.oxy;76;5090</idno>
-            <idno type="MP3">1396.02</idno>
+            <idno type="MP3">01396.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/143/142503.xml
+++ b/DCLP/143/142503.xml
@@ -20,7 +20,7 @@
             .
           </p>
             </availability>
-            <idno type="MP3">2353.81</idno>
+            <idno type="MP3">02353.810</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/DCLP/146/145040.xml
+++ b/DCLP/146/145040.xml
@@ -20,7 +20,7 @@
             .
           </p>
             </availability>
-            <idno type="MP3">0348.141</idno>
+            <idno type="MP3">00348.141</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/DCLP/155/154379.xml
+++ b/DCLP/155/154379.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">154379</idno>
             <idno type="filename">154379</idno>
             <idno type="dclp-hybrid">bkt;10;16</idno>
-            <idno type="MP3">2277.01</idno>
+            <idno type="MP3">02277.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/172/171880.xml
+++ b/DCLP/172/171880.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">171880</idno>
             <idno type="filename">171880</idno>
             <idno type="dclp-hybrid">p.oxy;78;5134</idno>
-            <idno type="MP3">1258.002</idno>
+            <idno type="MP3">01258.002</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/172/171881.xml
+++ b/DCLP/172/171881.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">171881</idno>
             <idno type="filename">171881</idno>
             <idno type="dclp-hybrid">p.oxy;78;5135</idno>
-            <idno type="MP3">1258.003</idno>
+            <idno type="MP3">01258.003</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/172/171882.xml
+++ b/DCLP/172/171882.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">171882</idno>
             <idno type="filename">171882</idno>
             <idno type="dclp-hybrid">p.oxy;78;5136</idno>
-            <idno type="MP3">1258.011</idno>
+            <idno type="MP3">01258.011</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/172/171902.xml
+++ b/DCLP/172/171902.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">171902</idno>
             <idno type="filename">171902</idno>
             <idno type="dclp-hybrid">p.oxy;78;5157</idno>
-            <idno type="MP3">1431.13</idno>
+            <idno type="MP3">01431.130</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/172/171903.xml
+++ b/DCLP/172/171903.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">171903</idno>
             <idno type="filename">171903</idno>
             <idno type="dclp-hybrid">p.oxy;78;5158</idno>
-            <idno type="MP3">1432.02</idno>
+            <idno type="MP3">01432.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/172/171906.xml
+++ b/DCLP/172/171906.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">171906</idno>
             <idno type="filename">171906</idno>
             <idno type="dclp-hybrid">p.oxy;78;5161</idno>
-            <idno type="MP3">2134.701</idno>
+            <idno type="MP3">02134.701</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/172/171907.xml
+++ b/DCLP/172/171907.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">171907</idno>
             <idno type="filename">171907</idno>
             <idno type="dclp-hybrid">p.oxy;78;5162</idno>
-            <idno type="MP3">1631.11</idno>
+            <idno type="MP3">01631.110</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/176/175275.xml
+++ b/DCLP/176/175275.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">175275</idno>
             <idno type="filename">175275</idno>
             <idno type="dclp-hybrid">p.bagnall;;10</idno>
-            <idno type="MP3">2692.02</idno>
+            <idno type="MP3">02692.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/176/175280.xml
+++ b/DCLP/176/175280.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">175280</idno>
             <idno type="filename">175280</idno>
             <idno type="dclp-hybrid">p.bagnall;;48</idno>
-            <idno type="MP3">2147.24</idno>
+            <idno type="MP3">02147.240</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/221/220492.xml
+++ b/DCLP/221/220492.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">220492</idno>
             <idno type="filename">220492</idno>
             <idno type="dclp-hybrid">psi;16;1580</idno>
-            <idno type="MP3">933.003</idno>
+            <idno type="MP3">00933.003</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/245/244047.xml
+++ b/DCLP/245/244047.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">244047</idno>
             <idno type="filename">244047</idno>
             <idno type="dclp-hybrid">tm;;244047</idno>
-            <idno type="MP3">1780.11</idno>
+            <idno type="MP3">01780.110</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/245/244048.xml
+++ b/DCLP/245/244048.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">244048</idno>
             <idno type="filename">244048</idno>
             <idno type="dclp-hybrid">tm;;244048</idno>
-            <idno type="MP3">2311.01</idno>
+            <idno type="MP3">02311.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/35/34296.xml
+++ b/DCLP/35/34296.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">10762</idno>
             <idno type="filename">34296</idno>
             <idno type="dclp-hybrid">o.eleph.wagner;;163</idno>
-            <idno type="MP3">2704.04</idno>
+            <idno type="MP3">02704.040</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/35/34297.xml
+++ b/DCLP/35/34297.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">10763</idno>
             <idno type="filename">34297</idno>
             <idno type="dclp-hybrid">o.eleph.wagner;;164</idno>
-            <idno type="MP3">2704.5</idno>
+            <idno type="MP3">02704.500</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/35/34810.xml
+++ b/DCLP/35/34810.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5912</idno>
             <idno type="filename">34810</idno>
             <idno type="dclp-hybrid">sb;14;11977</idno>
-            <idno type="MP3">2389.3</idno>
+            <idno type="MP3">02389.300</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/373/372062.xml
+++ b/DCLP/373/372062.xml
@@ -12,7 +12,7 @@
             <idno type="dclp">372062</idno>
             <idno type="dclp-hybrid">p.oxy;79;5197</idno>
             <idno type="TM">372062</idno>
-            <idno type="MP3">152.13</idno>
+            <idno type="MP3">00152.130</idno>
             <idno type="LDAB">372062</idno>
             <availability>
                <p>

--- a/DCLP/389/388550.xml
+++ b/DCLP/389/388550.xml
@@ -13,7 +13,7 @@
             <idno type="dclp-hybrid">p.oxy;80;5244</idno>
             <idno type="TM">388550</idno>
             <idno type="LDAB">388550</idno>
-            <idno type="MP3">2410.116</idno>
+            <idno type="MP3">02410.116</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/389/388556.xml
+++ b/DCLP/389/388556.xml
@@ -13,7 +13,7 @@
             <idno type="dclp-hybrid">p.oxy;80;5250</idno>
             <idno type="TM">388556</idno>
             <idno type="LDAB">388556</idno>
-            <idno type="MP3">2410.102</idno>
+            <idno type="MP3">02410.102</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/40/39700.xml
+++ b/DCLP/40/39700.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">10758</idno>
             <idno type="filename">39700</idno>
             <idno type="dclp-hybrid">o.eleph.wagner;;162</idno>
-            <idno type="MP3">2700.01</idno>
+            <idno type="MP3">02700.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/48/47271.xml
+++ b/DCLP/48/47271.xml
@@ -12,7 +12,7 @@
             <idno type="dclp">47271</idno>
             <idno type="dclp-hybrid">p.koeln;10;410</idno>
             <idno type="TM">47271</idno>
-            <idno type="MP3">2400.02</idno>
+            <idno type="MP3">02400.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59017.xml
+++ b/DCLP/60/59017.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">112</idno>
             <idno type="filename">59017</idno>
             <idno type="dclp-hybrid">p.oxy;20;2253</idno>
-            <idno type="MP3">30</idno>
+            <idno type="MP3">00030.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59051.xml
+++ b/DCLP/60/59051.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">146</idno>
             <idno type="filename">59051</idno>
             <idno type="dclp-hybrid">o.claud;2;413</idno>
-            <idno type="MP3">0052.03</idno>
+            <idno type="MP3">00052.030</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59130.xml
+++ b/DCLP/60/59130.xml
@@ -13,7 +13,7 @@
         <idno type="LDAB">225</idno>
         <idno type="filename">59130</idno>
         <idno type="dclp-hybrid">tm;;59130</idno>
-        <idno type="MP3">2720</idno>
+        <idno type="MP3">02720.000</idno>
         <availability>
           <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59131.xml
+++ b/DCLP/60/59131.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">226</idno>
             <idno type="filename">59131</idno>
             <idno type="dclp-hybrid">p.oxy;3;427</idno>
-            <idno type="MP3">00090.00</idno>
+            <idno type="MP3">00090.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59134.xml
+++ b/DCLP/60/59134.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">229</idno>
             <idno type="filename">59134</idno>
             <idno type="dclp-hybrid">tm;;59134</idno>
-            <idno type="MP3">2564.1</idno>
+            <idno type="MP3">02564.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59137.xml
+++ b/DCLP/60/59137.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">232</idno>
             <idno type="filename">59137</idno>
             <idno type="dclp-hybrid">tm;;59137</idno>
-            <idno type="MP3">0094.1</idno>
+            <idno type="MP3">00094.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59145.xml
+++ b/DCLP/60/59145.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">240</idno>
             <idno type="filename">59145</idno>
             <idno type="dclp-hybrid">tm;;59145</idno>
-            <idno type="MP3">1381</idno>
+            <idno type="MP3">01381.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59325.xml
+++ b/DCLP/60/59325.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">423</idno>
             <idno type="filename">59325</idno>
             <idno type="dclp-hybrid">tm;;59325</idno>
-            <idno type="MP3">171.1</idno>
+            <idno type="MP3">00171.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59327.xml
+++ b/DCLP/60/59327.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">425</idno>
             <idno type="filename">59327</idno>
             <idno type="dclp-hybrid">p.amh;2;10</idno>
-            <idno type="MP3">169</idno>
+            <idno type="MP3">00169.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59338.xml
+++ b/DCLP/60/59338.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">437</idno>
             <idno type="filename">59338</idno>
             <idno type="dclp-hybrid">bkt;9;113</idno>
-            <idno type="MP3">177.2</idno>
+            <idno type="MP3">00177.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59556.xml
+++ b/DCLP/60/59556.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">658</idno>
             <idno type="filename">59556</idno>
             <idno type="dclp-hybrid">tm;;59556</idno>
-            <idno type="MP3">0336</idno>
+            <idno type="MP3">00336.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59582.xml
+++ b/DCLP/60/59582.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">684</idno>
             <idno type="filename">59582</idno>
             <idno type="dclp-hybrid">bkt;9;185</idno>
-            <idno type="MP3">258.1</idno>
+            <idno type="MP3">00258.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59658.xml
+++ b/DCLP/60/59658.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">760</idno>
             <idno type="filename">59658</idno>
             <idno type="dclp-hybrid">bkt;9;190</idno>
-            <idno type="MP3">265.1</idno>
+            <idno type="MP3">00265.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59662.xml
+++ b/DCLP/60/59662.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">764</idno>
             <idno type="filename">59662</idno>
             <idno type="dclp-hybrid">p.oxy;31;2549</idno>
-            <idno type="MP3">00335.100;</idno>
+            <idno type="MP3">00335.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59663.xml
+++ b/DCLP/60/59663.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">765</idno>
             <idno type="filename">59663</idno>
             <idno type="dclp-hybrid">p.yale;2;135</idno>
-            <idno type="MP3">2751.2</idno>
+            <idno type="MP3">02751.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59665.xml
+++ b/DCLP/60/59665.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">767</idno>
             <idno type="filename">59665</idno>
             <idno type="dclp-hybrid">p.tebt;2;268</idno>
-            <idno type="MP3">338</idno>
+            <idno type="MP3">00338.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59727.xml
+++ b/DCLP/60/59727.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">831</idno>
             <idno type="filename">59727</idno>
             <idno type="dclp-hybrid">bkt;9;13</idno>
-            <idno type="MP3">2797.71</idno>
+            <idno type="MP3">02797.710</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59778.xml
+++ b/DCLP/60/59778.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">882</idno>
             <idno type="filename">59778</idno>
             <idno type="dclp-hybrid">tm;;59778</idno>
-            <idno type="MP3">0370</idno>
+            <idno type="MP3">00370.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59824.xml
+++ b/DCLP/60/59824.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">929</idno>
             <idno type="filename">59824</idno>
             <idno type="dclp-hybrid">p.oxy;31;2543</idno>
-            <idno type="MP3">0379.2</idno>
+            <idno type="MP3">00379.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59891.xml
+++ b/DCLP/60/59891.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">998</idno>
             <idno type="filename">59891</idno>
             <idno type="dclp-hybrid">bkt;9;111</idno>
-            <idno type="MP3">425.1</idno>
+            <idno type="MP3">00425.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59912.xml
+++ b/DCLP/60/59912.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1022</idno>
             <idno type="filename">59912</idno>
             <idno type="dclp-hybrid">tm;;59912</idno>
-            <idno type="MP3">0416</idno>
+            <idno type="MP3">00416.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59946.xml
+++ b/DCLP/60/59946.xml
@@ -20,7 +20,7 @@
             .
           </p>
         </availability>
-        <idno type="MP3">1575</idno>
+        <idno type="MP3">01575.000</idno>
       </publicationStmt>
       <sourceDesc>
         <msDesc>

--- a/DCLP/60/59955.xml
+++ b/DCLP/60/59955.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1067</idno>
             <idno type="filename">59955</idno>
             <idno type="dclp-hybrid">p.oxy;17;2103</idno>
-            <idno type="MP3">2954</idno>
+            <idno type="MP3">02954.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59956.xml
+++ b/DCLP/60/59956.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1068</idno>
             <idno type="filename">59956</idno>
             <idno type="dclp-hybrid">psi;11;1182</idno>
-            <idno type="MP3">2953</idno>
+            <idno type="MP3">02953.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59980.xml
+++ b/DCLP/60/59980.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1092</idno>
             <idno type="filename">59980</idno>
             <idno type="dclp-hybrid">p.hib;2;173</idno>
-            <idno type="MP3">136</idno>
+            <idno type="MP3">00136.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60010.xml
+++ b/DCLP/61/60010.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1124</idno>
             <idno type="filename">60010</idno>
             <idno type="dclp-hybrid">p.oxy;48;3380</idno>
-            <idno type="MP3">474.3</idno>
+            <idno type="MP3">00474.300</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60017.xml
+++ b/DCLP/61/60017.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1131</idno>
             <idno type="filename">60017</idno>
             <idno type="dclp-hybrid">p.ryl;1;55</idno>
-            <idno type="MP3">0472</idno>
+            <idno type="MP3">00472.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60023.xml
+++ b/DCLP/61/60023.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1137</idno>
             <idno type="filename">60023</idno>
             <idno type="dclp-hybrid">p.oxy;48;3377</idno>
-            <idno type="MP3">0473.1</idno>
+            <idno type="MP3">00473.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60024.xml
+++ b/DCLP/61/60024.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1138</idno>
             <idno type="filename">60024</idno>
             <idno type="dclp-hybrid">p.oxy;48;3381</idno>
-            <idno type="MP3">480</idno>
+            <idno type="MP3">00480.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60027.xml
+++ b/DCLP/61/60027.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1141</idno>
             <idno type="filename">60027</idno>
             <idno type="dclp-hybrid">p.oxy;48;3378</idno>
-            <idno type="MP3">474.1</idno>
+            <idno type="MP3">00474.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60028.xml
+++ b/DCLP/61/60028.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1142</idno>
             <idno type="filename">60028</idno>
             <idno type="dclp-hybrid">p.oxy;48;3382</idno>
-            <idno type="MP3">480.2</idno>
+            <idno type="MP3">00480.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60029.xml
+++ b/DCLP/61/60029.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1143</idno>
             <idno type="filename">60029</idno>
             <idno type="dclp-hybrid">p.oxy;48;3383</idno>
-            <idno type="MP3">0480.3</idno>
+            <idno type="MP3">00480.300</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60035.xml
+++ b/DCLP/61/60035.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1149</idno>
             <idno type="filename">60035</idno>
             <idno type="dclp-hybrid">p.oxy;1;18</idno>
-            <idno type="MP3">0466</idno>
+            <idno type="MP3">00466.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60037.xml
+++ b/DCLP/61/60037.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1151</idno>
             <idno type="filename">60037</idno>
             <idno type="dclp-hybrid">p.oxy;17;2097</idno>
-            <idno type="MP3">464</idno>
+            <idno type="MP3">00464.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60038.xml
+++ b/DCLP/61/60038.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1152</idno>
             <idno type="filename">60038</idno>
             <idno type="dclp-hybrid">p.oxy;48;3373</idno>
-            <idno type="MP3">0462.2</idno>
+            <idno type="MP3">00462.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60040.xml
+++ b/DCLP/61/60040.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1154</idno>
             <idno type="filename">60040</idno>
             <idno type="dclp-hybrid">p.oxy;48;3379</idno>
-            <idno type="MP3">474.2</idno>
+            <idno type="MP3">00474.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60144.xml
+++ b/DCLP/61/60144.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1258</idno>
             <idno type="filename">60144</idno>
             <idno type="dclp-hybrid">p.koeln;7;302</idno>
-            <idno type="MP3">0506.11</idno>
+            <idno type="MP3">00506.110</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60175.xml
+++ b/DCLP/61/60175.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1291</idno>
             <idno type="filename">60175</idno>
             <idno type="dclp-hybrid">p.oxy;9;1184</idno>
-            <idno type="MP3">540</idno>
+            <idno type="MP3">00540.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60180.xml
+++ b/DCLP/61/60180.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1297</idno>
             <idno type="filename">60180</idno>
             <idno type="dclp-hybrid">bkt;3;6</idno>
-            <idno type="MP3">0541</idno>
+            <idno type="MP3">00541.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60216.xml
+++ b/DCLP/61/60216.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1334</idno>
             <idno type="filename">60216</idno>
             <idno type="dclp-hybrid">bkt;9;88</idno>
-            <idno type="MP3">898.1</idno>
+            <idno type="MP3">00898.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60220.xml
+++ b/DCLP/61/60220.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1338</idno>
             <idno type="filename">60220</idno>
             <idno type="dclp-hybrid">tm;;60220</idno>
-            <idno type="MP3">735</idno>
+            <idno type="MP3">00735.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60229.xml
+++ b/DCLP/61/60229.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1348</idno>
             <idno type="filename">60229</idno>
             <idno type="dclp-hybrid">p.fay;;6</idno>
-            <idno type="MP3">976</idno>
+            <idno type="MP3">00976.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60230.xml
+++ b/DCLP/61/60230.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1349</idno>
             <idno type="filename">60230</idno>
             <idno type="dclp-hybrid">p.fay;;209</idno>
-            <idno type="MP3">0692</idno>
+            <idno type="MP3">00692.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60236.xml
+++ b/DCLP/61/60236.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1355</idno>
             <idno type="filename">60236</idno>
             <idno type="dclp-hybrid">psi.od;;2</idno>
-            <idno type="MP3">1023.1</idno>
+            <idno type="MP3">01023.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60237.xml
+++ b/DCLP/61/60237.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1356</idno>
             <idno type="filename">60237</idno>
             <idno type="dclp-hybrid">psi.od;;4</idno>
-            <idno type="MP3">1030.1</idno>
+            <idno type="MP3">01030.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60267.xml
+++ b/DCLP/61/60267.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1387</idno>
             <idno type="filename">60267</idno>
             <idno type="dclp-hybrid">tm;;60267</idno>
-            <idno type="MP3">0783.2</idno>
+            <idno type="MP3">00783.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60283.xml
+++ b/DCLP/61/60283.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1403</idno>
             <idno type="filename">60283</idno>
             <idno type="dclp-hybrid">p.oxy;4;754</idno>
-            <idno type="MP3">0732</idno>
+            <idno type="MP3">00732.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60296.xml
+++ b/DCLP/61/60296.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1416</idno>
             <idno type="filename">60296</idno>
             <idno type="dclp-hybrid">p.yale;2;91</idno>
-            <idno type="MP3">0757.2</idno>
+            <idno type="MP3">00757.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60314.xml
+++ b/DCLP/61/60314.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1435</idno>
             <idno type="filename">60314</idno>
             <idno type="dclp-hybrid">tm;;60314</idno>
-            <idno type="MP3">1017</idno>
+            <idno type="MP3">01017.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60320.xml
+++ b/DCLP/61/60320.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1441</idno>
             <idno type="filename">60320</idno>
             <idno type="dclp-hybrid">tm;;60320</idno>
-            <idno type="MP3">1096.1</idno>
+            <idno type="MP3">01096.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60342.xml
+++ b/DCLP/61/60342.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1463</idno>
             <idno type="filename">60342</idno>
             <idno type="dclp-hybrid">tm;;60342</idno>
-            <idno type="MP3">0857.11</idno>
+            <idno type="MP3">00857.110</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60346.xml
+++ b/DCLP/61/60346.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1467</idno>
             <idno type="filename">60346</idno>
             <idno type="dclp-hybrid">tm;;60346</idno>
-            <idno type="MP3">0850.1</idno>
+            <idno type="MP3">00850.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60384.xml
+++ b/DCLP/61/60384.xml
@@ -14,7 +14,7 @@
             <idno type="filename">60384</idno>
             <idno type="dclp-hybrid">bkt;9;125</idno>
             <idno type="dclp-hybrid">p.aberd;;108</idno>
-            <idno type="MP3">844.1</idno>
+            <idno type="MP3">00844.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60386.xml
+++ b/DCLP/61/60386.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1507</idno>
             <idno type="filename">60386</idno>
             <idno type="dclp-hybrid">p.amst;1;2</idno>
-            <idno type="MP3">782.1</idno>
+            <idno type="MP3">00782.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60410.xml
+++ b/DCLP/61/60410.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1531</idno>
             <idno type="filename">60410</idno>
             <idno type="dclp-hybrid">bkt;9;184</idno>
-            <idno type="MP3">972.010</idno>
+            <idno type="MP3">00972.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60412.xml
+++ b/DCLP/61/60412.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1533</idno>
             <idno type="filename">60412</idno>
             <idno type="dclp-hybrid">tm;;60412</idno>
-            <idno type="MP3">1071</idno>
+            <idno type="MP3">01071.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60425.xml
+++ b/DCLP/61/60425.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1547</idno>
             <idno type="filename">60425</idno>
             <idno type="dclp-hybrid">p.fay;;210</idno>
-            <idno type="MP3">0820</idno>
+            <idno type="MP3">00820.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60426.xml
+++ b/DCLP/61/60426.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1548</idno>
             <idno type="filename">60426</idno>
             <idno type="dclp-hybrid">p.fay;;309</idno>
-            <idno type="MP3">0661</idno>
+            <idno type="MP3">00661.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60442.xml
+++ b/DCLP/61/60442.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1564</idno>
             <idno type="filename">60442</idno>
             <idno type="dclp-hybrid">tm;;60442</idno>
-            <idno type="MP3">1125.11</idno>
+            <idno type="MP3">01125.110</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60446.xml
+++ b/DCLP/61/60446.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1568</idno>
             <idno type="filename">60446</idno>
             <idno type="dclp-hybrid">psi.od;;1</idno>
-            <idno type="MP3">1022.1</idno>
+            <idno type="MP3">01022.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60447.xml
+++ b/DCLP/61/60447.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1569</idno>
             <idno type="filename">60447</idno>
             <idno type="dclp-hybrid">psi.od;;3</idno>
-            <idno type="MP3">1027.1</idno>
+            <idno type="MP3">01027.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60462.xml
+++ b/DCLP/61/60462.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1584</idno>
             <idno type="filename">60462</idno>
             <idno type="dclp-hybrid">p.gen;2;83</idno>
-            <idno type="MP3">800</idno>
+            <idno type="MP3">00800.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60497.xml
+++ b/DCLP/61/60497.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1620</idno>
             <idno type="filename">60497</idno>
             <idno type="dclp-hybrid">p.koeln;1;31</idno>
-            <idno type="MP3">0852.1</idno>
+            <idno type="MP3">00852.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60538.xml
+++ b/DCLP/61/60538.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1662</idno>
             <idno type="filename">60538</idno>
             <idno type="dclp-hybrid">p.col;8;201</idno>
-            <idno type="MP3">1128</idno>
+            <idno type="MP3">01128.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60539.xml
+++ b/DCLP/61/60539.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1663</idno>
             <idno type="filename">60539</idno>
             <idno type="dclp-hybrid">p.col;8;198</idno>
-            <idno type="MP3">0784</idno>
+            <idno type="MP3">00784.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60540.xml
+++ b/DCLP/61/60540.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1664</idno>
             <idno type="filename">60540</idno>
             <idno type="dclp-hybrid">p.oxy;3;539</idno>
-            <idno type="MP3">0620</idno>
+            <idno type="MP3">00620.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60542.xml
+++ b/DCLP/61/60542.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1666</idno>
             <idno type="filename">60542</idno>
             <idno type="dclp-hybrid">p.amh;2;18</idno>
-            <idno type="MP3">01211</idno>
+            <idno type="MP3">01211.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60602.xml
+++ b/DCLP/61/60602.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1726</idno>
             <idno type="filename">60602</idno>
             <idno type="dclp-hybrid">tm;;60602</idno>
-            <idno type="MP3">0580.2</idno>
+            <idno type="MP3">00580.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60611.xml
+++ b/DCLP/61/60611.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1735</idno>
             <idno type="filename">60611</idno>
             <idno type="dclp-hybrid">p.yale;2;96</idno>
-            <idno type="MP3">1015.2</idno>
+            <idno type="MP3">01015.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60613.xml
+++ b/DCLP/61/60613.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1737</idno>
             <idno type="filename">60613</idno>
             <idno type="dclp-hybrid">psi.od;;10</idno>
-            <idno type="MP3">1112.1</idno>
+            <idno type="MP3">01112.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60619.xml
+++ b/DCLP/61/60619.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1743</idno>
             <idno type="filename">60619</idno>
             <idno type="dclp-hybrid">p.amst;1;3</idno>
-            <idno type="MP3">1033.1</idno>
+            <idno type="MP3">01033.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60628.xml
+++ b/DCLP/61/60628.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1752</idno>
             <idno type="filename">60628</idno>
             <idno type="dclp-hybrid">bkt;9;4</idno>
-            <idno type="MP3">1130.1</idno>
+            <idno type="MP3">01130.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60629.xml
+++ b/DCLP/61/60629.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1753</idno>
             <idno type="filename">60629</idno>
             <idno type="dclp-hybrid">bkt;9;62</idno>
-            <idno type="MP3">872.1</idno>
+            <idno type="MP3">00872.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60638.xml
+++ b/DCLP/61/60638.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1763</idno>
             <idno type="filename">60638</idno>
             <idno type="dclp-hybrid">p.oxy;4;751</idno>
-            <idno type="MP3">0683</idno>
+            <idno type="MP3">00683.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60639.xml
+++ b/DCLP/61/60639.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1764</idno>
             <idno type="filename">60639</idno>
             <idno type="dclp-hybrid">p.oxy;4;779</idno>
-            <idno type="MP3">1085</idno>
+            <idno type="MP3">01085.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60647.xml
+++ b/DCLP/61/60647.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1772</idno>
             <idno type="filename">60647</idno>
             <idno type="dclp-hybrid">psi.od;;8</idno>
-            <idno type="MP3">1067.1</idno>
+            <idno type="MP3">01067.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60665.xml
+++ b/DCLP/61/60665.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1790</idno>
             <idno type="filename">60665</idno>
             <idno type="dclp-hybrid">tm;;60665</idno>
-            <idno type="MP3">0767</idno>
+            <idno type="MP3">00767.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60670.xml
+++ b/DCLP/61/60670.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1795</idno>
             <idno type="filename">60670</idno>
             <idno type="dclp-hybrid">p.koeln;7;300</idno>
-            <idno type="MP3">0851.01</idno>
+            <idno type="MP3">00851.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60684.xml
+++ b/DCLP/61/60684.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1809</idno>
             <idno type="filename">60684</idno>
             <idno type="dclp-hybrid">tm;;60684</idno>
-            <idno type="MP3">0565</idno>
+            <idno type="MP3">00565.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60690.xml
+++ b/DCLP/61/60690.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1815</idno>
             <idno type="filename">60690</idno>
             <idno type="dclp-hybrid">tm;;60690</idno>
-            <idno type="MP3">0755</idno>
+            <idno type="MP3">00755.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60691.xml
+++ b/DCLP/61/60691.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1816</idno>
             <idno type="filename">60691</idno>
             <idno type="dclp-hybrid">tm;;60691</idno>
-            <idno type="MP3">0917</idno>
+            <idno type="MP3">00917.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60730.xml
+++ b/DCLP/61/60730.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1856</idno>
             <idno type="filename">60730</idno>
             <idno type="dclp-hybrid">tm;;60730</idno>
-            <idno type="MP3">1010</idno>
+            <idno type="MP3">01010.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60737.xml
+++ b/DCLP/61/60737.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1863</idno>
             <idno type="filename">60737</idno>
             <idno type="dclp-hybrid">tm;;60737</idno>
-            <idno type="MP3">0561.1</idno>
+            <idno type="MP3">00561.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60766.xml
+++ b/DCLP/61/60766.xml
@@ -13,7 +13,7 @@
                 <idno type="LDAB">1893</idno>
                 <idno type="filename">60766</idno>
                 <idno type="dclp-hybrid">bkt;5_1;5_1</idno>
-                <idno type="MP3">0924.000</idno>
+                <idno type="MP3">00924.000</idno>
                 <availability>
                     <p>
                         © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60774.xml
+++ b/DCLP/61/60774.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1901</idno>
             <idno type="filename">60774</idno>
             <idno type="dclp-hybrid">tm;;60774</idno>
-            <idno type="MP3">1003</idno>
+            <idno type="MP3">01003.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60775.xml
+++ b/DCLP/61/60775.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1902</idno>
             <idno type="filename">60775</idno>
             <idno type="dclp-hybrid">tm;;60775</idno>
-            <idno type="MP3">0949</idno>
+            <idno type="MP3">00949.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60790.xml
+++ b/DCLP/61/60790.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1917</idno>
             <idno type="filename">60790</idno>
             <idno type="dclp-hybrid">psi.od;;9</idno>
-            <idno type="MP3">1103.1</idno>
+            <idno type="MP3">01103.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60806.xml
+++ b/DCLP/61/60806.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1934</idno>
             <idno type="filename">60806</idno>
             <idno type="dclp-hybrid">p.oxy;3;446</idno>
-            <idno type="MP3">901.0</idno>
+            <idno type="MP3">00901.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60813.xml
+++ b/DCLP/61/60813.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1941</idno>
             <idno type="filename">60813</idno>
             <idno type="dclp-hybrid">p.heid;1;203</idno>
-            <idno type="MP3">0951</idno>
+            <idno type="MP3">00951.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60822.xml
+++ b/DCLP/61/60822.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1950</idno>
             <idno type="filename">60822</idno>
             <idno type="dclp-hybrid">p.koeln;7;299</idno>
-            <idno type="MP3">0741.01</idno>
+            <idno type="MP3">00741.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60846.xml
+++ b/DCLP/61/60846.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1974</idno>
             <idno type="filename">60846</idno>
             <idno type="dclp-hybrid">tm;;60846</idno>
-            <idno type="MP3">0693.2</idno>
+            <idno type="MP3">00693.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60848.xml
+++ b/DCLP/61/60848.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1976</idno>
             <idno type="filename">60848</idno>
             <idno type="dclp-hybrid">tm;;60848</idno>
-            <idno type="MP3">0566.1</idno>
+            <idno type="MP3">00566.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60861.xml
+++ b/DCLP/61/60861.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1989</idno>
             <idno type="filename">60861</idno>
             <idno type="dclp-hybrid">p.oxy;3;534</idno>
-            <idno type="MP3">0559</idno>
+            <idno type="MP3">00559.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60863.xml
+++ b/DCLP/61/60863.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1991</idno>
             <idno type="filename">60863</idno>
             <idno type="dclp-hybrid">p.col;8;199</idno>
-            <idno type="MP3">0918</idno>
+            <idno type="MP3">00918.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60864.xml
+++ b/DCLP/61/60864.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1992</idno>
             <idno type="filename">60864</idno>
             <idno type="dclp-hybrid">p.col;8;195</idno>
-            <idno type="MP3">0641</idno>
+            <idno type="MP3">00641.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60865.xml
+++ b/DCLP/61/60865.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1993</idno>
             <idno type="filename">60865</idno>
             <idno type="dclp-hybrid">p.col;8;194</idno>
-            <idno type="MP3">0594</idno>
+            <idno type="MP3">00594.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60868.xml
+++ b/DCLP/61/60868.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1996</idno>
             <idno type="filename">60868</idno>
             <idno type="dclp-hybrid">p.oxy;3;536</idno>
-            <idno type="MP3">579</idno>
+            <idno type="MP3">00579.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60869.xml
+++ b/DCLP/61/60869.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">1998</idno>
             <idno type="filename">60869</idno>
             <idno type="dclp-hybrid">p.oxy;3;537</idno>
-            <idno type="MP3">0589</idno>
+            <idno type="MP3">00589.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60883.xml
+++ b/DCLP/61/60883.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2012</idno>
             <idno type="filename">60883</idno>
             <idno type="dclp-hybrid">p.oxy;23;2379</idno>
-            <idno type="MP3">1231</idno>
+            <idno type="MP3">01231.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60904.xml
+++ b/DCLP/61/60904.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2034</idno>
             <idno type="filename">60904</idno>
             <idno type="dclp-hybrid">p.oxy;6;948</idno>
-            <idno type="MP3">861</idno>
+            <idno type="MP3">00861.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60905.xml
+++ b/DCLP/61/60905.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2035</idno>
             <idno type="filename">60905</idno>
             <idno type="dclp-hybrid">p.oxy;4;755</idno>
-            <idno type="MP3">737</idno>
+            <idno type="MP3">00737.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60920.xml
+++ b/DCLP/61/60920.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2050</idno>
             <idno type="filename">60920</idno>
             <idno type="dclp-hybrid">tm;;60920</idno>
-            <idno type="MP3">1231.1</idno>
+            <idno type="MP3">01231.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60928.xml
+++ b/DCLP/61/60928.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2058</idno>
             <idno type="filename">60928</idno>
             <idno type="dclp-hybrid">p.yale;2;95</idno>
-            <idno type="MP3">948.21</idno>
+            <idno type="MP3">00948.210</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61002.xml
+++ b/DCLP/62/61002.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2135</idno>
             <idno type="filename">61002</idno>
             <idno type="dclp-hybrid">p.oxy;11;1389</idno>
-            <idno type="MP3">805</idno>
+            <idno type="MP3">00805.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61066.xml
+++ b/DCLP/62/61066.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2203</idno>
             <idno type="filename">61066</idno>
             <idno type="dclp-hybrid">bkt;9;108</idno>
-            <idno type="MP3">01007.1</idno>
+            <idno type="MP3">01007.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61067.xml
+++ b/DCLP/62/61067.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2204</idno>
             <idno type="filename">61067</idno>
             <idno type="dclp-hybrid">bkt;9;109</idno>
-            <idno type="MP3">703.1</idno>
+            <idno type="MP3">00703.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61080.xml
+++ b/DCLP/62/61080.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2217</idno>
             <idno type="filename">61080</idno>
             <idno type="dclp-hybrid">p.oxy;36;2747</idno>
-            <idno type="MP3">625.1</idno>
+            <idno type="MP3">00625.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61090.xml
+++ b/DCLP/62/61090.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2227</idno>
             <idno type="filename">61090</idno>
             <idno type="dclp-hybrid">bkt;9;183</idno>
-            <idno type="MP3">761.01</idno>
+            <idno type="MP3">00761.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61101.xml
+++ b/DCLP/62/61101.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2238</idno>
             <idno type="filename">61101</idno>
             <idno type="dclp-hybrid">bkt;9;31</idno>
-            <idno type="MP3">855.2</idno>
+            <idno type="MP3">00855.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61107.xml
+++ b/DCLP/62/61107.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2244</idno>
             <idno type="filename">61107</idno>
             <idno type="dclp-hybrid">p.gen;2;84</idno>
-            <idno type="MP3">921.2</idno>
+            <idno type="MP3">00921.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61110.xml
+++ b/DCLP/62/61110.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2247</idno>
             <idno type="filename">61110</idno>
             <idno type="dclp-hybrid">p.mon.epiph;;612</idno>
-            <idno type="MP3">0557</idno>
+            <idno type="MP3">00557.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61127.xml
+++ b/DCLP/62/61127.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2266</idno>
             <idno type="filename">61127</idno>
             <idno type="dclp-hybrid">tm;;61127</idno>
-            <idno type="MP3">0988</idno>
+            <idno type="MP3">00988.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61128.xml
+++ b/DCLP/62/61128.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2267</idno>
             <idno type="filename">61128</idno>
             <idno type="dclp-hybrid">tm;;61128</idno>
-            <idno type="MP3">0812.01</idno>
+            <idno type="MP3">00812.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61163.xml
+++ b/DCLP/62/61163.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2302</idno>
             <idno type="filename">61163</idno>
             <idno type="dclp-hybrid">p.amst;1;1</idno>
-            <idno type="MP3">0720.1</idno>
+            <idno type="MP3">00720.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61191.xml
+++ b/DCLP/62/61191.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2331</idno>
             <idno type="filename">61191</idno>
             <idno type="dclp-hybrid">tm;;61191</idno>
-            <idno type="MP3">0995.1</idno>
+            <idno type="MP3">00995.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61202.xml
+++ b/DCLP/62/61202.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2342</idno>
             <idno type="filename">61202</idno>
             <idno type="dclp-hybrid">p.gen;2;82</idno>
-            <idno type="MP3">1145.1</idno>
+            <idno type="MP3">01145.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61217.xml
+++ b/DCLP/62/61217.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2357</idno>
             <idno type="filename">61217</idno>
             <idno type="dclp-hybrid">p.gen;3;118</idno>
-            <idno type="MP3">1231.11</idno>
+            <idno type="MP3">01231.110</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61222.xml
+++ b/DCLP/62/61222.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2362</idno>
             <idno type="filename">61222</idno>
             <idno type="dclp-hybrid">tm;;61222</idno>
-            <idno type="MP3">2131</idno>
+            <idno type="MP3">02131.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61295.xml
+++ b/DCLP/62/61295.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2437</idno>
             <idno type="filename">61295</idno>
             <idno type="dclp-hybrid">psi;15;1481</idno>
-            <idno type="MP3">1981.2</idno>
+            <idno type="MP3">01981.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61305.xml
+++ b/DCLP/62/61305.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2447</idno>
             <idno type="filename">61305</idno>
             <idno type="dclp-hybrid">tm;;61305</idno>
-            <idno type="MP3">1586</idno>
+            <idno type="MP3">01586.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61311.xml
+++ b/DCLP/62/61311.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2453</idno>
             <idno type="filename">61311</idno>
             <idno type="dclp-hybrid">tm;;61311</idno>
-            <idno type="MP3">1591</idno>
+            <idno type="MP3">01591.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61329.xml
+++ b/DCLP/62/61329.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2473</idno>
             <idno type="filename">61329</idno>
             <idno type="dclp-hybrid">p.amst;1;12</idno>
-            <idno type="MP3">1276.1</idno>
+            <idno type="MP3">01276.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61352.xml
+++ b/DCLP/62/61352.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2496</idno>
             <idno type="filename">61352</idno>
             <idno type="dclp-hybrid">tm;;61352</idno>
-            <idno type="MP3">1245.2</idno>
+            <idno type="MP3">01245.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61356.xml
+++ b/DCLP/62/61356.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2500</idno>
             <idno type="filename">61356</idno>
             <idno type="dclp-hybrid">p.col;8;204</idno>
-            <idno type="MP3">1278</idno>
+            <idno type="MP3">01278.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61362.xml
+++ b/DCLP/62/61362.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2506</idno>
             <idno type="filename">61362</idno>
             <idno type="dclp-hybrid">p.chic;;1</idno>
-            <idno type="MP3">1256</idno>
+            <idno type="MP3">01256.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61367.xml
+++ b/DCLP/62/61367.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2511</idno>
             <idno type="filename">61367</idno>
             <idno type="dclp-hybrid">p.koeln;7;309</idno>
-            <idno type="MP3">0312.01</idno>
+            <idno type="MP3">00312.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61394.xml
+++ b/DCLP/62/61394.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2538</idno>
             <idno type="filename">61394</idno>
             <idno type="dclp-hybrid">tm;;61394</idno>
-            <idno type="MP3">1255.01</idno>
+            <idno type="MP3">01255.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61402.xml
+++ b/DCLP/62/61402.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2546</idno>
             <idno type="filename">61402</idno>
             <idno type="dclp-hybrid">tm;;61402</idno>
-            <idno type="MP3">1251.1</idno>
+            <idno type="MP3">01251.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61406.xml
+++ b/DCLP/62/61406.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61406</idno>
             <idno type="LDAB">2550</idno>
             <idno type="filename">61406</idno>
-            <idno type="MP3">53</idno>
+            <idno type="MP3">00053.000</idno>
             <idno type="dclp-hybrid">pgm.2;2;23</idno>
             <availability>
                <p>

--- a/DCLP/62/61414.xml
+++ b/DCLP/62/61414.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2558</idno>
             <idno type="filename">61414</idno>
             <idno type="dclp-hybrid">p.ryl;3;474</idno>
-            <idno type="MP3">2974</idno>
+            <idno type="MP3">02974.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61475.xml
+++ b/DCLP/62/61475.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2622</idno>
             <idno type="filename">61475</idno>
             <idno type="dclp-hybrid">tm;;61475</idno>
-            <idno type="MP3">1320.700</idno>
+            <idno type="MP3">01320.700</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61486.xml
+++ b/DCLP/62/61486.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2633</idno>
             <idno type="filename">61486</idno>
             <idno type="dclp-hybrid">bkt;9;47</idno>
-            <idno type="MP3">1297.100</idno>
+            <idno type="MP3">01297.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61489.xml
+++ b/DCLP/62/61489.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2636</idno>
             <idno type="filename">61489</idno>
             <idno type="dclp-hybrid">o.claud;1;184</idno>
-            <idno type="MP3">2679.04</idno>
+            <idno type="MP3">02679.040</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61490.xml
+++ b/DCLP/62/61490.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2637</idno>
             <idno type="filename">61490</idno>
             <idno type="dclp-hybrid">o.claud;1;186</idno>
-            <idno type="MP3">Mertens-Pack 2679.06</idno>
+            <idno type="MP3">02679.060</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61491.xml
+++ b/DCLP/62/61491.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2638</idno>
             <idno type="filename">61491</idno>
             <idno type="dclp-hybrid">o.claud;1;187</idno>
-            <idno type="MP3">2679.07</idno>
+            <idno type="MP3">02679.070</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61492.xml
+++ b/DCLP/62/61492.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2639</idno>
             <idno type="filename">61492</idno>
             <idno type="dclp-hybrid">o.claud;1;185</idno>
-            <idno type="MP3">2679.05</idno>
+            <idno type="MP3">02679.050</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61512.xml
+++ b/DCLP/62/61512.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2659</idno>
             <idno type="filename">61512</idno>
             <idno type="dclp-hybrid">p.koeln;7;283</idno>
-            <idno type="MP3">1658.010</idno>
+            <idno type="MP3">01658.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61604.xml
+++ b/DCLP/62/61604.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2753</idno>
             <idno type="filename">61604</idno>
             <idno type="dclp-hybrid">p.oxy;3;418</idno>
-            <idno type="MP3">1164</idno>
+            <idno type="MP3">01164.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61606.xml
+++ b/DCLP/62/61606.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2755</idno>
             <idno type="filename">61606</idno>
             <idno type="dclp-hybrid">psi;8;1000</idno>
-            <idno type="MP3">1195.01</idno>
+            <idno type="MP3">01195.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/62/61800.xml
+++ b/DCLP/62/61800.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">2954</idno>
             <idno type="filename">61800</idno>
             <idno type="dclp-hybrid">tm;;61800</idno>
-            <idno type="MP3">2699.5</idno>
+            <idno type="MP3">02699.500</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62077.xml
+++ b/DCLP/63/62077.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3237</idno>
             <idno type="filename">62077</idno>
             <idno type="dclp-hybrid">p.oxy;11;1384</idno>
-            <idno type="MP3">2410</idno>
+            <idno type="MP3">02410.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62079.xml
+++ b/DCLP/63/62079.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3239</idno>
             <idno type="filename">62079</idno>
             <idno type="dclp-hybrid">p.koeln;4;175</idno>
-            <idno type="MP3">2704.7</idno>
+            <idno type="MP3">02704.700</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62334.xml
+++ b/DCLP/63/62334.xml
@@ -20,7 +20,7 @@
             .
           </p>
             </availability>
-            <idno type="MP3">1331</idno>
+            <idno type="MP3">01331.000</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/DCLP/63/62354.xml
+++ b/DCLP/63/62354.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3519</idno>
             <idno type="filename">62354</idno>
             <idno type="dclp-hybrid">tm;;62354</idno>
-            <idno type="MP3">1336</idno>
+            <idno type="MP3">01336.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62359.xml
+++ b/DCLP/63/62359.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3524</idno>
             <idno type="filename">62359</idno>
             <idno type="dclp-hybrid">tm;;62359</idno>
-            <idno type="MP3">2956</idno>
+            <idno type="MP3">02956.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62360.xml
+++ b/DCLP/63/62360.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3525</idno>
             <idno type="filename">62360</idno>
             <idno type="dclp-hybrid">tm;;62360</idno>
-            <idno type="MP3">2957</idno>
+            <idno type="MP3">02957.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62572.xml
+++ b/DCLP/63/62572.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3756</idno>
             <idno type="filename">62572</idno>
             <idno type="dclp-hybrid">bkt;9;114</idno>
-            <idno type="MP3">1387</idno>
+            <idno type="MP3">01387.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62575.xml
+++ b/DCLP/63/62575.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3759</idno>
             <idno type="filename">62575</idno>
             <idno type="dclp-hybrid">p.koeln;7;306</idno>
-            <idno type="MP3">1422.110</idno>
+            <idno type="MP3">01422.110</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62631.xml
+++ b/DCLP/63/62631.xml
@@ -13,7 +13,8 @@
             <idno type="LDAB">3816</idno>
             <idno type="filename">62631</idno>
             <idno type="dclp-hybrid">p.oxy;6;881</idno>
-            <idno type="MP3">01411.000; 01412.000</idno>
+            <idno type="MP3">01411.000</idno>
+            <idno type="MP3">01412.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62648.xml
+++ b/DCLP/63/62648.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3834</idno>
             <idno type="filename">62648</idno>
             <idno type="dclp-hybrid">p.hib;2;228</idno>
-            <idno type="MP3">01395</idno>
+            <idno type="MP3">01395.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62676.xml
+++ b/DCLP/63/62676.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3864</idno>
             <idno type="filename">62676</idno>
             <idno type="dclp-hybrid">tm;;62676</idno>
-            <idno type="MP3">1567</idno>
+            <idno type="MP3">01567.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62722.xml
+++ b/DCLP/63/62722.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3910</idno>
             <idno type="filename">62722</idno>
             <idno type="dclp-hybrid">p.ross.georg;1;19</idno>
-            <idno type="MP3">2412</idno>
+            <idno type="MP3">02412.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62723.xml
+++ b/DCLP/63/62723.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3911</idno>
             <idno type="filename">62723</idno>
             <idno type="dclp-hybrid">p.grenf;2;107</idno>
-            <idno type="MP3">2957.1</idno>
+            <idno type="MP3">02957.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62724.xml
+++ b/DCLP/63/62724.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3912</idno>
             <idno type="filename">62724</idno>
             <idno type="dclp-hybrid">p.mich;3;139</idno>
-            <idno type="MP3">1458</idno>
+            <idno type="MP3">01458.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62761.xml
+++ b/DCLP/63/62761.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3949</idno>
             <idno type="filename">62761</idno>
             <idno type="dclp-hybrid">bkt;9;112</idno>
-            <idno type="MP3">1462.1</idno>
+            <idno type="MP3">01462.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62778.xml
+++ b/DCLP/63/62778.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3966</idno>
             <idno type="filename">62778</idno>
             <idno type="dclp-hybrid">Hermes;41;106</idno>
-            <idno type="MP3">1484</idno>
+            <idno type="MP3">01484.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62798.xml
+++ b/DCLP/63/62798.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">3987</idno>
             <idno type="filename">62798</idno>
             <idno type="dclp-hybrid">tm;;62798</idno>
-            <idno type="MP3">1496</idno>
+            <idno type="MP3">01496.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62821.xml
+++ b/DCLP/63/62821.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4011</idno>
             <idno type="filename">62821</idno>
             <idno type="dclp-hybrid">bkt;9;124</idno>
-            <idno type="MP3">1498.01</idno>
+            <idno type="MP3">01498.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62859.xml
+++ b/DCLP/63/62859.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4049</idno>
             <idno type="filename">62859</idno>
             <idno type="dclp-hybrid">psi;16;1591</idno>
-            <idno type="MP3">1531.4</idno>
+            <idno type="MP3">01531.400</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62884.xml
+++ b/DCLP/63/62884.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4075</idno>
             <idno type="filename">62884</idno>
             <idno type="dclp-hybrid">psi;16;1589</idno>
-            <idno type="MP3">1526.1</idno>
+            <idno type="MP3">01526.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62939.xml
+++ b/DCLP/63/62939.xml
@@ -13,7 +13,7 @@
             <idno type="dclp-hybrid">psi;14;1449</idno>
             <idno type="TM">62939</idno>
             <idno type="LDAB">4131</idno>
-            <idno type="MP3">2960</idno>
+            <idno type="MP3">02960.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62940.xml
+++ b/DCLP/63/62940.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4132</idno>
             <idno type="filename">62940</idno>
             <idno type="dclp-hybrid">p.ant;1;22</idno>
-            <idno type="MP3">2979</idno>
+            <idno type="MP3">02979.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62941.xml
+++ b/DCLP/63/62941.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4133</idno>
             <idno type="filename">62941</idno>
             <idno type="dclp-hybrid">tm;;62941</idno>
-            <idno type="MP3">2985</idno>
+            <idno type="MP3">02985.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62944.xml
+++ b/DCLP/63/62944.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4136</idno>
             <idno type="filename">62944</idno>
             <idno type="dclp-hybrid">tm;;62944</idno>
-            <idno type="MP3">2959</idno>
+            <idno type="MP3">02959.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62945.xml
+++ b/DCLP/63/62945.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4137</idno>
             <idno type="filename">62945</idno>
             <idno type="dclp-hybrid">tm;;62945</idno>
-            <idno type="MP3">2962</idno>
+            <idno type="MP3">02962.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62948.xml
+++ b/DCLP/63/62948.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4140</idno>
             <idno type="filename">62948</idno>
             <idno type="dclp-hybrid">tm;;62948</idno>
-            <idno type="MP3">2948.01</idno>
+            <idno type="MP3">02948.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62952.xml
+++ b/DCLP/63/62952.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4144</idno>
             <idno type="filename">62952</idno>
             <idno type="dclp-hybrid">o.claud;1;190</idno>
-            <idno type="MP3">3016.01</idno>
+            <idno type="MP3">03016.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/63/62992.xml
+++ b/DCLP/63/62992.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4184</idno>
             <idno type="filename">62992</idno>
             <idno type="dclp-hybrid">tm;;62992</idno>
-            <idno type="MP3">1551</idno>
+            <idno type="MP3">01551.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63019.xml
+++ b/DCLP/64/63019.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4211</idno>
             <idno type="filename">63019</idno>
             <idno type="dclp-hybrid">tm;;63019</idno>
-            <idno type="MP3">2391.61</idno>
+            <idno type="MP3">02391.610</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63036.xml
+++ b/DCLP/64/63036.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4232</idno>
             <idno type="filename">63036</idno>
             <idno type="dclp-hybrid">tm;;63036</idno>
-            <idno type="MP3">2993.7</idno>
+            <idno type="MP3">02993.700</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63062.xml
+++ b/DCLP/64/63062.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4265</idno>
             <idno type="filename">63062</idno>
             <idno type="dclp-hybrid">p.schub;;32</idno>
-            <idno type="MP3">2507</idno>
+            <idno type="MP3">02507.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63126.xml
+++ b/DCLP/64/63126.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4330</idno>
             <idno type="filename">63126</idno>
             <idno type="dclp-hybrid">p.mich;3;148</idno>
-            <idno type="MP3">2003</idno>
+            <idno type="MP3">02003.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63194.xml
+++ b/DCLP/64/63194.xml
@@ -15,8 +15,6 @@
             <idno type="dclp-hybrid">tm;;63194</idno>
             <idno type="MP3">02318.130</idno>
             <idno type="MP3">02735.000</idno>
-            <idno type="MP3">02735.010</idno>
-            <idno type="MP3">02735.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63258.xml
+++ b/DCLP/64/63258.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4463</idno>
             <idno type="filename">63258</idno>
             <idno type="dclp-hybrid">p.oxy;1;8</idno>
-            <idno type="MP3">1889</idno>
+            <idno type="MP3">01889.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63260.xml
+++ b/DCLP/64/63260.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4465</idno>
             <idno type="filename">63260</idno>
             <idno type="dclp-hybrid">p.koeln;1;6</idno>
-            <idno type="MP3">1869.1</idno>
+            <idno type="MP3">01869.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63275.xml
+++ b/DCLP/64/63275.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4481</idno>
             <idno type="filename">63275</idno>
             <idno type="dclp-hybrid">p.mich;7;456</idno>
-            <idno type="MP3">2987</idno>
+            <idno type="MP3">02987.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63292.xml
+++ b/DCLP/64/63292.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4498</idno>
             <idno type="filename">63292</idno>
             <idno type="dclp-hybrid">p.oxy;46;3315</idno>
-            <idno type="MP3">3004.200</idno>
+            <idno type="MP3">03004.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63311.xml
+++ b/DCLP/64/63311.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4517</idno>
             <idno type="filename">63311</idno>
             <idno type="dclp-hybrid">o.leid;;2</idno>
-            <idno type="MP3">2433.2</idno>
+            <idno type="MP3">02433.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63357.xml
+++ b/DCLP/64/63357.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4564</idno>
             <idno type="filename">63357</idno>
             <idno type="dclp-hybrid">tm;;63357</idno>
-            <idno type="MP3">0089.12</idno>
+            <idno type="MP3">00089.120</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63360.xml
+++ b/DCLP/64/63360.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4567</idno>
             <idno type="filename">63360</idno>
             <idno type="dclp-hybrid">bkt;9;16</idno>
-            <idno type="MP3">1202.01</idno>
+            <idno type="MP3">01202.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63376.xml
+++ b/DCLP/64/63376.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4583</idno>
             <idno type="filename">63376</idno>
             <idno type="dclp-hybrid">bkt;9;171</idno>
-            <idno type="MP3">2797.91</idno>
+            <idno type="MP3">02797.910</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63412.xml
+++ b/DCLP/64/63412.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4620</idno>
             <idno type="filename">63412</idno>
             <idno type="dclp-hybrid">o.claud;1;182</idno>
-            <idno type="MP3">2750.01</idno>
+            <idno type="MP3">02750.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63559.xml
+++ b/DCLP/64/63559.xml
@@ -10,7 +10,8 @@
             <authority>Digital Corpus of Literary Papyri</authority>
             <idno type="dclp">63559</idno>
             <idno type="TM">63559</idno>
-            <idno type="MP3">02446.010 02345.010</idno>
+            <idno type="MP3">02446.010</idno>
+            <idno type="MP3">02345.010</idno>
             <idno type="LDAB">4768</idno>
             <idno type="filename">63559</idno>
             <idno type="dclp-hybrid">p.mich;18;762</idno>

--- a/DCLP/64/63646.xml
+++ b/DCLP/64/63646.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4855</idno>
             <idno type="filename">63646</idno>
             <idno type="dclp-hybrid">p.oxy;42;3011</idno>
-            <idno type="MP3">2619.2</idno>
+            <idno type="MP3">02619.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63711.xml
+++ b/DCLP/64/63711.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4921</idno>
             <idno type="filename">63711</idno>
             <idno type="dclp-hybrid">p.ross.georg;5;52</idno>
-            <idno type="MP3">2412.2</idno>
+            <idno type="MP3">02412.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63768.xml
+++ b/DCLP/64/63768.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4981</idno>
             <idno type="filename">63768</idno>
             <idno type="dclp-hybrid">bkt;9;156</idno>
-            <idno type="MP3">2797.87</idno>
+            <idno type="MP3">02797.870</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63786.xml
+++ b/DCLP/64/63786.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4999</idno>
             <idno type="filename">63786</idno>
             <idno type="dclp-hybrid">tm;;63786</idno>
-            <idno type="MP3">2729</idno>
+            <idno type="MP3">02729.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63799.xml
+++ b/DCLP/64/63799.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5012</idno>
             <idno type="filename">63799</idno>
             <idno type="dclp-hybrid">tm;;63799</idno>
-            <idno type="MP3">2602</idno>
+            <idno type="MP3">02602.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63805.xml
+++ b/DCLP/64/63805.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5018</idno>
             <idno type="filename">63805</idno>
             <idno type="dclp-hybrid">psi;7;850</idno>
-            <idno type="MP3">2462</idno>
+            <idno type="MP3">02462.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63816.xml
+++ b/DCLP/64/63816.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5029</idno>
             <idno type="filename">63816</idno>
             <idno type="dclp-hybrid">p.laur;4;151</idno>
-            <idno type="MP3">2420</idno>
+            <idno type="MP3">02420.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63825.xml
+++ b/DCLP/64/63825.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5038</idno>
             <idno type="filename">63825</idno>
             <idno type="dclp-hybrid">p.oxy;3;428</idno>
-            <idno type="MP3">1678</idno>
+            <idno type="MP3">01678.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63866.xml
+++ b/DCLP/64/63866.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5080</idno>
             <idno type="filename">63866</idno>
             <idno type="dclp-hybrid">p.narm.2006;;20</idno>
-            <idno type="MP3">2691.36</idno>
+            <idno type="MP3">02691.360</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63868.xml
+++ b/DCLP/64/63868.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5082</idno>
             <idno type="filename">63868</idno>
             <idno type="dclp-hybrid">o.narm;1;131</idno>
-            <idno type="MP3">2691.37</idno>
+            <idno type="MP3">02691.370</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63869.xml
+++ b/DCLP/64/63869.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5083</idno>
             <idno type="filename">63869</idno>
             <idno type="dclp-hybrid">o.narm;1;129</idno>
-            <idno type="MP3">2691.35</idno>
+            <idno type="MP3">02691.350</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63870.xml
+++ b/DCLP/64/63870.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5084</idno>
             <idno type="filename">63870</idno>
             <idno type="dclp-hybrid">sb;26;16388</idno>
-            <idno type="MP3">2691.34</idno>
+            <idno type="MP3">02691.340</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63930.xml
+++ b/DCLP/64/63930.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5145</idno>
             <idno type="filename">63930</idno>
             <idno type="dclp-hybrid">p.vind.worp;;20</idno>
-            <idno type="MP3">2423.2</idno>
+            <idno type="MP3">02423.200</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63941.xml
+++ b/DCLP/64/63941.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5156</idno>
             <idno type="filename">63941</idno>
             <idno type="dclp-hybrid">o.mich;1;672</idno>
-            <idno type="MP3">2690</idno>
+            <idno type="MP3">02690.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63954.xml
+++ b/DCLP/64/63954.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5169</idno>
             <idno type="filename">63954</idno>
             <idno type="dclp-hybrid">p.aberd;;130</idno>
-            <idno type="MP3">2983</idno>
+            <idno type="MP3">02983.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63971.xml
+++ b/DCLP/64/63971.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5186</idno>
             <idno type="filename">63971</idno>
             <idno type="dclp-hybrid">tm;;63971</idno>
-            <idno type="MP3">1673.100</idno>
+            <idno type="MP3">01673.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63974.xml
+++ b/DCLP/64/63974.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5189</idno>
             <idno type="filename">63974</idno>
             <idno type="dclp-hybrid">bkt;9;77</idno>
-            <idno type="MP3">2057.020</idno>
+            <idno type="MP3">02057.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/64/63980.xml
+++ b/DCLP/64/63980.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5195</idno>
             <idno type="filename">63980</idno>
             <idno type="dclp-hybrid">bkt;9;165</idno>
-            <idno type="MP3">2116.01</idno>
+            <idno type="MP3">02116.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64004.xml
+++ b/DCLP/65/64004.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5219</idno>
             <idno type="filename">64004</idno>
             <idno type="dclp-hybrid">o.mich;1;656</idno>
-            <idno type="MP3">2685</idno>
+            <idno type="MP3">02685.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64037.xml
+++ b/DCLP/65/64037.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5252</idno>
             <idno type="filename">64037</idno>
             <idno type="dclp-hybrid">psi;9;1095</idno>
-            <idno type="MP3">2567</idno>
+            <idno type="MP3">02567.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64041.xml
+++ b/DCLP/65/64041.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5257</idno>
             <idno type="filename">64041</idno>
             <idno type="dclp-hybrid">psicongr;20;5</idno>
-            <idno type="MP3">2419.01</idno>
+            <idno type="MP3">02419.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64152.xml
+++ b/DCLP/65/64152.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5371</idno>
             <idno type="filename">64152</idno>
             <idno type="dclp-hybrid">p.oxy;31;2604</idno>
-            <idno type="MP3">2750.1</idno>
+            <idno type="MP3">02750.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64173.xml
+++ b/DCLP/65/64173.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5392</idno>
             <idno type="filename">64173</idno>
             <idno type="dclp-hybrid">p.oxy;61;4098</idno>
-            <idno type="MP3">2451.03</idno>
+            <idno type="MP3">02451.030</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64214.xml
+++ b/DCLP/65/64214.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5433</idno>
             <idno type="filename">64214</idno>
             <idno type="dclp-hybrid">o.bodl;2;2187</idno>
-            <idno type="MP3">2430</idno>
+            <idno type="MP3">02430.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64242.xml
+++ b/DCLP/65/64242.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5461</idno>
             <idno type="filename">64242</idno>
             <idno type="dclp-hybrid">tm;;64242</idno>
-            <idno type="MP3">2422.4</idno>
+            <idno type="MP3">02422.400</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64272.xml
+++ b/DCLP/65/64272.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5492</idno>
             <idno type="filename">64272</idno>
             <idno type="dclp-hybrid">tm;;64272</idno>
-            <idno type="MP3">1831.1</idno>
+            <idno type="MP3">01831.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64274.xml
+++ b/DCLP/65/64274.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5494</idno>
             <idno type="filename">64274</idno>
             <idno type="dclp-hybrid">bkt;9;126</idno>
-            <idno type="MP3">1984.600</idno>
+            <idno type="MP3">01984.600</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64285.xml
+++ b/DCLP/65/64285.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5505</idno>
             <idno type="filename">64285</idno>
             <idno type="dclp-hybrid">o.mich;1;658</idno>
-            <idno type="MP3">2686.1</idno>
+            <idno type="MP3">02686.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64353.xml
+++ b/DCLP/65/64353.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5575</idno>
             <idno type="filename">64353</idno>
             <idno type="dclp-hybrid">mpern.s;13;5</idno>
-            <idno type="MP3">2422.6</idno>
+            <idno type="MP3">02422.600</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64439.xml
+++ b/DCLP/65/64439.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5663</idno>
             <idno type="filename">64439</idno>
             <idno type="dclp-hybrid">p.kellis;1;89</idno>
-            <idno type="MP3">2400.01</idno>
+            <idno type="MP3">02400.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64463.xml
+++ b/DCLP/65/64463.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5687</idno>
             <idno type="filename">64463</idno>
             <idno type="dclp-hybrid">tm;;64463</idno>
-            <idno type="MP3">02731</idno>
+            <idno type="MP3">02731.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64502.xml
+++ b/DCLP/65/64502.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5728</idno>
             <idno type="filename">64502</idno>
             <idno type="dclp-hybrid">o.bodl;2;2183</idno>
-            <idno type="MP3">2426</idno>
+            <idno type="MP3">02426.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64503.xml
+++ b/DCLP/65/64503.xml
@@ -14,7 +14,7 @@
             <idno type="filename">64503</idno>
             <idno type="dclp-hybrid">o.bodl;2;2185</idno>
             <idno type="dclp-hybrid">sb;14;11709</idno>
-            <idno type="MP3">2428</idno>
+            <idno type="MP3">02428.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64504.xml
+++ b/DCLP/65/64504.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5730</idno>
             <idno type="filename">64504</idno>
             <idno type="dclp-hybrid">o.bodl;2;2186</idno>
-            <idno type="MP3">2429</idno>
+            <idno type="MP3">02429.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64505.xml
+++ b/DCLP/65/64505.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5731</idno>
             <idno type="filename">64505</idno>
             <idno type="dclp-hybrid">o.bodl;2;2188</idno>
-            <idno type="MP3">2431</idno>
+            <idno type="MP3">02431.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64506.xml
+++ b/DCLP/65/64506.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5732</idno>
             <idno type="filename">64506</idno>
             <idno type="dclp-hybrid">o.bodl;2;2189</idno>
-            <idno type="MP3">2782.1</idno>
+            <idno type="MP3">02782.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64507.xml
+++ b/DCLP/65/64507.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5733</idno>
             <idno type="filename">64507</idno>
             <idno type="dclp-hybrid">o.bodl;2;2184</idno>
-            <idno type="MP3">2427</idno>
+            <idno type="MP3">02427.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64509.xml
+++ b/DCLP/65/64509.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5736</idno>
             <idno type="filename">64509</idno>
             <idno type="dclp-hybrid">p.bingen;;17</idno>
-            <idno type="MP3">2741.07</idno>
+            <idno type="MP3">02741.070</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64531.xml
+++ b/DCLP/65/64531.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5759</idno>
             <idno type="filename">64531</idno>
             <idno type="dclp-hybrid">p.oxy;17;2089</idno>
-            <idno type="MP3">2975</idno>
+            <idno type="MP3">02975.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64538.xml
+++ b/DCLP/65/64538.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5766</idno>
             <idno type="filename">64538</idno>
             <idno type="dclp-hybrid">bkt;10;30</idno>
-            <idno type="MP3">2990</idno>
+            <idno type="MP3">02990.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64566.xml
+++ b/DCLP/65/64566.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5796</idno>
             <idno type="filename">64566</idno>
             <idno type="dclp-hybrid">tm;;64566</idno>
-            <idno type="MP3">2982</idno>
+            <idno type="MP3">02982.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64568.xml
+++ b/DCLP/65/64568.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5798</idno>
             <idno type="filename">64568</idno>
             <idno type="dclp-hybrid">p.freib;4;45</idno>
-            <idno type="MP3">1591.01</idno>
+            <idno type="MP3">01591.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64583.xml
+++ b/DCLP/65/64583.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5813</idno>
             <idno type="filename">64583</idno>
             <idno type="dclp-hybrid">p.ryl;3;476</idno>
-            <idno type="MP3">2282</idno>
+            <idno type="MP3">02282.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64590.xml
+++ b/DCLP/65/64590.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5820</idno>
             <idno type="filename">64590</idno>
             <idno type="dclp-hybrid">p.amh;2;28</idno>
-            <idno type="MP3">2978</idno>
+            <idno type="MP3">02978.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64631.xml
+++ b/DCLP/65/64631.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5862</idno>
             <idno type="filename">64631</idno>
             <idno type="dclp-hybrid">chla;44;1311</idno>
-            <idno type="MP3">2954.01</idno>
+            <idno type="MP3">02954.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64656.xml
+++ b/DCLP/65/64656.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5887</idno>
             <idno type="filename">64656</idno>
             <idno type="dclp-hybrid">o.amst;;1</idno>
-            <idno type="MP3">2667.9</idno>
+            <idno type="MP3">02667.900</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64699.xml
+++ b/DCLP/65/64699.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5933</idno>
             <idno type="filename">64699</idno>
             <idno type="dclp-hybrid">bkt;9;154</idno>
-            <idno type="MP3">2797.86</idno>
+            <idno type="MP3">02797.860</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64703.xml
+++ b/DCLP/65/64703.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64703</idno>
             <idno type="LDAB">5937</idno>
             <idno type="filename">64703</idno>
-            <idno type="MP3">6033</idno>
+            <idno type="MP3">06033.000</idno>
             <idno type="dclp-hybrid">suppl.mag;1;26</idno>
             <availability>
                <p>

--- a/DCLP/65/64725.xml
+++ b/DCLP/65/64725.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5959</idno>
             <idno type="filename">64725</idno>
             <idno type="dclp-hybrid">psicongr;17;19</idno>
-            <idno type="MP3">2419.1</idno>
+            <idno type="MP3">02419.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64745.xml
+++ b/DCLP/65/64745.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">5979</idno>
             <idno type="filename">64745</idno>
             <idno type="dclp-hybrid">p.ryl;3;475</idno>
-            <idno type="MP3">2280</idno>
+            <idno type="MP3">02280.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64797.xml
+++ b/DCLP/65/64797.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6035</idno>
             <idno type="filename">64797</idno>
             <idno type="dclp-hybrid">mpern.s;3;38</idno>
-            <idno type="MP3">2286</idno>
+            <idno type="MP3">02286.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64818.xml
+++ b/DCLP/65/64818.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6056</idno>
             <idno type="filename">64818</idno>
             <idno type="dclp-hybrid">cla;10;1524</idno>
-            <idno type="MP3">2993.1</idno>
+            <idno type="MP3">02993.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64838.xml
+++ b/DCLP/65/64838.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6076</idno>
             <idno type="filename">64838</idno>
             <idno type="dclp-hybrid">tm;;64838</idno>
-            <idno type="MP3">2993.73</idno>
+            <idno type="MP3">02993.730</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64840.xml
+++ b/DCLP/65/64840.xml
@@ -13,7 +13,7 @@
             <idno type="dclp-hybrid">tm;;64840</idno>
             <idno type="TM">64840</idno>
             <idno type="LDAB">6078</idno>
-            <idno type="MP3">2277</idno>
+            <idno type="MP3">02277.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64846.xml
+++ b/DCLP/65/64846.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64846</idno>
             <idno type="LDAB">6084</idno>
             <idno type="filename">64846</idno>
-            <idno type="MP3">6032</idno>
+            <idno type="MP3">06032.000</idno>
             <idno type="dclp-hybrid">suppl.mag;1;31</idno>
             <availability>
                <p>

--- a/DCLP/65/64848.xml
+++ b/DCLP/65/64848.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6086</idno>
             <idno type="filename">64848</idno>
             <idno type="dclp-hybrid">tm;;64848</idno>
-            <idno type="MP3">2394.02</idno>
+            <idno type="MP3">02394.020</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64866.xml
+++ b/DCLP/65/64866.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6104</idno>
             <idno type="filename">64866</idno>
             <idno type="dclp-hybrid">p.gascou;;20</idno>
-            <idno type="MP3">6044</idno>
+            <idno type="MP3">06044.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64874.xml
+++ b/DCLP/65/64874.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64874</idno>
             <idno type="LDAB">6113</idno>
             <idno type="filename">64874</idno>
-            <idno type="MP3">6055</idno>
+            <idno type="MP3">06055.000</idno>
             <idno type="dclp-hybrid">suppl.mag;1;33</idno>
             <availability>
                <p>

--- a/DCLP/65/64889.xml
+++ b/DCLP/65/64889.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6128</idno>
             <idno type="filename">64889</idno>
             <idno type="dclp-hybrid">sb;14;11964</idno>
-            <idno type="MP3">2379.1</idno>
+            <idno type="MP3">02379.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64897.xml
+++ b/DCLP/65/64897.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6136</idno>
             <idno type="filename">64897</idno>
             <idno type="dclp-hybrid">tm;;64897</idno>
-            <idno type="MP3">2979.1</idno>
+            <idno type="MP3">02979.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64985.xml
+++ b/DCLP/65/64985.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6226</idno>
             <idno type="filename">64985</idno>
             <idno type="dclp-hybrid">cla;8;1034</idno>
-            <idno type="MP3">2992</idno>
+            <idno type="MP3">02992.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/65/64986.xml
+++ b/DCLP/65/64986.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6227</idno>
             <idno type="filename">64986</idno>
             <idno type="dclp-hybrid">cla;8;1035</idno>
-            <idno type="MP3">2993</idno>
+            <idno type="MP3">02993.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/66/65032.xml
+++ b/DCLP/66/65032.xml
@@ -13,7 +13,7 @@
             <idno type="dclp-hybrid">psi;13;1349</idno>
             <idno type="TM">65032</idno>
             <idno type="LDAB">6273</idno>
-            <idno type="MP3">2278</idno>
+            <idno type="MP3">02278.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/66/65155.xml
+++ b/DCLP/66/65155.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6397</idno>
             <idno type="filename">65155</idno>
             <idno type="dclp-hybrid">tm;;65155</idno>
-            <idno type="MP3">2984</idno>
+            <idno type="MP3">02984.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/66/65227.xml
+++ b/DCLP/66/65227.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6469</idno>
             <idno type="filename">65227</idno>
             <idno type="dclp-hybrid">p.ness;2;11</idno>
-            <idno type="MP3">2284</idno>
+            <idno type="MP3">02284.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/66/65308.xml
+++ b/DCLP/66/65308.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6553</idno>
             <idno type="filename">65308</idno>
             <idno type="dclp-hybrid">tm;;65308</idno>
-            <idno type="MP3">2739</idno>
+            <idno type="MP3">02739.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/66/65337.xml
+++ b/DCLP/66/65337.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6583</idno>
             <idno type="filename">65337</idno>
             <idno type="dclp-hybrid">p.ness;2;12</idno>
-            <idno type="MP3">2285</idno>
+            <idno type="MP3">02285.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/66/65429.xml
+++ b/DCLP/66/65429.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6676</idno>
             <idno type="filename">65429</idno>
             <idno type="dclp-hybrid">p.rain.unterrichtkopt;;77</idno>
-            <idno type="MP3">2693</idno>
+            <idno type="MP3">02693.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/66/65515.xml
+++ b/DCLP/66/65515.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6765</idno>
             <idno type="filename">65515</idno>
             <idno type="dclp-hybrid">bkt;9;159</idno>
-            <idno type="MP3">2797.89</idno>
+            <idno type="MP3">02797.890</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/66/65559.xml
+++ b/DCLP/66/65559.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6810</idno>
             <idno type="filename">65559</idno>
             <idno type="dclp-hybrid">p.schub;;34</idno>
-            <idno type="MP3">2469</idno>
+            <idno type="MP3">02469.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/66/65740.xml
+++ b/DCLP/66/65740.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">6994</idno>
             <idno type="filename">65740</idno>
             <idno type="dclp-hybrid">p.hib;2;191</idno>
-            <idno type="MP3">2348</idno>
+            <idno type="MP3">02348.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/66/65823.xml
+++ b/DCLP/66/65823.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">7079</idno>
             <idno type="filename">65823</idno>
             <idno type="dclp-hybrid">tm;;65823</idno>
-            <idno type="MP3">1596.1</idno>
+            <idno type="MP3">01596.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/67/66070.xml
+++ b/DCLP/67/66070.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">7317</idno>
             <idno type="filename">66070</idno>
             <idno type="dclp-hybrid">tm;;66070</idno>
-            <idno type="MP3">1274.01</idno>
+            <idno type="MP3">01274.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/67/66749.xml
+++ b/DCLP/67/66749.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">7999</idno>
             <idno type="filename">66749</idno>
             <idno type="dclp-hybrid">p.bingen;;19</idno>
-            <idno type="MP3">1597.11</idno>
+            <idno type="MP3">01597.110</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/67/66750.xml
+++ b/DCLP/67/66750.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">4248</idno>
             <idno type="filename">66750</idno>
             <idno type="dclp-hybrid">o.mon.phoib;;40</idno>
-            <idno type="MP3">1597.1</idno>
+            <idno type="MP3">01597.100</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/67/66755.xml
+++ b/DCLP/67/66755.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">8005</idno>
             <idno type="filename">66755</idno>
             <idno type="dclp-hybrid">p.bingen;;26</idno>
-            <idno type="MP3">1597.12</idno>
+            <idno type="MP3">01597.120</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/67/66979.xml
+++ b/DCLP/67/66979.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">8244</idno>
             <idno type="filename">66979</idno>
             <idno type="dclp-hybrid">p.nyu;2;1</idno>
-            <idno type="MP3">0585.01</idno>
+            <idno type="MP3">00585.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/68/67356.xml
+++ b/DCLP/68/67356.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">9947</idno>
             <idno type="filename">67356</idno>
             <idno type="dclp-hybrid">tm;;67356</idno>
-            <idno type="MP3">2973</idno>
+            <idno type="MP3">02973.000</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/69/68666.xml
+++ b/DCLP/69/68666.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">9939</idno>
             <idno type="filename">68666</idno>
             <idno type="dclp-hybrid">tm;;68666</idno>
-            <idno type="MP3">0571.01</idno>
+            <idno type="MP3">00571.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/69/68678.xml
+++ b/DCLP/69/68678.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">9952</idno>
             <idno type="filename">68678</idno>
             <idno type="dclp-hybrid">tm;;68678</idno>
-            <idno type="MP3">625.101</idno>
+            <idno type="MP3">00625.101</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/69/68973.xml
+++ b/DCLP/69/68973.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">10243</idno>
             <idno type="filename">68973</idno>
             <idno type="dclp-hybrid">p.oxy;68;4667</idno>
-            <idno type="MP3">1231.01</idno>
+            <idno type="MP3">01231.010</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/698/697566.xml
+++ b/DCLP/698/697566.xml
@@ -13,7 +13,7 @@
             <idno type="dclp-hybrid">tm;;697566</idno>
             <idno type="TM">697566</idno>
             <idno type="LDAB">697566</idno>
-            <idno type="MP3">152.011</idno>
+            <idno type="MP3">00152.011</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/70/69030.xml
+++ b/DCLP/70/69030.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">10301</idno>
             <idno type="filename">69030</idno>
             <idno type="dclp-hybrid">sb;28;17136</idno>
-            <idno type="MP3">2410.13</idno>
+            <idno type="MP3">02410.130</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/70/69031.xml
+++ b/DCLP/70/69031.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">10302</idno>
             <idno type="filename">69031</idno>
             <idno type="dclp-hybrid">sb;28;17137</idno>
-            <idno type="MP3">2410.14</idno>
+            <idno type="MP3">02410.140</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/705/704687.xml
+++ b/DCLP/705/704687.xml
@@ -12,7 +12,7 @@
             <idno type="dclp">704687</idno>
             <idno type="dclp-hybrid">tm;;704687</idno>
             <idno type="TM">704687</idno>
-            <idno type="MP3">2281</idno>
+            <idno type="MP3">02281.000</idno>
             <idno type="LDAB">704687</idno>
             <availability>
                <p>

--- a/DCLP/75/74466.xml
+++ b/DCLP/75/74466.xml
@@ -13,7 +13,7 @@
             <idno type="LDAB">10761</idno>
             <idno type="filename">74466</idno>
             <idno type="dclp-hybrid">o.eleph.wagner;;126</idno>
-            <idno type="MP3">2704.03</idno>
+            <idno type="MP3">02704.030</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/829/828803.xml
+++ b/DCLP/829/828803.xml
@@ -12,7 +12,7 @@
             <idno type="dclp">828803</idno>
             <idno type="dclp-hybrid">tm;;828803</idno>
             <idno type="TM">828803</idno>
-            <idno type="MP3">2277.13</idno>
+            <idno type="MP3">02277.130</idno>
             <idno type="LDAB">828803</idno>
             <availability>
                <p>

--- a/DCLP/829/828804.xml
+++ b/DCLP/829/828804.xml
@@ -12,7 +12,7 @@
             <idno type="dclp">828804</idno>
             <idno type="dclp-hybrid">tm;;828804</idno>
             <idno type="TM">828804</idno>
-            <idno type="MP3">2277.11</idno>
+            <idno type="MP3">02277.110</idno>
             <idno type="LDAB">828804</idno>
             <availability>
                <p>

--- a/DCLP/829/828805.xml
+++ b/DCLP/829/828805.xml
@@ -12,7 +12,7 @@
             <idno type="dclp">828805</idno>
             <idno type="dclp-hybrid">tm;;828805</idno>
             <idno type="TM">828805</idno>
-            <idno type="MP3">2277.12</idno>
+            <idno type="MP3">02277.120</idno>
             <idno type="LDAB">828805</idno>
             <availability>
                <p>

--- a/DCLP/829/828806.xml
+++ b/DCLP/829/828806.xml
@@ -12,7 +12,7 @@
             <idno type="dclp">828806</idno>
             <idno type="dclp-hybrid">tm;;828806</idno>
             <idno type="TM">828806</idno>
-            <idno type="MP3">2277.16</idno>
+            <idno type="MP3">02277.160</idno>
             <idno type="LDAB">828806</idno>
             <availability>
                <p>

--- a/DCLP/829/828807.xml
+++ b/DCLP/829/828807.xml
@@ -12,7 +12,7 @@
             <idno type="dclp">828807</idno>
             <idno type="dclp-hybrid">tm;;828807</idno>
             <idno type="TM">828807</idno>
-            <idno type="MP3">2955.01</idno>
+            <idno type="MP3">02955.010</idno>
             <idno type="LDAB">828807</idno>
             <availability>
                <p>

--- a/DCLP/829/828808.xml
+++ b/DCLP/829/828808.xml
@@ -12,7 +12,7 @@
             <idno type="dclp">828808</idno>
             <idno type="dclp-hybrid">tm;;828808</idno>
             <idno type="TM">828808</idno>
-            <idno type="MP3">2993.74</idno>
+            <idno type="MP3">02993.740</idno>
             <idno type="LDAB">828808</idno>
             <availability>
                <p>

--- a/DCLP/829/828811.xml
+++ b/DCLP/829/828811.xml
@@ -12,7 +12,7 @@
             <idno type="dclp">828811</idno>
             <idno type="dclp-hybrid">tm;;828811</idno>
             <idno type="TM">828811</idno>
-            <idno type="MP3">2277.17</idno>
+            <idno type="MP3">02277.170</idno>
             <idno type="LDAB">828811</idno>
             <availability>
                <p>

--- a/DCLP/829/828813.xml
+++ b/DCLP/829/828813.xml
@@ -12,7 +12,7 @@
             <idno type="dclp">828813</idno>
             <idno type="dclp-hybrid">tm;;828813</idno>
             <idno type="TM">828813</idno>
-            <idno type="MP3">2277.18</idno>
+            <idno type="MP3">02277.180</idno>
             <idno type="LDAB">828813</idno>
             <availability>
                <p>

--- a/DCLP/833/832675.xml
+++ b/DCLP/833/832675.xml
@@ -13,7 +13,7 @@
             <idno type="dclp-hybrid">tm;;832675</idno>
             <idno type="TM">832675</idno>
             <idno type="LDAB">832675</idno>
-            <idno type="MP3">2277.14</idno>
+            <idno type="MP3">02277.140</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a


### PR DESCRIPTION
These commits standardize the format of the MP3 `<idno>` in DCLP to `\d{5}\.\d{3}`; it should be possible to have XSLT point to the corresponding file in CEDOPAL's records automatically, but only if these are in the correct format.