### PR TITLE
xWalk P.Yale IV to HGV, plus APIS aggregation

### DIFF
--- a/APIS/yale/xml/yale.apis.0002030000.xml
+++ b/APIS/yale/xml/yale.apis.0002030000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0002030000</idno>
             <idno type="controlNo">(CtY)203 qua</idno>
+            <idno type="HGV">974997</idno>
+            <idno type="TM">974997</idno>
+            <idno type="ddb-hybrid">p.yale;4;180</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0002310000.xml
+++ b/APIS/yale/xml/yale.apis.0002310000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0002310000</idno>
             <idno type="controlNo">(CtY)231</idno>
+            <idno type="HGV">974987</idno>
+            <idno type="TM">974987</idno>
+            <idno type="ddb-hybrid">p.yale;4;170</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0002750000.xml
+++ b/APIS/yale/xml/yale.apis.0002750000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0002750000</idno>
             <idno type="controlNo">(CtY)275</idno>
+            <idno type="HGV">974979</idno>
+            <idno type="TM">974979</idno>
+            <idno type="ddb-hybrid">p.yale;4;161</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0003054100.xml
+++ b/APIS/yale/xml/yale.apis.0003054100.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0003054100</idno>
             <idno type="controlNo">(CtY)305(A)</idno>
+            <idno type="HGV">974985</idno>
+            <idno type="TM">974985</idno>
+            <idno type="ddb-hybrid">p.yale;4;168</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0003054200.xml
+++ b/APIS/yale/xml/yale.apis.0003054200.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0003054200</idno>
             <idno type="controlNo">(CtY)305(B)</idno>
+            <idno type="HGV">976543</idno>
+            <idno type="TM">976543</idno>
+            <idno type="ddb-hybrid">p.yale;4;168r</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0003300000.xml
+++ b/APIS/yale/xml/yale.apis.0003300000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0003300000</idno>
             <idno type="controlNo">(CtY)330</idno>
+            <idno type="HGV">974984</idno>
+            <idno type="TM">974984</idno>
+            <idno type="ddb-hybrid">p.yale;4;167</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0003410000.xml
+++ b/APIS/yale/xml/yale.apis.0003410000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0003410000</idno>
             <idno type="controlNo">(CtY)341 qua</idno>
+            <idno type="HGV">974998</idno>
+            <idno type="TM">974998</idno>
+            <idno type="ddb-hybrid">p.yale;4;181</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0004110000.xml
+++ b/APIS/yale/xml/yale.apis.0004110000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0004110000</idno>
             <idno type="controlNo">(CtY)411</idno>
+            <idno type="HGV">974978</idno>
+            <idno type="TM">974978</idno>
+            <idno type="ddb-hybrid">p.yale;4;160</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0004184100.xml
+++ b/APIS/yale/xml/yale.apis.0004184100.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0004184100</idno>
             <idno type="controlNo">(CtY)418(A) qua</idno>
+            <idno type="HGV">974972</idno>
+            <idno type="TM">974972</idno>
+            <idno type="ddb-hybrid">p.yale;4;154r</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0004184200.xml
+++ b/APIS/yale/xml/yale.apis.0004184200.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0004184200</idno>
             <idno type="controlNo">(CtY)418(B) qua</idno>
+            <idno type="HGV">976541</idno>
+            <idno type="TM">976541</idno>
+            <idno type="ddb-hybrid">p.yale;4;154v</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0004564131.xml
+++ b/APIS/yale/xml/yale.apis.0004564131.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0004564131</idno>
             <idno type="controlNo">(CtY)456(A)(first text)</idno>
+            <idno type="HGV">974983</idno>
+            <idno type="TM">974983</idno>
+            <idno type="ddb-hybrid">p.yale;4;165</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0004564132.xml
+++ b/APIS/yale/xml/yale.apis.0004564132.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0004564132</idno>
             <idno type="controlNo">(CtY)456(A)(second text)</idno>
+            <idno type="HGV">974983</idno>
+            <idno type="TM">974983</idno>
+            <idno type="ddb-hybrid">p.yale;4;165</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0004564231.xml
+++ b/APIS/yale/xml/yale.apis.0004564231.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0004564231</idno>
             <idno type="controlNo">(CtY)456(B)(first text)</idno>
+            <idno type="HGV">974983</idno>
+            <idno type="TM">974983</idno>
+            <idno type="ddb-hybrid">p.yale;4;165</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0004564232.xml
+++ b/APIS/yale/xml/yale.apis.0004564232.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0004564232</idno>
             <idno type="controlNo">(CtY)456(B)(second text)</idno>
+            <idno type="HGV">974983</idno>
+            <idno type="TM">974983</idno>
+            <idno type="ddb-hybrid">p.yale;4;165</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0005084100.xml
+++ b/APIS/yale/xml/yale.apis.0005084100.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0005084100</idno>
             <idno type="controlNo">(CtY)508(A)</idno>
+            <idno type="HGV">974995</idno>
+            <idno type="TM">974995</idno>
+            <idno type="ddb-hybrid">p.yale;4;178</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0005730000.xml
+++ b/APIS/yale/xml/yale.apis.0005730000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0005730000</idno>
             <idno type="controlNo">(CtY)573</idno>
+            <idno type="HGV">974989</idno>
+            <idno type="TM">974989</idno>
+            <idno type="ddb-hybrid">p.yale;4;172</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0006590000.xml
+++ b/APIS/yale/xml/yale.apis.0006590000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0006590000</idno>
             <idno type="controlNo">(CtY)659</idno>
+            <idno type="HGV">974999</idno>
+            <idno type="TM">974999</idno>
+            <idno type="ddb-hybrid">p.yale;4;182</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0006940000.xml
+++ b/APIS/yale/xml/yale.apis.0006940000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0006940000</idno>
             <idno type="controlNo">(CtY)694</idno>
+            <idno type="HGV">974977</idno>
+            <idno type="TM">974977</idno>
+            <idno type="ddb-hybrid">p.yale;4;159</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0007220000.xml
+++ b/APIS/yale/xml/yale.apis.0007220000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0007220000</idno>
             <idno type="controlNo">(CtY)722</idno>
+            <idno type="HGV">974975</idno>
+            <idno type="TM">974975</idno>
+            <idno type="ddb-hybrid">p.yale;4;157</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0009014131.xml
+++ b/APIS/yale/xml/yale.apis.0009014131.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0009014131</idno>
             <idno type="controlNo">(CtY)901(A)(First text) fol</idno>
+            <idno type="HGV">974981</idno>
+            <idno type="TM">974981</idno>
+            <idno type="ddb-hybrid">p.yale;4;163</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0009014200.xml
+++ b/APIS/yale/xml/yale.apis.0009014200.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0009014200</idno>
             <idno type="controlNo">(CtY)901(B) fol</idno>
+            <idno type="HGV">974982</idno>
+            <idno type="TM">974982</idno>
+            <idno type="ddb-hybrid">p.yale;4;164</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0009090000.xml
+++ b/APIS/yale/xml/yale.apis.0009090000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0009090000</idno>
             <idno type="controlNo">(CtY)909</idno>
+            <idno type="HGV">974988</idno>
+            <idno type="TM">974988</idno>
+            <idno type="ddb-hybrid">p.yale;4;171</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0011230000.xml
+++ b/APIS/yale/xml/yale.apis.0011230000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0011230000</idno>
             <idno type="controlNo">(CtY)1123</idno>
+            <idno type="HGV">974992</idno>
+            <idno type="TM">974992</idno>
+            <idno type="ddb-hybrid">p.yale;4;175</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0012440000.xml
+++ b/APIS/yale/xml/yale.apis.0012440000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0012440000</idno>
             <idno type="controlNo">(CtY)1244</idno>
+            <idno type="HGV">974996</idno>
+            <idno type="TM">974996</idno>
+            <idno type="ddb-hybrid">p.yale;4;179</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0012520000.xml
+++ b/APIS/yale/xml/yale.apis.0012520000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0012520000</idno>
             <idno type="controlNo">(CtY)1252</idno>
+            <idno type="HGV">974991</idno>
+            <idno type="TM">974991</idno>
+            <idno type="ddb-hybrid">p.yale;4;174</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0012540000.xml
+++ b/APIS/yale/xml/yale.apis.0012540000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0012540000</idno>
             <idno type="controlNo">(CtY)1254 qua</idno>
+            <idno type="HGV">974976</idno>
+            <idno type="TM">974976</idno>
+            <idno type="ddb-hybrid">p.yale;4;158</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0014250000.xml
+++ b/APIS/yale/xml/yale.apis.0014250000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0014250000</idno>
             <idno type="controlNo">(CtY)1425</idno>
+            <idno type="HGV">974990</idno>
+            <idno type="TM">974990</idno>
+            <idno type="ddb-hybrid">p.yale;4;173</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0014374100.xml
+++ b/APIS/yale/xml/yale.apis.0014374100.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0014374100</idno>
             <idno type="controlNo">(CtY)1437(A)</idno>
+            <idno type="HGV">974993</idno>
+            <idno type="TM">974993</idno>
+            <idno type="ddb-hybrid">p.yale;4;176v</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0014374200.xml
+++ b/APIS/yale/xml/yale.apis.0014374200.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0014374200</idno>
             <idno type="controlNo">(CtY)1437(B)</idno>
+            <idno type="HGV">976547</idno>
+            <idno type="TM">976547</idno>
+            <idno type="ddb-hybrid">p.yale;4;176r</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0015624131.xml
+++ b/APIS/yale/xml/yale.apis.0015624131.xml
@@ -10,6 +10,8 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0015624131</idno>
             <idno type="controlNo">(CtY)1562 (A)(first text) qua</idno>
+            <idno type="HGV">974973</idno>
+            <idno type="TM">974973</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0015624200.xml
+++ b/APIS/yale/xml/yale.apis.0015624200.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0015624200</idno>
             <idno type="controlNo">(CtY)1562(B) qua</idno>
+            <idno type="HGV">974974</idno>
+            <idno type="TM">974974</idno>
+            <idno type="ddb-hybrid">p.yale;4;156</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0015630000.xml
+++ b/APIS/yale/xml/yale.apis.0015630000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0015630000</idno>
             <idno type="controlNo">(CtY)1563</idno>
+            <idno type="HGV">974994</idno>
+            <idno type="TM">974994</idno>
+            <idno type="ddb-hybrid">p.yale;4;177</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0015950000.xml
+++ b/APIS/yale/xml/yale.apis.0015950000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0015950000</idno>
             <idno type="controlNo">(CtY)1595</idno>
+            <idno type="HGV">974971</idno>
+            <idno type="TM">974971</idno>
+            <idno type="ddb-hybrid">p.yale;4;153</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0016460000.xml
+++ b/APIS/yale/xml/yale.apis.0016460000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0016460000</idno>
             <idno type="controlNo">(CtY)1646</idno>
+            <idno type="HGV">974986</idno>
+            <idno type="TM">974986</idno>
+            <idno type="ddb-hybrid">p.yale;4;169</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0036740000.xml
+++ b/APIS/yale/xml/yale.apis.0036740000.xml
@@ -10,6 +10,12 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0036740000</idno>
             <idno type="controlNo">(CtY)3674</idno>
+            <idno type="HGV">975007</idno>
+            <idno type="TM">975007</idno>
+            <idno type="ddb-hybrid">p.yale;4;190</idno>
+            <idno type="HGV">975008</idno>
+            <idno type="TM">975008</idno>
+            <idno type="ddb-hybrid">p.yale;4;191</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0036754100.xml
+++ b/APIS/yale/xml/yale.apis.0036754100.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0036754100</idno>
             <idno type="controlNo">(CtY)3675(A)</idno>
+            <idno type="HGV">975003</idno>
+            <idno type="TM">975003</idno>
+            <idno type="ddb-hybrid">p.yale;4;186</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0036764100.xml
+++ b/APIS/yale/xml/yale.apis.0036764100.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0036764100</idno>
             <idno type="controlNo">(CtY)3676(A)</idno>
+            <idno type="HGV">975001</idno>
+            <idno type="TM">975001</idno>
+            <idno type="ddb-hybrid">p.yale;4;184</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0036804100.xml
+++ b/APIS/yale/xml/yale.apis.0036804100.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0036804100</idno>
             <idno type="controlNo">(CtY)3680(A)</idno>
+            <idno type="HGV">975006</idno>
+            <idno type="TM">975006</idno>
+            <idno type="ddb-hybrid">p.yale;4;189</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0036804200.xml
+++ b/APIS/yale/xml/yale.apis.0036804200.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0036804200</idno>
             <idno type="controlNo">(CtY)3680(B)</idno>
+            <idno type="HGV">975005</idno>
+            <idno type="TM">975005</idno>
+            <idno type="ddb-hybrid">p.yale;4;188</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0045000000.xml
+++ b/APIS/yale/xml/yale.apis.0045000000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0045000000</idno>
             <idno type="controlNo">(CtY)4500 qua</idno>
+            <idno type="HGV">873596</idno>
+            <idno type="TM">873596</idno>
+            <idno type="ddb-hybrid">p.yale;4;141</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0045980000.xml
+++ b/APIS/yale/xml/yale.apis.0045980000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0045980000</idno>
             <idno type="controlNo">(CtY)4598</idno>
+            <idno type="HGV">873592</idno>
+            <idno type="TM">873592</idno>
+            <idno type="ddb-hybrid">p.yale;4;152</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0045990000.xml
+++ b/APIS/yale/xml/yale.apis.0045990000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0045990000</idno>
             <idno type="controlNo">(CtY)4599</idno>
+            <idno type="HGV">873591</idno>
+            <idno type="TM">873591</idno>
+            <idno type="ddb-hybrid">p.yale;4;151</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0046020000.xml
+++ b/APIS/yale/xml/yale.apis.0046020000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0046020000</idno>
             <idno type="controlNo">(CtY)4602</idno>
+            <idno type="HGV">873587</idno>
+            <idno type="TM">873587</idno>
+            <idno type="ddb-hybrid">p.yale;4;147</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0046030000.xml
+++ b/APIS/yale/xml/yale.apis.0046030000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0046030000</idno>
             <idno type="controlNo">(CtY)4603 qua</idno>
+            <idno type="HGV">873594</idno>
+            <idno type="TM">873594</idno>
+            <idno type="ddb-hybrid">p.yale;4;139</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0046040000.xml
+++ b/APIS/yale/xml/yale.apis.0046040000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0046040000</idno>
             <idno type="controlNo">(CtY)4604 qua</idno>
+            <idno type="HGV">873593</idno>
+            <idno type="TM">873593</idno>
+            <idno type="ddb-hybrid">p.yale;4;138</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0046050000.xml
+++ b/APIS/yale/xml/yale.apis.0046050000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0046050000</idno>
             <idno type="controlNo">(CtY)4605 qua</idno>
+            <idno type="HGV">873595</idno>
+            <idno type="TM">873595</idno>
+            <idno type="ddb-hybrid">p.yale;4;140</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0046060000.xml
+++ b/APIS/yale/xml/yale.apis.0046060000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0046060000</idno>
             <idno type="controlNo">(CtY)4606 qua</idno>
+            <idno type="HGV">873597</idno>
+            <idno type="TM">873597</idno>
+            <idno type="ddb-hybrid">p.yale;4;142</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0046070000.xml
+++ b/APIS/yale/xml/yale.apis.0046070000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0046070000</idno>
             <idno type="controlNo">(CtY)4607 qua</idno>
+            <idno type="HGV">873598</idno>
+            <idno type="TM">873598</idno>
+            <idno type="ddb-hybrid">p.yale;4;143</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0046080000.xml
+++ b/APIS/yale/xml/yale.apis.0046080000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0046080000</idno>
             <idno type="controlNo">(CtY)4608</idno>
+            <idno type="HGV">873599</idno>
+            <idno type="TM">873599</idno>
+            <idno type="ddb-hybrid">p.yale;4;144</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0046100000.xml
+++ b/APIS/yale/xml/yale.apis.0046100000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0046100000</idno>
             <idno type="controlNo">(CtY)4610 qua</idno>
+            <idno type="HGV">873586</idno>
+            <idno type="TM">873586</idno>
+            <idno type="ddb-hybrid">p.yale;4;146</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0046110000.xml
+++ b/APIS/yale/xml/yale.apis.0046110000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0046110000</idno>
             <idno type="controlNo">(CtY)4611 qua</idno>
+            <idno type="HGV">873588</idno>
+            <idno type="TM">873588</idno>
+            <idno type="ddb-hybrid">p.yale;4;148</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0046120000.xml
+++ b/APIS/yale/xml/yale.apis.0046120000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0046120000</idno>
             <idno type="controlNo">(CtY)4612 qua</idno>
+            <idno type="HGV">873589</idno>
+            <idno type="TM">873589</idno>
+            <idno type="ddb-hybrid">p.yale;4;149</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0046130000.xml
+++ b/APIS/yale/xml/yale.apis.0046130000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0046130000</idno>
             <idno type="controlNo">(CtY)4613</idno>
+            <idno type="HGV">873590</idno>
+            <idno type="TM">873590</idno>
+            <idno type="ddb-hybrid">p.yale;4;150</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/yale/xml/yale.apis.0049710000.xml
+++ b/APIS/yale/xml/yale.apis.0049710000.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">yale.apis.0049710000</idno>
             <idno type="controlNo">(CtY)4971</idno>
+            <idno type="HGV">975000</idno>
+            <idno type="TM">975000</idno>
+            <idno type="ddb-hybrid">p.yale;4;183</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/HGV_meta_EpiDoc/HGV141/140259.xml
+++ b/HGV_meta_EpiDoc/HGV141/140259.xml
@@ -18,7 +18,7 @@
                   <placeName>
                      <settlement>New Haven</settlement>
                   </placeName>
-                  <collection>The Beinecke Rare Book and Manuscript Library</collection>
+                  <collection>Yale University, Beinecke Library</collection>
                   <idno type="invNo">P.CtYBR inv. 4623</idno>
                </msIdentifier>
                <physDesc>

--- a/HGV_meta_EpiDoc/HGV141/140308.xml
+++ b/HGV_meta_EpiDoc/HGV141/140308.xml
@@ -18,7 +18,7 @@
                   <placeName>
                      <settlement>New Haven, Yale University</settlement>
                   </placeName>
-                  <collection>Beinecke Library</collection>
+                  <collection>Yale University, Beinecke Library</collection>
                   <idno type="invNo">P. CtYBR 1115</idno>
                </msIdentifier>
                <physDesc>

--- a/HGV_meta_EpiDoc/HGV755/754941.xml
+++ b/HGV_meta_EpiDoc/HGV755/754941.xml
@@ -18,7 +18,7 @@
             <placeName>
               <settlement>New Haven</settlement>
             </placeName>
-            <collection>Beinecke Library</collection>
+            <collection>Yale University, Beinecke Library</collection>
             <idno type="invNo">P.CtYBR 5058</idno>
           </msIdentifier>
           <physDesc>

--- a/HGV_meta_EpiDoc/HGV755/754942.xml
+++ b/HGV_meta_EpiDoc/HGV755/754942.xml
@@ -18,7 +18,7 @@
             <placeName>
               <settlement>New Haven</settlement>
             </placeName>
-            <collection>Beinecke Library</collection>
+            <collection>Yale University, Beinecke Library</collection>
             <idno type="invNo">P.CtYBR 5059</idno>
           </msIdentifier>
           <physDesc>

--- a/HGV_meta_EpiDoc/HGV755/754943.xml
+++ b/HGV_meta_EpiDoc/HGV755/754943.xml
@@ -18,7 +18,7 @@
             <placeName>
               <settlement>New Haven</settlement>
             </placeName>
-            <collection>Beinecke Library</collection>
+            <collection>Yale University, Beinecke Library</collection>
             <idno type="invNo">P.CtYBR 5060</idno>
           </msIdentifier>
           <physDesc>

--- a/HGV_meta_EpiDoc/HGV755/754944.xml
+++ b/HGV_meta_EpiDoc/HGV755/754944.xml
@@ -18,7 +18,7 @@
             <placeName>
               <settlement>New Haven</settlement>
             </placeName>
-            <collection>Beinecke Library</collection>
+            <collection>Yale University, Beinecke Library</collection>
             <idno type="invNo">P.CtYBR 5061 qua</idno>
           </msIdentifier>
           <physDesc>

--- a/HGV_meta_EpiDoc/HGV755/754945.xml
+++ b/HGV_meta_EpiDoc/HGV755/754945.xml
@@ -18,7 +18,7 @@
             <placeName>
               <settlement>New Haven</settlement>
             </placeName>
-            <collection>Beinecke Library</collection>
+            <collection>Yale University, Beinecke Library</collection>
             <idno type="invNo">P.CtYBR 5062</idno>
           </msIdentifier>
           <physDesc>

--- a/HGV_meta_EpiDoc/HGV755/754946.xml
+++ b/HGV_meta_EpiDoc/HGV755/754946.xml
@@ -18,7 +18,7 @@
             <placeName>
               <settlement>New Haven</settlement>
             </placeName>
-            <collection>Beinecke Library</collection>
+            <collection>Yale University, Beinecke Library</collection>
             <idno type="invNo">P.CtYBR 5063</idno>
           </msIdentifier>
           <physDesc>

--- a/HGV_meta_EpiDoc/HGV874/873586.xml
+++ b/HGV_meta_EpiDoc/HGV874/873586.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition an den Epistrategen Boethos wegen Verdrängung aus dem Erbteil</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873586</idno>
+        <idno type="TM">873586</idno>
+        <idno type="ddb-filename">p.yale.4.146</idno>
+        <idno type="ddb-hybrid">p.yale;4;146</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4610</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Chnothis (Herakleopolites)</origPlace>
+              <origDate notBefore="-0137-07-07" notAfter="-0137-07-08">7. - 8. Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/58562">Chnothis</placeName>
+                <placeName n="2"
+                                type="ancient"
+                                subtype="nome"
+                                ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">Hermione an Boethos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">146</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 14-15</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767745"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873587.xml
+++ b/HGV_meta_EpiDoc/HGV874/873587.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition an den Epistrategen Boethos wegen eines nicht zurückgezahlten Darlehens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873587</idno>
+        <idno type="TM">873587</idno>
+        <idno type="ddb-filename">p.yale.4.147</idno>
+        <idno type="ddb-hybrid">p.yale;4;147</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4602</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+                <origPlace>Herakleopolis ? (Herakleopolites)</origPlace>
+                <origDate when="-0137-07-09">9. Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance>
+                <p>
+                    <placeName n="1"
+                                type="ancient"
+                                cert="low"
+                                ref="https://www.trismegistos.org/place/801 https://pleiades.stoa.org/places/736920">Herakleopolis</placeName>
+                    <placeName n="2"
+                                type="ancient"
+                                subtype="nome"
+                                ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+                </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">Hermione an Boethos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">147</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 16-17</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767531"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873588.xml
+++ b/HGV_meta_EpiDoc/HGV874/873588.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition an den Epistrategen Boethos mit dem Ersuchen um Beschleunigung eines Prozesses vor dem Strategen</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873588</idno>
+        <idno type="TM">873588</idno>
+        <idno type="ddb-filename">p.yale.4.148</idno>
+        <idno type="ddb-hybrid">p.yale;4;148</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4611</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolites</origPlace>
+              <origDate notBefore="-0137-07-19" notAfter="-0137-07-20">19. - 20. Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">Herieus an Boethos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">148</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 18</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767640"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873589.xml
+++ b/HGV_meta_EpiDoc/HGV874/873589.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Bittgesuch eines Königlichen Bauern an den Epistrategen Boethos</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873589</idno>
+        <idno type="TM">873589</idno>
+        <idno type="ddb-filename">p.yale.4.149</idno>
+        <idno type="ddb-hybrid">p.yale;4;149</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4612</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolites</origPlace>
+              <origDate when="-0137-07">Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">Herieus an Boethos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">149</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 19</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767551"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873590.xml
+++ b/HGV_meta_EpiDoc/HGV874/873590.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment einer Petition?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873590</idno>
+        <idno type="TM">873590</idno>
+        <idno type="ddb-filename">p.yale.4.150</idno>
+        <idno type="ddb-hybrid">p.yale;4;150</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4613</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolites</origPlace>
+              <origDate when="-0137-07">Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe (?)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">150</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 20</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767442"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873591.xml
+++ b/HGV_meta_EpiDoc/HGV874/873591.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment einer Eingabe</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873591</idno>
+        <idno type="TM">873591</idno>
+        <idno type="ddb-filename">p.yale.4.151</idno>
+        <idno type="ddb-hybrid">p.yale;4;151</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4599</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolites</origPlace>
+              <origDate when="-0137-07" cert="low">Juli 137 v.Chr. (?)</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">151</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 21-22</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767423"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873592.xml
+++ b/HGV_meta_EpiDoc/HGV874/873592.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment unbestimmten Inhalts</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873592</idno>
+        <idno type="TM">873592</idno>
+        <idno type="ddb-filename">p.yale.4.152</idno>
+        <idno type="ddb-hybrid">p.yale;4;152</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4598</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolites</origPlace>
+              <origDate when="-0137-07" cert="low">Juli 137 v.Chr. (?)</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Fragment</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">152</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 23</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767559"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873593.xml
+++ b/HGV_meta_EpiDoc/HGV874/873593.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition an den Epistrategen Boethos wegen der unrechtmäßigen Bebauung eines ψιλὸς τόπος</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873593</idno>
+        <idno type="TM">873593</idno>
+        <idno type="ddb-filename">p.yale.4.138</idno>
+        <idno type="ddb-hybrid">p.yale;4;138</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4604</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+                <origPlace>Neileus (Herakleopolites)</origPlace>
+                <origDate notBefore="-0137-07-03" notAfter="-0137-07-06">3. - 6. Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+                <p>
+                    <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/58563">Neileus</placeName>
+                    <placeName n="2"
+                                type="ancient"
+                                subtype="nome"
+                                ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+                </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">Herpechusios an Boethos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">138</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 1</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767825"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873594.xml
+++ b/HGV_meta_EpiDoc/HGV874/873594.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition an den Epistrategen Boethos wegen eines nicht zurückgezahlten Darlehens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873594</idno>
+        <idno type="TM">873594</idno>
+        <idno type="ddb-filename">p.yale.4.139</idno>
+        <idno type="ddb-hybrid">p.yale;4;139</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4603</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Kolasouchis und Tertonpetemun (Herakleopolites)</origPlace>
+              <origDate when="-0137-07-05">5. Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/3042">Kolasouchis und Tertonpetemun</placeName>
+                <placeName n="2"
+                                type="ancient"
+                                subtype="nome"
+                                ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">Emetonis an Boethos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">139</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 2-3</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767426"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873595.xml
+++ b/HGV_meta_EpiDoc/HGV874/873595.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition eines Soldaten an den Epistrategen Boethos wegen des Übergri s eines Vorgesetzten und des Diebstahls von Schafen</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873595</idno>
+        <idno type="TM">873595</idno>
+        <idno type="ddb-filename">p.yale.4.140</idno>
+        <idno type="ddb-hybrid">p.yale;4;140</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4605</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hiera Nesos (Herakleopolites)</origPlace>
+              <origDate notBefore="-0137-07-05" notAfter="-0137-07-06">5. - 6. Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/842">Hiera Nesos</placeName>
+                <placeName n="2"
+                                type="ancient"
+                                subtype="nome"
+                                ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">N.N. an Boethos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">140</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 4-5</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767428"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873596.xml
+++ b/HGV_meta_EpiDoc/HGV874/873596.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition an den Epistrategen Boethos wegen eines nicht zurückgezahlten Darlehens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873596</idno>
+        <idno type="TM">873596</idno>
+        <idno type="ddb-filename">p.yale.4.141</idno>
+        <idno type="ddb-hybrid">p.yale;4;141</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4500</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Phebichis (Herakleopolites)</origPlace>
+              <origDate when="-0137-07-06">6. Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1755 https://pleiades.stoa.org/places/737005">Phebichis</placeName>
+                <placeName n="2"
+                                type="ancient"
+                                subtype="nome"
+                                ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">Euthaios an Boethos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">141</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 6-7</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767335"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873597.xml
+++ b/HGV_meta_EpiDoc/HGV874/873597.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition an den Epistrategen Boethos wegen Verdrängung aus dem Erbteil durch den Neubau eines eingestürzten Hauses</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873597</idno>
+        <idno type="TM">873597</idno>
+        <idno type="ddb-filename">p.yale.4.142</idno>
+        <idno type="ddb-hybrid">p.yale;4;142</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4606</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Busiris (Herakleopolites)</origPlace>
+              <origDate when="-0137-07-06">6. Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/471 https://pleiades.stoa.org/places/736900">Busiris</placeName>
+                <placeName n="2"
+                                type="ancient"
+                                subtype="nome"
+                                ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">Hembetephnachtis an Boethos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">142</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 8-9</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767637"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873598.xml
+++ b/HGV_meta_EpiDoc/HGV874/873598.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition an den Epistrategen Boethos wegen des unrechtmäßigen Verkaufs von Grundstücken</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873598</idno>
+        <idno type="TM">873598</idno>
+        <idno type="ddb-filename">p.yale.4.143</idno>
+        <idno type="ddb-hybrid">p.yale;4;143</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4607</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Poimenon Kome (Herakleopolites)</origPlace>
+              <origDate when="-0137-07-06">6. Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1874">Poimenon Kome</placeName>
+                <placeName n="2"
+                                type="ancient"
+                                subtype="nome"
+                                ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">Hergeus an Boethos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">143</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 10</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767747"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV874/873599.xml
+++ b/HGV_meta_EpiDoc/HGV874/873599.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Petition an den Epistrategen Boethos wegen eines nicht zurückgezahlten Darlehens</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">873599</idno>
+        <idno type="TM">873599</idno>
+        <idno type="ddb-filename">p.yale.4.144</idno>
+        <idno type="ddb-hybrid">p.yale;4;144</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4608</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolis ? (Herakleopolites)</origPlace>
+              <origDate when="-0137-07-07">7. Juli 137 v.Chr.</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/801 https://pleiades.stoa.org/places/736920" cert="low">Herakleopolis</placeName>
+                <placeName n="2"
+                                type="ancient"
+                                subtype="nome"
+                                ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">144</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 11</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2767618"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974974.xml
+++ b/HGV_meta_EpiDoc/HGV975/974974.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Drafts of a Petition concerning the Reconstruction of a Propylon</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974974</idno>
+        <idno type="TM">974974</idno>
+        <idno type="ddb-filename">p.yale.4.156</idno>
+        <idno type="ddb-hybrid">p.yale;4;156</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 1562 B</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos (Oxyrhynchites)</origPlace>
+              <origDate notBefore="-0005">
+                        <offset n="1" type="after">nach</offset>
+                5 v.Chr.
+              </origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eingabe</term>
+          <term n="2">Entwurf</term>
+          <term n="3">Wiederaufbau</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">156</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 27</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2758771"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974975.xml
+++ b/HGV_meta_EpiDoc/HGV975/974975.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Affidavit</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974975</idno>
+        <idno type="TM">974975</idno>
+        <idno type="ddb-filename">p.yale.4.157</idno>
+        <idno type="ddb-hybrid">p.yale;4;157</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 722</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos (Oxyrhynchites)</origPlace>
+              <origDate notBefore="0055" notAfter="0068">55 - 68</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Erklärung</term>
+          <term n="2">Eid</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">157</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 28</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2757553"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974976.xml
+++ b/HGV_meta_EpiDoc/HGV975/974976.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Two Private Letters on One Sheet</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974976</idno>
+        <idno type="TM">974976</idno>
+        <idno type="ddb-filename">p.yale.4.158</idno>
+        <idno type="ddb-hybrid">p.yale;4;158</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 1254</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0076" notAfter="0200" precision="low">Ende I - II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (privat)</term>
+          <term n="2">Achilleus an Zoilos</term>
+          <term n="3">N.N. an Zoilos</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">158</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 29</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2758094"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974977.xml
+++ b/HGV_meta_EpiDoc/HGV975/974977.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a Private Letter regarding the Care of a Goose</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974977</idno>
+        <idno type="TM">974977</idno>
+        <idno type="ddb-filename">p.yale.4.159</idno>
+        <idno type="ddb-hybrid">p.yale;4;159</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 694</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0001" notAfter="0200" precision="low">I - II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (privat)</term>
+          <term n="2">Gans</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">159</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 30</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2757527"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974978.xml
+++ b/HGV_meta_EpiDoc/HGV975/974978.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Application to Iulius Aulus, basilikos grammateus, to Rent Land</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974978</idno>
+        <idno type="TM">974978</idno>
+        <idno type="ddb-filename">p.yale.4.160</idno>
+        <idno type="ddb-hybrid">p.yale;4;160</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 411</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Tebtynis (Arsinoites)</origPlace>
+              <origDate notBefore="0098" notAfter="0117">98 - 117</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">Tebtynis</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Miete</term>
+          <term n="2">Antrag</term>
+          <term n="3">königlicher Schreiber</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">160</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 31</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2775658"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974979.xml
+++ b/HGV_meta_EpiDoc/HGV975/974979.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Declaration (προσφώνησις) of an Official</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974979</idno>
+        <idno type="TM">974979</idno>
+        <idno type="ddb-filename">p.yale.4.161</idno>
+        <idno type="ddb-hybrid">p.yale;4;161</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 275</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0120" notAfter="0125">
+                ca. 120 - 125
+                <precision match="../@notBefore" degree="0.5"/>
+                     </origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Erklärung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">161</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 32</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2757028"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974981.xml
+++ b/HGV_meta_EpiDoc/HGV975/974981.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Dossier administratif</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974981</idno>
+        <idno type="TM">974981</idno>
+        <idno type="ddb-filename">p.yale.4.163</idno>
+        <idno type="ddb-hybrid">p.yale;4;163</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 901 recto</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoites</origPlace>
+                                   <origDate notBefore="0145">
+                        <offset n="1" type="after">nach</offset>
+                145
+              </origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Fall</term>
+          <term n="2">Brief (amtlich)</term>
+          <term n="3">Apolinarius an Sarapion</term>
+          <term n="4">Verordnungen</term>
+          <term n="5">Präfekt</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">163</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 34</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2757675"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974982.xml
+++ b/HGV_meta_EpiDoc/HGV975/974982.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Liste nominative d’arriérés en numéraire</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974982</idno>
+        <idno type="TM">974982</idno>
+        <idno type="ddb-filename">p.yale.4.164</idno>
+        <idno type="ddb-hybrid">p.yale;4;164</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 901 verso</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoites</origPlace>
+              <origDate notBefore="0151" notAfter="0200" precision="low">2. Hälfte II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+          <term n="2">Rückstände</term>
+          <term n="3">Zahlung</term>
+          <term n="4">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">164</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 35</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2757720"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974983.xml
+++ b/HGV_meta_EpiDoc/HGV975/974983.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Three Lists of Names and an Account</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974983</idno>
+        <idno type="TM">974983</idno>
+        <idno type="ddb-filename">p.yale.4.165</idno>
+        <idno type="ddb-hybrid">p.yale;4;165</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 456</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoites</origPlace>
+              <origDate when="0156" precision="medium">ca. 156</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+          <term n="2">Namen</term>
+          <term n="3">Rechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">165</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 36-37</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure n="1">
+            <graphic url="https://hdl.handle.net/10079/digcoll/2775715"/>
+          </figure>
+          <figure n="2">
+            <graphic url="https://hdl.handle.net/10079/digcoll/2775704"/>
+          </figure>
+          <figure n="3">
+            <graphic url="https://hdl.handle.net/10079/digcoll/2775691"/>
+          </figure>
+          <figure n="4">
+            <graphic url="https://hdl.handle.net/10079/digcoll/2775686"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974984.xml
+++ b/HGV_meta_EpiDoc/HGV975/974984.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for φόρετρον Tax</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974984</idno>
+        <idno type="TM">974984</idno>
+        <idno type="ddb-filename">p.yale.4.167</idno>
+        <idno type="ddb-hybrid">p.yale;4;167</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 330</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoites</origPlace>
+              <origDate when="0162-05-09">9. Mai 162</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Transport</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">167</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 39</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2757111"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974985.xml
+++ b/HGV_meta_EpiDoc/HGV975/974985.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Tax Receipt for πρόσοδοι ἱερατικῶν τάξεων</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974985</idno>
+        <idno type="TM">974985</idno>
+        <idno type="ddb-filename">p.yale.4.168</idno>
+        <idno type="ddb-hybrid">p.yale;4;168</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 305 A</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Tebtynis (Arsinoites)</origPlace>
+              <origDate notBefore="0176-03" notAfter="0176-04">März - Apr. 176</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">Tebtynis</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Steuer</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">168</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 39 [sic]</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2757135"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974986.xml
+++ b/HGV_meta_EpiDoc/HGV975/974986.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for Camel σύμβολον</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974986</idno>
+        <idno type="TM">974986</idno>
+        <idno type="ddb-filename">p.yale.4.169</idno>
+        <idno type="ddb-hybrid">p.yale;4;169</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 1646</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theresis (Prosopites)</origPlace>
+              <origDate when="0183-08-08">8. Aug. 183</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/3083">Theresis</placeName>
+                <placeName n="2" type="ancient" ref="https://www.trismegistos.org/place/3081 https://pleiades.stoa.org/places/727206">Prosopites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Steuer</term>
+          <term n="3">Kamel</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">169</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 40</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2758991"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974987.xml
+++ b/HGV_meta_EpiDoc/HGV975/974987.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Προσφώνησις through the archidikastes of the ἐκμαρτύρησις of a Chirographic Cession</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974987</idno>
+        <idno type="TM">974987</idno>
+        <idno type="ddb-filename">p.yale.4.170</idno>
+        <idno type="ddb-hybrid">p.yale;4;170</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 231</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites</origPlace>
+              <origDate when="0195">195</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag</term>
+          <term n="2">Kauf</term>
+          <term n="3">Land</term>
+          <term n="4">Parachoresis</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">170</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 41</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2756996"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974988.xml
+++ b/HGV_meta_EpiDoc/HGV975/974988.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Preliminary Receipt for τιμὴ πυροῦ</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974988</idno>
+        <idno type="TM">974988</idno>
+        <idno type="ddb-filename">p.yale.4.171</idno>
+        <idno type="ddb-hybrid">p.yale;4;171</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 909</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Bacchias ? (Arsinoites)</origPlace>
+              <origDate notBefore="0200-09-28" notAfter="0200-10-27">28. Sept. - 27. Okt. 200</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/392 https://pleiades.stoa.org/places/736896">Bacchias</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Steuer</term>
+          <term n="3">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">171</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 42</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2757640"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974989.xml
+++ b/HGV_meta_EpiDoc/HGV975/974989.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Contract of Sale for a Slave in the Form of a synchoresis</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974989</idno>
+        <idno type="TM">974989</idno>
+        <idno type="ddb-filename">p.yale.4.172</idno>
+        <idno type="ddb-hybrid">p.yale;4;172</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 573</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Alexandria</origPlace>
+              <origDate notBefore="0215" notAfter="0217">215 - 217</origDate>
+            </origin>
+            <provenance type="written">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/100 https://pleiades.stoa.org/places/727070">Alexandria</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag</term>
+          <term n="2">Kauf</term>
+          <term n="3">Sklavin</term>
+          <term n="4">Synchoresis</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">172</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 43-44</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2792434"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974990.xml
+++ b/HGV_meta_EpiDoc/HGV975/974990.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Delivery Slip for Wine</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974990</idno>
+        <idno type="TM">974990</idno>
+        <idno type="ddb-filename">p.yale.4.173</idno>
+        <idno type="ddb-hybrid">p.yale;4;173</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 1425</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites ?</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" subtype="nome" type="ancient" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982" cert="low">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+          <term n="2">Lieferung</term>
+          <term n="3">Wein</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">173</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 45</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2758275"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974991.xml
+++ b/HGV_meta_EpiDoc/HGV975/974991.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Two Private Letters on One Sheet</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974991</idno>
+        <idno type="TM">974991</idno>
+        <idno type="ddb-filename">p.yale.4.174</idno>
+        <idno type="ddb-hybrid">p.yale;4;174</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 1252</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (privat)</term>
+          <term n="2">Helios an Koptites</term>
+          <term n="3">Helios an Serenus</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">174</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 46</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2758405"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974992.xml
+++ b/HGV_meta_EpiDoc/HGV975/974992.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Private Letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974992</idno>
+        <idno type="TM">974992</idno>
+        <idno type="ddb-filename">p.yale.4.175</idno>
+        <idno type="ddb-hybrid">p.yale;4;175</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 1123</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Tebtynis ? (Arsinoites)</origPlace>
+              <origDate notBefore="0276" notAfter="0300" precision="low">Ende III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072" cert="low">Tebtynis</placeName>
+                <placeName n="2"
+                                   type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (privat)</term>
+          <term n="2">N.N. an Kronion</term>
+          <term n="3">Preis</term>
+          <term n="4">Kleidung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">175</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 47</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2757942"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974993.xml
+++ b/HGV_meta_EpiDoc/HGV975/974993.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Private Letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974993</idno>
+        <idno type="TM">974993</idno>
+        <idno type="ddb-filename">p.yale.4.176v</idno>
+        <idno type="ddb-hybrid">p.yale;4;176v</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 1437</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Apotheke ? (Apollonopolites)</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/3346 https://pleiades.stoa.org/places/756536" cert="low">Apotheke</placeName>
+                <placeName n="2" type="ancient" ref="https://www.trismegistos.org/place/2717">Apollonopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (privat)</term>
+          <term n="2">Bettzeug</term>
+          <term n="3">Geld</term>
+          <term n="4">Kleidung</term>
+          <term n="5">Schuld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">176</biblScope>
+            <biblScope n="3" type="side">V</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 48</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2758552"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Rückseite P.Yale IV 176 recto</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974994.xml
+++ b/HGV_meta_EpiDoc/HGV975/974994.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Business Letter Belonging to the Archive of Papnouthis and Dorotheos</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974994</idno>
+        <idno type="TM">974994</idno>
+        <idno type="ddb-filename">p.yale.4.177</idno>
+        <idno type="ddb-hybrid">p.yale;4;177</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 1563</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos (Oxyrhynchites)</origPlace>
+              <origDate when="0360" precision="medium">ca. 360</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (geschäftlich)</term>
+          <term n="2">Dorotheos an Antiochos</term>
+          <term n="3">Steuer</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">177</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 49</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2758769"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974995.xml
+++ b/HGV_meta_EpiDoc/HGV975/974995.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Document concerning the ἐμβολή</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974995</idno>
+        <idno type="TM">974995</idno>
+        <idno type="ddb-filename">p.yale.4.178</idno>
+        <idno type="ddb-hybrid">p.yale;4;178</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 508</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolites</origPlace>
+              <origDate notBefore="0326" notAfter="0375" precision="low">Mitte IV</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Getriede</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">178</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 50-51</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2792237"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974996.xml
+++ b/HGV_meta_EpiDoc/HGV975/974996.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Private Letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974996</idno>
+        <idno type="TM">974996</idno>
+        <idno type="ddb-filename">p.yale.4.179</idno>
+        <idno type="ddb-hybrid">p.yale;4;179</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 1244</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0301" notAfter="0400" precision="low">IV</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (privat)</term>
+          <term n="2">Eirene an Ammonios</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">179</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 52</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2758399"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/974997.xml
+++ b/HGV_meta_EpiDoc/HGV975/974997.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Two Recipes for Medicinal Wines</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">974997</idno>
+        <idno type="TM">974997</idno>
+        <idno type="ddb-filename">p.yale.4.180</idno>
+        <idno type="ddb-hybrid">p.yale;4;180</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 203</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoites ?</origPlace>
+              <origDate notBefore="0401" notAfter="0500" cert="low" precision="low">V (?)</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888" cert="low">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Wein</term>
+          <term n="2">Medizin</term>
+          <term n="3">Rezept</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">180</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 53</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2757019"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV975/975000.xml
+++ b/HGV_meta_EpiDoc/HGV975/975000.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Mummy Label for a Sixteen-Year-Old Girl</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">975000</idno>
+        <idno type="TM">975000</idno>
+        <idno type="ddb-filename">p.yale.4.183</idno>
+        <idno type="ddb-hybrid">p.yale;4;183</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 4971</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Holz</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Thebes ?</origPlace>
+              <origDate notBefore="0301" notAfter="0400" precision="low">IV</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017" cert="low">Thebes</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Mumienetickett</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">183</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 56</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2768250"/>
+          </figure>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV976/975001.xml
+++ b/HGV_meta_EpiDoc/HGV976/975001.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Quittung für annona civica (ἐμβολή)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">975001</idno>
+        <idno type="TM">975001</idno>
+        <idno type="ddb-filename">p.yale.4.184</idno>
+        <idno type="ddb-hybrid">p.yale;4;184</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 3676 A</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Holz</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Palosis (Oxyrhynchites)</origPlace>
+              <origDate notBefore="0602-07-25" notAfter="0602-08-23">25. Juli - 23. Aug. 602</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref=" https://pleiades.stoa.org/places/736988">Palosis</placeName>
+                <placeName n="2" subtype="nome" type="ancient" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+          <term n="2">Steuer</term>
+          <term n="3">Getriede</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">184</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 57</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2764659"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Rückseite P.Yale IV 185</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV976/975003.xml
+++ b/HGV_meta_EpiDoc/HGV976/975003.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Lieferungskauf von Schwingflachs (στίππιον κογχισθέν)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">975003</idno>
+        <idno type="TM">975003</idno>
+        <idno type="ddb-filename">p.yale.4.186</idno>
+        <idno type="ddb-hybrid">p.yale;4;186</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 3675 A</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+                         <history>
+                  <origin>
+                     <origPlace>Oxyrhynchites oder Hipponon (Herakleopolites)</origPlace>
+                     <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p n="1" xml:id="geoBHDA1E" exclude="#geoC2IH87">
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+                     </p>
+                     <p n="2" xml:id="geoC2IH87" exclude="#geoBHDA1E">
+                        <placeName n="1"
+                                   type="ancient"
+                                   ref="https://www.trismegistos.org/place/2634 https://pleiades.stoa.org/places/736924">Hipponon</placeName>
+                        <placeName n="2"
+                                   type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+                     </p>
+                  </provenance>
+               </history>
+
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Kauf</term>
+          <term n="2">Lieferungskauf</term>
+          <term n="3">Schwingflachs</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">186</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 59</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2764849"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Rückseite P.Yale IV 187</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV976/975005.xml
+++ b/HGV_meta_EpiDoc/HGV976/975005.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Lieferungskauf</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">975005</idno>
+        <idno type="TM">975005</idno>
+        <idno type="ddb-filename">p.yale.4.188</idno>
+        <idno type="ddb-hybrid">p.yale;4;188</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 3680 B</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Holz</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Palosis (Oxyrhynchites)</origPlace>
+              <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref=" https://pleiades.stoa.org/places/736988">Palosis</placeName>
+                <placeName n="2" type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Kauf</term>
+          <term n="2">Lieferungskauf</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-31" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">188</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 61</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2764837"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Rückseite P.Yale IV 189</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV976/975006.xml
+++ b/HGV_meta_EpiDoc/HGV976/975006.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Writing Exercises of Coptic Epistolary Formulas</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">975006</idno>
+        <idno type="TM">975006</idno>
+        <idno type="ddb-filename">p.yale.4.189</idno>
+        <idno type="ddb-hybrid">p.yale;4;189</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+<collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 3680 A</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Holz</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites</origPlace>
+              <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1"></term>
+          <term n="2">Schreibübungen</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-31" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">189</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 62</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2765050"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Rückseite P.Yale IV 188</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV976/975007.xml
+++ b/HGV_meta_EpiDoc/HGV976/975007.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Schreibübungen zu griechischem Vertragsformular</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">975007</idno>
+        <idno type="TM">975007</idno>
+        <idno type="ddb-filename">p.yale.4.190</idno>
+        <idno type="ddb-hybrid">p.yale;4;190</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 3674 A</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Holz</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites ?</origPlace>
+              <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982" 
+                                   cert="low">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1"></term>
+          <term n="2">Schreibübungen</term>
+          <term n="3">Vertrag</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-31" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">190</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 63</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2764943"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Rückseite P.Yale IV 191</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV976/975008.xml
+++ b/HGV_meta_EpiDoc/HGV976/975008.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Schreibübungen zu griechischem Vertragsformular</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">975008</idno>
+        <idno type="TM">975008</idno>
+        <idno type="ddb-filename">p.yale.4.191</idno>
+        <idno type="ddb-hybrid">p.yale;4;191</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 3674 B</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Holz</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites ?</origPlace>
+              <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982" 
+                                   cert="low">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1"></term>
+          <term n="2">Schreibübungen</term>
+          <term n="3">Vertrag</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-31" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">191</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 64</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2764943"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Rückseite P.Yale IV 190</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV977/976541.xml
+++ b/HGV_meta_EpiDoc/HGV977/976541.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of Money</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">976541</idno>
+        <idno type="TM">976541</idno>
+        <idno type="ddb-filename">p.yale.4.154v</idno>
+        <idno type="ddb-hybrid">p.yale;4;154v</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 418</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites</origPlace>
+              <origDate notBefore="-0100" notAfter="-0001" precision="low">I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Rechnung</term>
+          <term n="2">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-29" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">154</biblScope>
+            <biblScope n="3" type="side">V</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">Pl. 25</bibl>
+        </p>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2775694"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Rückseite P.Yale IV 154 recto</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV977/976543.xml
+++ b/HGV_meta_EpiDoc/HGV977/976543.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Contract or Declaration?</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">976543</idno>
+        <idno type="TM">976543</idno>
+        <idno type="ddb-filename">p.yale.4.168r</idno>
+        <idno type="ddb-hybrid">p.yale;4;168r</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 305 A</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+                  <origin>
+                     <origPlace>Tebtynis ? (Arsinoites)</origPlace>
+                     <origDate notAfter="0176">
+                        <offset n="1" type="before">vor</offset>
+                176
+                     </origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName n="1"
+                                   type="ancient"
+                                   cert="low"
+                                   ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">Tebtynis</placeName>
+                        <placeName n="2"
+                                   type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                     </p>
+                  </provenance>
+               </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag?</term>
+          <term n="2">Erklärung?</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">168</biblScope>
+            <biblScope n="3" type="side">R</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <figure>
+            <graphic url="http://hdl.handle.net/10079/digcoll/2757132"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Descr. Rückseite P.Yale IV 168</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV977/976547.xml
+++ b/HGV_meta_EpiDoc/HGV977/976547.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">976547</idno>
+        <idno type="TM">976547</idno>
+        <idno type="ddb-filename">p.yale.4.176r</idno>
+        <idno type="ddb-hybrid">p.yale;4;176r</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>New Haven</settlement>
+            </placeName>
+            <collection>Yale University, Beinecke Library</collection>
+            <idno type="invNo">P.CtYBR 1437</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Apotheke ? (Apollonopolites)</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/3346 https://pleiades.stoa.org/places/756536" cert="low">Apotheke</placeName>
+                <placeName n="2" type="ancient" ref="https://www.trismegistos.org/place/2717">Apollonopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Rechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-05-30" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Yale</title>
+            <biblScope n="1" type="volume">4</biblScope>
+            <biblScope n="2" type="numbers">176</biblScope>
+            <biblScope n="3" type="side">R</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="figure">
+        <p>
+          <figure>
+            <graphic url="https://hdl.handle.net/10079/digcoll/2758318"/>
+          </figure>
+        </p>
+      </div>
+      <div type="commentary" subtype ="general">
+        <p>Descr. Rückseite P.Yale IV 176 verso</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV982/981677.xml
+++ b/HGV_meta_EpiDoc/HGV982/981677.xml
@@ -18,7 +18,7 @@
             <placeName>
               <settlement>New Haven</settlement>
             </placeName>
-            <collection>Beinecke Library</collection>
+            <collection>Yale University, Beinecke Library</collection>
             <idno type="invNo">P.CtYBR 339</idno>
           </msIdentifier>
           <physDesc>

--- a/HGV_meta_EpiDoc/HGV982/981678.xml
+++ b/HGV_meta_EpiDoc/HGV982/981678.xml
@@ -18,7 +18,7 @@
             <placeName>
               <settlement>New Haven</settlement>
             </placeName>
-            <collection>Beinecke Library</collection>
+            <collection>Yale University, Beinecke Library</collection>
             <idno type="invNo">P.CtYBR 339</idno>
           </msIdentifier>
           <physDesc>

--- a/HGV_meta_EpiDoc/HGV982/981679.xml
+++ b/HGV_meta_EpiDoc/HGV982/981679.xml
@@ -18,7 +18,7 @@
             <placeName>
               <settlement>New Haven</settlement>
             </placeName>
-            <collection>Beinecke Library</collection>
+            <collection>Yale University, Beinecke Library</collection>
             <idno type="invNo">P.CtYBR 572</idno>
           </msIdentifier>
           <physDesc>

--- a/HGV_meta_EpiDoc/HGV982/981680.xml
+++ b/HGV_meta_EpiDoc/HGV982/981680.xml
@@ -18,7 +18,7 @@
             <placeName>
               <settlement>New Haven</settlement>
             </placeName>
-            <collection>Beinecke Library</collection>
+            <collection>Yale University, Beinecke Library</collection>
             <idno type="invNo">P.CtYBR 1411</idno>
           </msIdentifier>
           <physDesc>


### PR DESCRIPTION
These commits xWalk new metadata for P.Yale IV to HGV, and update the appropriate APIS files with idnos for aggregation. Items submitted via SoSOL have not been reduplicated; 145 and 162 have HGV records already; 166 has been fully updated already; and 185 and 187 are destined for DCLP. 