### PR TITLE
XWalk P.Lugd. Bat. 40 for HGV

### DIFF
--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.100.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.100.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.100</idno>
+            <idno type="filename">p.leid.inst.1.100</idno>
             <idno type="ddb-perseus-style">0149;;100</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;100</idno>
             <idno type="HGV">18489</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.101.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.101.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.101</idno>
+            <idno type="filename">p.leid.inst.1.101</idno>
             <idno type="ddb-perseus-style">0149;;101</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;101</idno>
             <idno type="HGV">33047</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.102.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.102.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.102</idno>
+            <idno type="filename">p.leid.inst.1.102</idno>
             <idno type="ddb-perseus-style">0149;;102</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;102</idno>
             <idno type="HGV">33048</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.103.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.103.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.103</idno>
+            <idno type="filename">p.leid.inst.1.103</idno>
             <idno type="ddb-perseus-style">0149;;103</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;103</idno>
             <idno type="HGV">33049</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.104.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.104.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.104</idno>
+            <idno type="filename">p.leid.inst.1.104</idno>
             <idno type="ddb-perseus-style">0149;;104</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;104</idno>
             <idno type="HGV">33050</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.105.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.105.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.105</idno>
+            <idno type="filename">p.leid.inst.1.105</idno>
             <idno type="ddb-perseus-style">0149;;105</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;105</idno>
             <idno type="HGV">36574</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.106.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.106.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.106</idno>
+            <idno type="filename">p.leid.inst.1.106</idno>
             <idno type="ddb-perseus-style">0149;;106</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;106</idno>
             <idno type="HGV">36575</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.107.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.107.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.107</idno>
+            <idno type="filename">p.leid.inst.1.107</idno>
             <idno type="ddb-perseus-style">0149;;107</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;107</idno>
             <idno type="HGV">33051</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.13.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.13.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.13</idno>
+            <idno type="filename">p.leid.inst.1.13</idno>
             <idno type="ddb-perseus-style">0149;;13</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;13</idno>
             <idno type="TM">65419</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.17.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.17.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.17</idno>
+            <idno type="filename">p.leid.inst.1.17</idno>
             <idno type="ddb-perseus-style">0149;;17</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;17</idno>
             <idno type="HGV">64449</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.19.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.19.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.19</idno>
+            <idno type="filename">p.leid.inst.1.19</idno>
             <idno type="ddb-perseus-style">0149;;19</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;19</idno>
             <idno type="HGV">78485</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.20.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.20.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.20</idno>
+            <idno type="filename">p.leid.inst.1.20</idno>
             <idno type="ddb-perseus-style">0149;;20</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;20</idno>
             <idno type="HGV">2853</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.21.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.21.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.21</idno>
+            <idno type="filename">p.leid.inst.1.21</idno>
             <idno type="ddb-perseus-style">0149;;21</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;21</idno>
             <idno type="HGV">5235</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.22.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.22.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.22</idno>
+            <idno type="filename">p.leid.inst.1.22</idno>
             <idno type="ddb-perseus-style">0149;;22</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;22</idno>
             <idno type="HGV">18463</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.23.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.23.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.23</idno>
+            <idno type="filename">p.leid.inst.1.23</idno>
             <idno type="ddb-perseus-style">0149;;23</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;23</idno>
             <idno type="HGV">18464</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.24.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.24.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.24</idno>
+            <idno type="filename">p.leid.inst.1.24</idno>
             <idno type="ddb-perseus-style">0149;;24</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;24</idno>
             <idno type="HGV">18465</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.25.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.25.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.25</idno>
+            <idno type="filename">p.leid.inst.1.25</idno>
             <idno type="ddb-perseus-style">0149;;25</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;25</idno>
             <idno type="HGV">11872</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.26.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.26.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.26</idno>
+            <idno type="filename">p.leid.inst.1.26</idno>
             <idno type="ddb-perseus-style">0149;;26</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;26</idno>
             <idno type="HGV">25423</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.28.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.28.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.28</idno>
+            <idno type="filename">p.leid.inst.1.28</idno>
             <idno type="ddb-perseus-style">0149;;28</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;28</idno>
             <idno type="HGV">25426</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.30.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.30.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.30</idno>
+            <idno type="filename">p.leid.inst.1.30</idno>
             <idno type="ddb-perseus-style">0149;;30</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;30</idno>
             <idno type="HGV">25427</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.31.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.31.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.31</idno>
+            <idno type="filename">p.leid.inst.1.31</idno>
             <idno type="ddb-perseus-style">0149;;31</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;31</idno>
             <idno type="HGV">44616</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.32.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.32.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.32</idno>
+            <idno type="filename">p.leid.inst.1.32</idno>
             <idno type="ddb-perseus-style">0149;;32</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;32</idno>
             <idno type="HGV">11873</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.33.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.33.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.33</idno>
+            <idno type="filename">p.leid.inst.1.33</idno>
             <idno type="ddb-perseus-style">0149;;33</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;33</idno>
             <idno type="HGV">43133a 43133b 43133c</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.34.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.34.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.34</idno>
+            <idno type="filename">p.leid.inst.1.34</idno>
             <idno type="ddb-perseus-style">0149;;34</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;34</idno>
             <idno type="HGV">18470</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.35.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.35.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.35</idno>
+            <idno type="filename">p.leid.inst.1.35</idno>
             <idno type="ddb-perseus-style">0149;;35</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;35</idno>
             <idno type="HGV">27727</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.36.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.36.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.36</idno>
+            <idno type="filename">p.leid.inst.1.36</idno>
             <idno type="ddb-perseus-style">0149;;36</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;36</idno>
             <idno type="HGV">11877</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.37.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.37.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.37</idno>
+            <idno type="filename">p.leid.inst.1.37</idno>
             <idno type="ddb-perseus-style">0149;;37</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;37</idno>
             <idno type="HGV">18471</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.38.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.38.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.38</idno>
+            <idno type="filename">p.leid.inst.1.38</idno>
             <idno type="ddb-perseus-style">0149;;38</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;38</idno>
             <idno type="HGV">18472</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.39.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.39.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.39</idno>
+            <idno type="filename">p.leid.inst.1.39</idno>
             <idno type="ddb-perseus-style">0149;;39</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;39</idno>
             <idno type="HGV">18473</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.40.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.40.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.40</idno>
+            <idno type="filename">p.leid.inst.1.40</idno>
             <idno type="ddb-perseus-style">0149;;40</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;40</idno>
             <idno type="HGV">18474</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.41.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.41.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.41</idno>
+            <idno type="filename">p.leid.inst.1.41</idno>
             <idno type="ddb-perseus-style">0149;;41</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;41</idno>
             <idno type="HGV">27728</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.42.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.42.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.42</idno>
+            <idno type="filename">p.leid.inst.1.42</idno>
             <idno type="ddb-perseus-style">0149;;42</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;42</idno>
             <idno type="HGV">27729 43134</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.43.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.43.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.43</idno>
+            <idno type="filename">p.leid.inst.1.43</idno>
             <idno type="ddb-perseus-style">0149;;43</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;43</idno>
             <idno type="HGV">27731</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.44.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.44.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.44</idno>
+            <idno type="filename">p.leid.inst.1.44</idno>
             <idno type="ddb-perseus-style">0149;;44</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;44</idno>
             <idno type="HGV">27732</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.46.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.46.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.46</idno>
+            <idno type="filename">p.leid.inst.1.46</idno>
             <idno type="ddb-perseus-style">0149;;46</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;46</idno>
             <idno type="HGV">27735</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.47.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.47.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.47</idno>
+            <idno type="filename">p.leid.inst.1.47</idno>
             <idno type="ddb-perseus-style">0149;;47</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;47</idno>
             <idno type="HGV">27736</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.48.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.48.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.48</idno>
+            <idno type="filename">p.leid.inst.1.48</idno>
             <idno type="ddb-perseus-style">0149;;48</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;48</idno>
             <idno type="HGV">27737</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.50.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.50.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.50</idno>
+            <idno type="filename">p.leid.inst.1.50</idno>
             <idno type="ddb-perseus-style">0149;;50</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;50</idno>
             <idno type="HGV">18475</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.51.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.51.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.51</idno>
+            <idno type="filename">p.leid.inst.1.51</idno>
             <idno type="ddb-perseus-style">0149;;51</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;51</idno>
             <idno type="HGV">18476</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.52.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.52.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.52</idno>
+            <idno type="filename">p.leid.inst.1.52</idno>
             <idno type="ddb-perseus-style">0149;;52</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;52</idno>
             <idno type="HGV">18478</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.53.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.53.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.53</idno>
+            <idno type="filename">p.leid.inst.1.53</idno>
             <idno type="ddb-perseus-style">0149;;53</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;53</idno>
             <idno type="HGV">30999</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.54.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.54.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.54</idno>
+            <idno type="filename">p.leid.inst.1.54</idno>
             <idno type="ddb-perseus-style">0149;;54</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;54</idno>
             <idno type="HGV">18479</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.55.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.55.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.55</idno>
+            <idno type="filename">p.leid.inst.1.55</idno>
             <idno type="ddb-perseus-style">0149;;55</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;55</idno>
             <idno type="HGV">31000</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.56.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.56.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.56</idno>
+            <idno type="filename">p.leid.inst.1.56</idno>
             <idno type="ddb-perseus-style">0149;;56</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;56</idno>
             <idno type="HGV">31001</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.57.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.57.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.57</idno>
+            <idno type="filename">p.leid.inst.1.57</idno>
             <idno type="ddb-perseus-style">0149;;57</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;57</idno>
             <idno type="HGV">31002</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.58.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.58.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.58</idno>
+            <idno type="filename">p.leid.inst.1.58</idno>
             <idno type="ddb-perseus-style">0149;;58</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;58</idno>
             <idno type="HGV">31003</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.59.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.59.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.59</idno>
+            <idno type="filename">p.leid.inst.1.59</idno>
             <idno type="ddb-perseus-style">0149;;59</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;59</idno>
             <idno type="HGV">18480</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.60.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.60.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.60</idno>
+            <idno type="filename">p.leid.inst.1.60</idno>
             <idno type="ddb-perseus-style">0149;;60</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;60</idno>
             <idno type="HGV">18481</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.61.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.61.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.61</idno>
+            <idno type="filename">p.leid.inst.1.61</idno>
             <idno type="ddb-perseus-style">0149;;61</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;61</idno>
             <idno type="HGV">18482</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.62.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.62.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.62</idno>
+            <idno type="filename">p.leid.inst.1.62</idno>
             <idno type="ddb-perseus-style">0149;;62</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;62</idno>
             <idno type="HGV">18485</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.63.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.63.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.63</idno>
+            <idno type="filename">p.leid.inst.1.63</idno>
             <idno type="ddb-perseus-style">0149;;63</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;63</idno>
             <idno type="HGV">33044</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.64.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.64.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.64</idno>
+            <idno type="filename">p.leid.inst.1.64</idno>
             <idno type="ddb-perseus-style">0149;;64</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;64</idno>
             <idno type="HGV">33045</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.65.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.65.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.65</idno>
+            <idno type="filename">p.leid.inst.1.65</idno>
             <idno type="ddb-perseus-style">0149;;65</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;65</idno>
             <idno type="HGV">33046</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.66.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.66.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.66</idno>
+            <idno type="filename">p.leid.inst.1.66</idno>
             <idno type="ddb-perseus-style">0149;;66</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;66</idno>
             <idno type="HGV">18486</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.67.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.67.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.67</idno>
+            <idno type="filename">p.leid.inst.1.67</idno>
             <idno type="ddb-perseus-style">0149;;67</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;67</idno>
             <idno type="HGV">35178</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.68.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.68.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.68</idno>
+            <idno type="filename">p.leid.inst.1.68</idno>
             <idno type="ddb-perseus-style">0149;;68</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;68</idno>
             <idno type="HGV">35179</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.69.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.69.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.69</idno>
+            <idno type="filename">p.leid.inst.1.69</idno>
             <idno type="ddb-perseus-style">0149;;69</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;69</idno>
             <idno type="HGV">35180</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.71.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.71.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.71</idno>
+            <idno type="filename">p.leid.inst.1.71</idno>
             <idno type="ddb-perseus-style">0149;;71</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;71</idno>
             <idno type="HGV">36569</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.72.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.72.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.72</idno>
+            <idno type="filename">p.leid.inst.1.72</idno>
             <idno type="ddb-perseus-style">0149;;72</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;72</idno>
             <idno type="HGV">36570</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.73.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.73.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.73</idno>
+            <idno type="filename">p.leid.inst.1.73</idno>
             <idno type="ddb-perseus-style">0149;;73</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;73</idno>
             <idno type="HGV">36571</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.74.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.74.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.74</idno>
+            <idno type="filename">p.leid.inst.1.74</idno>
             <idno type="ddb-perseus-style">0149;;74</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;74</idno>
             <idno type="HGV">36572</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.75.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.75.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.75</idno>
+            <idno type="filename">p.leid.inst.1.75</idno>
             <idno type="ddb-perseus-style">0149;;75</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;75</idno>
             <idno type="HGV">36573</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.76.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.76.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.76</idno>
+            <idno type="filename">p.leid.inst.1.76</idno>
             <idno type="ddb-perseus-style">0149;;76</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;76</idno>
             <idno type="HGV">38781</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.77.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.77.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.77</idno>
+            <idno type="filename">p.leid.inst.1.77</idno>
             <idno type="ddb-perseus-style">0149;;77</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;77</idno>
             <idno type="HGV">38782</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.78.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.78.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.78</idno>
+            <idno type="filename">p.leid.inst.1.78</idno>
             <idno type="ddb-perseus-style">0149;;78</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;78</idno>
             <idno type="HGV">38783</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.79.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.79.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.79</idno>
+            <idno type="filename">p.leid.inst.1.79</idno>
             <idno type="ddb-perseus-style">0149;;79</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;79</idno>
             <idno type="HGV">38784</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.80.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.80.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.80</idno>
+            <idno type="filename">p.leid.inst.1.80</idno>
             <idno type="ddb-perseus-style">0149;;80</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;80</idno>
             <idno type="HGV">38785</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.81.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.81.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.81</idno>
+            <idno type="filename">p.leid.inst.1.81</idno>
             <idno type="ddb-perseus-style">0149;;81</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;81</idno>
             <idno type="HGV">78486</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.82.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.82.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.82</idno>
+            <idno type="filename">p.leid.inst.1.82</idno>
             <idno type="ddb-perseus-style">0149;;82</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;82</idno>
             <idno type="HGV">78487</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.83.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.83.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.83</idno>
+            <idno type="filename">p.leid.inst.1.83</idno>
             <idno type="ddb-perseus-style">0149;;83</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;83</idno>
             <idno type="HGV">78488</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.84.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.84.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.84</idno>
+            <idno type="filename">p.leid.inst.1.84</idno>
             <idno type="ddb-perseus-style">0149;;84</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;84</idno>
             <idno type="HGV">78489</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.85.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.85.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.85</idno>
+            <idno type="filename">p.leid.inst.1.85</idno>
             <idno type="ddb-perseus-style">0149;;85</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;85</idno>
             <idno type="HGV">78490</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.86.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.86.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.86</idno>
+            <idno type="filename">p.leid.inst.1.86</idno>
             <idno type="ddb-perseus-style">0149;;86</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;86</idno>
             <idno type="HGV">25429</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.87.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.87.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.87</idno>
+            <idno type="filename">p.leid.inst.1.87</idno>
             <idno type="ddb-perseus-style">0149;;87</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;87</idno>
             <idno type="HGV">25430</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.88.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.88.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.88</idno>
+            <idno type="filename">p.leid.inst.1.88</idno>
             <idno type="ddb-perseus-style">0149;;88</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;88</idno>
             <idno type="HGV">25431</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.89.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.89.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.89</idno>
+            <idno type="filename">p.leid.inst.1.89</idno>
             <idno type="ddb-perseus-style">0149;;89</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;89</idno>
             <idno type="HGV">25432</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.90.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.90.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.90</idno>
+            <idno type="filename">p.leid.inst.1.90</idno>
             <idno type="ddb-perseus-style">0149;;90</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;90</idno>
             <idno type="HGV">27740</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.91.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.91.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.91</idno>
+            <idno type="filename">p.leid.inst.1.91</idno>
             <idno type="ddb-perseus-style">0149;;91</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;91</idno>
             <idno type="HGV">27741</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.92.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.92.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.92</idno>
+            <idno type="filename">p.leid.inst.1.92</idno>
             <idno type="ddb-perseus-style">0149;;92</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;92</idno>
             <idno type="HGV">27742</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.93.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.93.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.93</idno>
+            <idno type="filename">p.leid.inst.1.93</idno>
             <idno type="ddb-perseus-style">0149;;93</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;93</idno>
             <idno type="HGV">27743</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.94.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.94.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.94</idno>
+            <idno type="filename">p.leid.inst.1.94</idno>
             <idno type="ddb-perseus-style">0149;;94</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;94</idno>
             <idno type="HGV">31004</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.95.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.95.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.95</idno>
+            <idno type="filename">p.leid.inst.1.95</idno>
             <idno type="ddb-perseus-style">0149;;95</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;95</idno>
             <idno type="HGV">31005</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.96.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.96.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.96</idno>
+            <idno type="filename">p.leid.inst.1.96</idno>
             <idno type="ddb-perseus-style">0149;;96</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;96</idno>
             <idno type="HGV">31006</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.97.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.97.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.97</idno>
+            <idno type="filename">p.leid.inst.1.97</idno>
             <idno type="ddb-perseus-style">0149;;97</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;97</idno>
             <idno type="HGV">31007</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.98.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.98.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.98</idno>
+            <idno type="filename">p.leid.inst.1.98</idno>
             <idno type="ddb-perseus-style">0149;;98</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;98</idno>
             <idno type="HGV">31008</idno>

--- a/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.99.xml
+++ b/DDB_EpiDoc_XML/p.leid.inst/p.leid.inst.1/p.leid.inst.1.99.xml
@@ -11,7 +11,7 @@
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-            <idno type="filename">p.leid.inst.99</idno>
+            <idno type="filename">p.leid.inst.1.99</idno>
             <idno type="ddb-perseus-style">0149;;99</idno>
             <idno type="ddb-hybrid">p.leid.inst;1;99</idno>
             <idno type="HGV">31009</idno>

--- a/HGV_meta_EpiDoc/HGV12/11872.xml
+++ b/HGV_meta_EpiDoc/HGV12/11872.xml
@@ -81,8 +81,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">25</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV12/11873.xml
+++ b/HGV_meta_EpiDoc/HGV12/11873.xml
@@ -91,8 +91,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">32</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV12/11877.xml
+++ b/HGV_meta_EpiDoc/HGV12/11877.xml
@@ -82,8 +82,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">36</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV130/129697.xml
+++ b/HGV_meta_EpiDoc/HGV130/129697.xml
@@ -79,8 +79,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope n="1" type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope n="1" type="volume">1</biblScope>
                   <biblScope n="2" type="numbers">49</biblScope>
                   <biblScope n="3" type="generic">Einl.</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV19/18463.xml
+++ b/HGV_meta_EpiDoc/HGV19/18463.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">22</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18464.xml
+++ b/HGV_meta_EpiDoc/HGV19/18464.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">23</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18465.xml
+++ b/HGV_meta_EpiDoc/HGV19/18465.xml
@@ -83,8 +83,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">24</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18466.xml
+++ b/HGV_meta_EpiDoc/HGV19/18466.xml
@@ -81,8 +81,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">29</biblScope>
                   <biblScope type="side">R</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV19/18468.xml
+++ b/HGV_meta_EpiDoc/HGV19/18468.xml
@@ -82,8 +82,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">29</biblScope>
                   <biblScope type="side">V</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV19/18470.xml
+++ b/HGV_meta_EpiDoc/HGV19/18470.xml
@@ -78,8 +78,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope n="1" type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope n="1" type="volume">1</biblScope>
                   <biblScope n="2" type="numbers">34</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18471.xml
+++ b/HGV_meta_EpiDoc/HGV19/18471.xml
@@ -82,8 +82,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">37</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18472.xml
+++ b/HGV_meta_EpiDoc/HGV19/18472.xml
@@ -71,8 +71,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">38</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18473.xml
+++ b/HGV_meta_EpiDoc/HGV19/18473.xml
@@ -83,8 +83,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">39</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18474.xml
+++ b/HGV_meta_EpiDoc/HGV19/18474.xml
@@ -71,8 +71,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">40</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18475.xml
+++ b/HGV_meta_EpiDoc/HGV19/18475.xml
@@ -94,8 +94,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">50</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18476.xml
+++ b/HGV_meta_EpiDoc/HGV19/18476.xml
@@ -98,8 +98,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">51</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18478.xml
+++ b/HGV_meta_EpiDoc/HGV19/18478.xml
@@ -70,8 +70,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">52</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18479.xml
+++ b/HGV_meta_EpiDoc/HGV19/18479.xml
@@ -82,8 +82,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">54</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18480.xml
+++ b/HGV_meta_EpiDoc/HGV19/18480.xml
@@ -78,8 +78,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">59</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18481.xml
+++ b/HGV_meta_EpiDoc/HGV19/18481.xml
@@ -79,8 +79,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">60</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18482.xml
+++ b/HGV_meta_EpiDoc/HGV19/18482.xml
@@ -79,8 +79,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">61</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18485.xml
+++ b/HGV_meta_EpiDoc/HGV19/18485.xml
@@ -109,8 +109,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">62</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18486.xml
+++ b/HGV_meta_EpiDoc/HGV19/18486.xml
@@ -78,8 +78,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">66</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV19/18487.xml
+++ b/HGV_meta_EpiDoc/HGV19/18487.xml
@@ -80,8 +80,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">70</biblScope>
                   <biblScope type="side">R</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV19/18488.xml
+++ b/HGV_meta_EpiDoc/HGV19/18488.xml
@@ -76,8 +76,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">70</biblScope>
                   <biblScope type="side">V</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV19/18489.xml
+++ b/HGV_meta_EpiDoc/HGV19/18489.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">100</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV26/25423.xml
+++ b/HGV_meta_EpiDoc/HGV26/25423.xml
@@ -72,8 +72,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">26</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV26/25424.xml
+++ b/HGV_meta_EpiDoc/HGV26/25424.xml
@@ -81,8 +81,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">27</biblScope>
                   <biblScope type="side">R</biblScope>
                   <biblScope type="lines">Z. 1 - 21</biblScope>

--- a/HGV_meta_EpiDoc/HGV26/25425.xml
+++ b/HGV_meta_EpiDoc/HGV26/25425.xml
@@ -81,8 +81,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">27</biblScope>
                   <biblScope type="side">V</biblScope>
                   <biblScope type="lines">Z. 22 - 36</biblScope>

--- a/HGV_meta_EpiDoc/HGV26/25426.xml
+++ b/HGV_meta_EpiDoc/HGV26/25426.xml
@@ -80,8 +80,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">28</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV26/25427.xml
+++ b/HGV_meta_EpiDoc/HGV26/25427.xml
@@ -72,8 +72,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">30</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV26/25429.xml
+++ b/HGV_meta_EpiDoc/HGV26/25429.xml
@@ -81,8 +81,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">86</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV26/25430.xml
+++ b/HGV_meta_EpiDoc/HGV26/25430.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">87</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV26/25431.xml
+++ b/HGV_meta_EpiDoc/HGV26/25431.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">88</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV26/25432.xml
+++ b/HGV_meta_EpiDoc/HGV26/25432.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">89</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV28/27727.xml
+++ b/HGV_meta_EpiDoc/HGV28/27727.xml
@@ -70,8 +70,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">35</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV28/27728.xml
+++ b/HGV_meta_EpiDoc/HGV28/27728.xml
@@ -81,8 +81,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">41</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV28/27729.xml
+++ b/HGV_meta_EpiDoc/HGV28/27729.xml
@@ -82,8 +82,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">42</biblScope>
                   <biblScope type="lines">Z. 1 - 19</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV28/27731.xml
+++ b/HGV_meta_EpiDoc/HGV28/27731.xml
@@ -80,8 +80,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">43</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV28/27732.xml
+++ b/HGV_meta_EpiDoc/HGV28/27732.xml
@@ -74,8 +74,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">44</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV28/27733.xml
+++ b/HGV_meta_EpiDoc/HGV28/27733.xml
@@ -79,8 +79,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">45</biblScope>
                   <biblScope type="side">R</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV28/27734.xml
+++ b/HGV_meta_EpiDoc/HGV28/27734.xml
@@ -80,8 +80,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">45</biblScope>
                   <biblScope type="side">V</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV28/27735.xml
+++ b/HGV_meta_EpiDoc/HGV28/27735.xml
@@ -72,8 +72,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">46</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV28/27736.xml
+++ b/HGV_meta_EpiDoc/HGV28/27736.xml
@@ -71,8 +71,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">47</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV28/27737.xml
+++ b/HGV_meta_EpiDoc/HGV28/27737.xml
@@ -72,8 +72,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">48</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV28/27738.xml
+++ b/HGV_meta_EpiDoc/HGV28/27738.xml
@@ -71,8 +71,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">49</biblScope>
                   <biblScope type="side">R</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV28/27739.xml
+++ b/HGV_meta_EpiDoc/HGV28/27739.xml
@@ -75,8 +75,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">49</biblScope>
                   <biblScope type="side">V</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV28/27740.xml
+++ b/HGV_meta_EpiDoc/HGV28/27740.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">90</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV28/27741.xml
+++ b/HGV_meta_EpiDoc/HGV28/27741.xml
@@ -74,8 +74,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">91</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV28/27742.xml
+++ b/HGV_meta_EpiDoc/HGV28/27742.xml
@@ -75,8 +75,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">92</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV28/27743.xml
+++ b/HGV_meta_EpiDoc/HGV28/27743.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">93</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV3/2853.xml
+++ b/HGV_meta_EpiDoc/HGV3/2853.xml
@@ -75,8 +75,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">20</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV31/30999.xml
+++ b/HGV_meta_EpiDoc/HGV31/30999.xml
@@ -75,8 +75,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">53</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV31/31000.xml
+++ b/HGV_meta_EpiDoc/HGV31/31000.xml
@@ -70,8 +70,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">55</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV32/31001.xml
+++ b/HGV_meta_EpiDoc/HGV32/31001.xml
@@ -71,8 +71,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">56</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV32/31002.xml
+++ b/HGV_meta_EpiDoc/HGV32/31002.xml
@@ -72,8 +72,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">57</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV32/31003.xml
+++ b/HGV_meta_EpiDoc/HGV32/31003.xml
@@ -70,8 +70,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">58</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV32/31004.xml
+++ b/HGV_meta_EpiDoc/HGV32/31004.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">94</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV32/31005.xml
+++ b/HGV_meta_EpiDoc/HGV32/31005.xml
@@ -74,8 +74,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">95</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV32/31006.xml
+++ b/HGV_meta_EpiDoc/HGV32/31006.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">96</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV32/31007.xml
+++ b/HGV_meta_EpiDoc/HGV32/31007.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">97</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV32/31008.xml
+++ b/HGV_meta_EpiDoc/HGV32/31008.xml
@@ -74,8 +74,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">98</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV32/31009.xml
+++ b/HGV_meta_EpiDoc/HGV32/31009.xml
@@ -74,8 +74,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">99</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV34/33044.xml
+++ b/HGV_meta_EpiDoc/HGV34/33044.xml
@@ -70,8 +70,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">63</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV34/33045.xml
+++ b/HGV_meta_EpiDoc/HGV34/33045.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">64</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV34/33046.xml
+++ b/HGV_meta_EpiDoc/HGV34/33046.xml
@@ -83,8 +83,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">65</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV34/33047.xml
+++ b/HGV_meta_EpiDoc/HGV34/33047.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">101</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV34/33048.xml
+++ b/HGV_meta_EpiDoc/HGV34/33048.xml
@@ -75,8 +75,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">102</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV34/33049.xml
+++ b/HGV_meta_EpiDoc/HGV34/33049.xml
@@ -84,8 +84,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">103</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV34/33050.xml
+++ b/HGV_meta_EpiDoc/HGV34/33050.xml
@@ -81,8 +81,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">104</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV34/33051.xml
+++ b/HGV_meta_EpiDoc/HGV34/33051.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">107</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV36/35178.xml
+++ b/HGV_meta_EpiDoc/HGV36/35178.xml
@@ -72,8 +72,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">67</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV36/35179.xml
+++ b/HGV_meta_EpiDoc/HGV36/35179.xml
@@ -74,8 +74,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">68</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV36/35180.xml
+++ b/HGV_meta_EpiDoc/HGV36/35180.xml
@@ -89,8 +89,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">69</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV37/36569.xml
+++ b/HGV_meta_EpiDoc/HGV37/36569.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">71</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV37/36570.xml
+++ b/HGV_meta_EpiDoc/HGV37/36570.xml
@@ -82,8 +82,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">72</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV37/36571.xml
+++ b/HGV_meta_EpiDoc/HGV37/36571.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">73</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV37/36572.xml
+++ b/HGV_meta_EpiDoc/HGV37/36572.xml
@@ -70,8 +70,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">74</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV37/36573.xml
+++ b/HGV_meta_EpiDoc/HGV37/36573.xml
@@ -82,8 +82,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">75</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV37/36574.xml
+++ b/HGV_meta_EpiDoc/HGV37/36574.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">105</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV37/36575.xml
+++ b/HGV_meta_EpiDoc/HGV37/36575.xml
@@ -75,8 +75,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">106</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV39/38781.xml
+++ b/HGV_meta_EpiDoc/HGV39/38781.xml
@@ -75,8 +75,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">76</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV39/38782.xml
+++ b/HGV_meta_EpiDoc/HGV39/38782.xml
@@ -75,8 +75,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">77</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV39/38783.xml
+++ b/HGV_meta_EpiDoc/HGV39/38783.xml
@@ -75,8 +75,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">78</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV39/38784.xml
+++ b/HGV_meta_EpiDoc/HGV39/38784.xml
@@ -74,8 +74,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">79</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV39/38785.xml
+++ b/HGV_meta_EpiDoc/HGV39/38785.xml
@@ -83,8 +83,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">80</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV44/43133a.xml
+++ b/HGV_meta_EpiDoc/HGV44/43133a.xml
@@ -106,8 +106,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">33</biblScope>
                   <biblScope type="generic">a</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV44/43133b.xml
+++ b/HGV_meta_EpiDoc/HGV44/43133b.xml
@@ -97,8 +97,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">33</biblScope>
                   <biblScope type="generic">b</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV44/43133c.xml
+++ b/HGV_meta_EpiDoc/HGV44/43133c.xml
@@ -94,8 +94,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">33</biblScope>
                   <biblScope type="generic">c</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV44/43134.xml
+++ b/HGV_meta_EpiDoc/HGV44/43134.xml
@@ -84,8 +84,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">42</biblScope>
                   <biblScope type="lines">Z. 20 - 28</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV45/44616.xml
+++ b/HGV_meta_EpiDoc/HGV45/44616.xml
@@ -82,8 +82,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">31</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV6/5235.xml
+++ b/HGV_meta_EpiDoc/HGV6/5235.xml
@@ -82,8 +82,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">21</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV65/64449.xml
+++ b/HGV_meta_EpiDoc/HGV65/64449.xml
@@ -86,8 +86,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">17</biblScope>
                   <biblScope type="generic">Side II A</biblScope>
                </bibl>

--- a/HGV_meta_EpiDoc/HGV701/700791.xml
+++ b/HGV_meta_EpiDoc/HGV701/700791.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of expenses for shipping of wine</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">700791</idno>
+        <idno type="TM">700791</idno>
+        <idno type="ddb-filename">p.leid.inst.2.45</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;45</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 111</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">45</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 156</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV701/700791.xml
+++ b/HGV_meta_EpiDoc/HGV701/700791.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">45</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV79/78485.xml
+++ b/HGV_meta_EpiDoc/HGV79/78485.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">19</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV79/78486.xml
+++ b/HGV_meta_EpiDoc/HGV79/78486.xml
@@ -80,8 +80,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">81</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV79/78487.xml
+++ b/HGV_meta_EpiDoc/HGV79/78487.xml
@@ -75,8 +75,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">82</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV79/78488.xml
+++ b/HGV_meta_EpiDoc/HGV79/78488.xml
@@ -73,8 +73,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">83</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV79/78489.xml
+++ b/HGV_meta_EpiDoc/HGV79/78489.xml
@@ -75,8 +75,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">84</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV79/78490.xml
+++ b/HGV_meta_EpiDoc/HGV79/78490.xml
@@ -78,8 +78,8 @@
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
-                  <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-                  <biblScope type="volume">25</biblScope>
+                  <title level="s" type="abbreviated">P.Leid.Inst.</title>
+                  <biblScope type="volume">1</biblScope>
                   <biblScope type="numbers">85</biblScope>
                </bibl>
             </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971451.xml
+++ b/HGV_meta_EpiDoc/HGV972/971451.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Tax receipt and Greek name</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971451</idno>
+        <idno type="TM">971451</idno>
+        <idno type="ddb-filename">p.leid.inst.2.3</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;3</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 75</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">3</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 32, 33</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971451.xml
+++ b/HGV_meta_EpiDoc/HGV972/971451.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">3</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971452.xml
+++ b/HGV_meta_EpiDoc/HGV972/971452.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">4</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971452.xml
+++ b/HGV_meta_EpiDoc/HGV972/971452.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Payment</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971452</idno>
+        <idno type="TM">971452</idno>
+        <idno type="ddb-filename">p.leid.inst.2.4</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;4</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 65</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Zahlung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">4</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 34</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971453.xml
+++ b/HGV_meta_EpiDoc/HGV972/971453.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Oil receipt to priests and delivery of an unknown product</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971453</idno>
+        <idno type="TM">971453</idno>
+        <idno type="ddb-filename">p.leid.inst.2.5</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;5</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 71</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">5</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 36, 37</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971453.xml
+++ b/HGV_meta_EpiDoc/HGV972/971453.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">5</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971454.xml
+++ b/HGV_meta_EpiDoc/HGV972/971454.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Payment of wine between individuals</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971454</idno>
+        <idno type="TM">971454</idno>
+        <idno type="ddb-filename">p.leid.inst.2.6</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;6</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 74</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Zahlung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">6</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 38</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971454.xml
+++ b/HGV_meta_EpiDoc/HGV972/971454.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">6</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971455.xml
+++ b/HGV_meta_EpiDoc/HGV972/971455.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">7</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971455.xml
+++ b/HGV_meta_EpiDoc/HGV972/971455.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for payment of grain and Greek numbers</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971455</idno>
+        <idno type="TM">971455</idno>
+        <idno type="ddb-filename">p.leid.inst.2.7</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;7</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 70</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">7</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 39, 40</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971456.xml
+++ b/HGV_meta_EpiDoc/HGV972/971456.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Reminder concerning grain</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971456</idno>
+        <idno type="TM">971456</idno>
+        <idno type="ddb-filename">p.leid.inst.2.8</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;8</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 63</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Mahnung</term>
+          <term n="2">Transaktion</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">8</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 41, 42</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971456.xml
+++ b/HGV_meta_EpiDoc/HGV972/971456.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">8</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971457.xml
+++ b/HGV_meta_EpiDoc/HGV972/971457.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of names and name list with payment</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971457</idno>
+        <idno type="TM">971457</idno>
+        <idno type="ddb-filename">p.leid.inst.2.9</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;9</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 67</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">9</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 43, 44</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971457.xml
+++ b/HGV_meta_EpiDoc/HGV972/971457.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">9</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971458.xml
+++ b/HGV_meta_EpiDoc/HGV972/971458.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of names</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971458</idno>
+        <idno type="TM">971458</idno>
+        <idno type="ddb-filename">p.leid.inst.2.10</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;10</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 62</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">10</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 45</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971458.xml
+++ b/HGV_meta_EpiDoc/HGV972/971458.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">10</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971459.xml
+++ b/HGV_meta_EpiDoc/HGV972/971459.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Unknown contents</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971459</idno>
+        <idno type="TM">971459</idno>
+        <idno type="ddb-filename">p.leid.inst.2.11</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;11</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 64</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Unbekannt</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">11</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 46</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971459.xml
+++ b/HGV_meta_EpiDoc/HGV972/971459.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">11</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971460.xml
+++ b/HGV_meta_EpiDoc/HGV972/971460.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Wisdom text or scribal exercise (?)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971460</idno>
+        <idno type="TM">971460</idno>
+        <idno type="ddb-filename">p.leid.inst.2.12</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;12</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 68</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Schreibübung</term>
+          <term n="2">Weisheitstext</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">12</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 47</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971460.xml
+++ b/HGV_meta_EpiDoc/HGV972/971460.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">12</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971461.xml
+++ b/HGV_meta_EpiDoc/HGV972/971461.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Document / letter (?)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971461</idno>
+        <idno type="TM">971461</idno>
+        <idno type="ddb-filename">p.leid.inst.2.13</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;13</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 72</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Dokument</term>
+          <term n="2">Brief</term>
+          <term n="3">Zahlung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">13</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 48</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971461.xml
+++ b/HGV_meta_EpiDoc/HGV972/971461.xml
@@ -74,8 +74,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">13</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971462.xml
+++ b/HGV_meta_EpiDoc/HGV972/971462.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Tax receipt</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971462</idno>
+        <idno type="TM">971462</idno>
+        <idno type="ddb-filename">p.leid.inst.2.14</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;14</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 77</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">14</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 49</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971462.xml
+++ b/HGV_meta_EpiDoc/HGV972/971462.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">14</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971463.xml
+++ b/HGV_meta_EpiDoc/HGV972/971463.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971463</idno>
+        <idno type="TM">971463</idno>
+        <idno type="ddb-filename">p.leid.inst.2.15</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;15</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 66</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Pathyrites</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">15</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 51</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971463.xml
+++ b/HGV_meta_EpiDoc/HGV972/971463.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">15</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971464.xml
+++ b/HGV_meta_EpiDoc/HGV972/971464.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Service or payment for temple (?)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971464</idno>
+        <idno type="TM">971464</idno>
+        <idno type="ddb-filename">p.leid.inst.2.16</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;16</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 61</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Dienst</term>
+          <term n="2">Zahlung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">16</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 52</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971464.xml
+++ b/HGV_meta_EpiDoc/HGV972/971464.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">16</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971465.xml
+++ b/HGV_meta_EpiDoc/HGV972/971465.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">17</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971465.xml
+++ b/HGV_meta_EpiDoc/HGV972/971465.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971465</idno>
+        <idno type="TM">971465</idno>
+        <idno type="ddb-filename">p.leid.inst.2.17</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;17</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 76</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">17</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 53</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971466.xml
+++ b/HGV_meta_EpiDoc/HGV972/971466.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">18</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971466.xml
+++ b/HGV_meta_EpiDoc/HGV972/971466.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Payment and unidentified document</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971466</idno>
+        <idno type="TM">971466</idno>
+        <idno type="ddb-filename">p.leid.inst.2.18</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;18</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 60</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0300" notAfter="-0001" cert="low" precision="low">III - I v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Zahlung</term>
+          <term n="2">unbekannt</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">18</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 54, 55</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971467.xml
+++ b/HGV_meta_EpiDoc/HGV972/971467.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971467</idno>
+        <idno type="TM">971467</idno>
+        <idno type="ddb-filename">p.leid.inst.2.19</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;19</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 78</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0100" notAfter="0100" cert="low" precision="low">I v.Chr. - I n.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">19</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 56</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971467.xml
+++ b/HGV_meta_EpiDoc/HGV972/971467.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">19</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971468.xml
+++ b/HGV_meta_EpiDoc/HGV972/971468.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">20</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971468.xml
+++ b/HGV_meta_EpiDoc/HGV972/971468.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Document concerning some oil (?)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971468</idno>
+        <idno type="TM">971468</idno>
+        <idno type="ddb-filename">p.leid.inst.2.20</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;20</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 73</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="-0100" notAfter="0100" cert="low" precision="low">I v.Chr. - I n.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Dokument</term>
+          <term n="2">Öl</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">20</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 58</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971469.xml
+++ b/HGV_meta_EpiDoc/HGV972/971469.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">21</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971469.xml
+++ b/HGV_meta_EpiDoc/HGV972/971469.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt for the naubion tax</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971469</idno>
+        <idno type="TM">971469</idno>
+        <idno type="ddb-filename">p.leid.inst.2.21</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;21</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">O. 69</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Theben</origPlace>
+              <origDate notBefore="0001" notAfter="0200" precision="low">I - II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">21</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 59</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Demotisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971470.xml
+++ b/HGV_meta_EpiDoc/HGV972/971470.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter about a mule and calves</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971470</idno>
+        <idno type="TM">971470</idno>
+        <idno type="ddb-filename">p.leid.inst.2.22</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;22</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologisches Institut</collection>
+            <idno type="invNo">P. 636</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate xml:id="dateAlternativeX" when="-0232">232 v.Chr.</origDate><origDate xml:id="dateAlternativeY" when="-0207">207 v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (amtlich)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">22</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 63, 64</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971470.xml
+++ b/HGV_meta_EpiDoc/HGV972/971470.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">22</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971471.xml
+++ b/HGV_meta_EpiDoc/HGV972/971471.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">23</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971471.xml
+++ b/HGV_meta_EpiDoc/HGV972/971471.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971471</idno>
+        <idno type="TM">971471</idno>
+        <idno type="ddb-filename">p.leid.inst.2.23</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;23</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 103</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="-0200" notAfter="-0151" precision="low">1. Hälfte II v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">23</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 66</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971472.xml
+++ b/HGV_meta_EpiDoc/HGV972/971472.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Report on (the transport of?) grain</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971472</idno>
+        <idno type="TM">971472</idno>
+        <idno type="ddb-filename">p.leid.inst.2.24</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;24</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 138</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoites (?)</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" when="-0179-11-30" cert="low">30. Nov. 179 v.Chr. (?)</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888" cert="low">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Bericht</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">24</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 68</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971472.xml
+++ b/HGV_meta_EpiDoc/HGV972/971472.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">24</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971473.xml
+++ b/HGV_meta_EpiDoc/HGV972/971473.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Receipt of a loan repaid through a bank</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971473</idno>
+        <idno type="TM">971473</idno>
+        <idno type="ddb-filename">p.leid.inst.2.25</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;25</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 102</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="-0200" notAfter="-0101" precision="low">II v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">25</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 71</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971473.xml
+++ b/HGV_meta_EpiDoc/HGV972/971473.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">25</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971474.xml
+++ b/HGV_meta_EpiDoc/HGV972/971474.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">26</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971474.xml
+++ b/HGV_meta_EpiDoc/HGV972/971474.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Lease of land</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971474</idno>
+        <idno type="TM">971474</idno>
+        <idno type="ddb-filename">p.leid.inst.2.26</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;26</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 557</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoites (?)</origPlace>
+              <origDate notBefore="-0200" notAfter="-0101" precision="low">II v.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888" cert="low">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag</term>
+          <term n="2">Pacht</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">26</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 74</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971475.xml
+++ b/HGV_meta_EpiDoc/HGV972/971475.xml
@@ -74,8 +74,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">27</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971475.xml
+++ b/HGV_meta_EpiDoc/HGV972/971475.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Loan of money</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971475</idno>
+        <idno type="TM">971475</idno>
+        <idno type="ddb-filename">p.leid.inst.2.27</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;27</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 140</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="-0011" notAfter="-0005">11 - 5 v.Chr.<precision match="../@notAfter" degree="0.5"/></origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag</term>
+          <term n="2">Darlehen</term>
+          <term n="3">Geld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">27</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 80</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971476.xml
+++ b/HGV_meta_EpiDoc/HGV972/971476.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">28</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971476.xml
+++ b/HGV_meta_EpiDoc/HGV972/971476.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Beginning of a census return</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971476</idno>
+        <idno type="TM">971476</idno>
+        <idno type="ddb-filename">p.leid.inst.2.28</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;28</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 128</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos</origPlace>
+              <origDate notBefore="0033" notAfter="0034">33 - 34</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Deklaration</term>
+          <term n="2">Zensus</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">28</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 85</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971477.xml
+++ b/HGV_meta_EpiDoc/HGV972/971477.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">29</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971477.xml
+++ b/HGV_meta_EpiDoc/HGV972/971477.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Official letter and petition about land encroachment</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971477</idno>
+        <idno type="TM">971477</idno>
+        <idno type="ddb-filename">p.leid.inst.2.29</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;29</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 571</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Psinteo (Arsinoites)</origPlace>
+              <origDate when="0148-11-21">21. Nov. 148</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1991 https://pleiades.stoa.org/places/741580">Psinteo</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (amtlich)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">29</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 88, 90</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971478.xml
+++ b/HGV_meta_EpiDoc/HGV972/971478.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Report on a fallen sycamore tree</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971478</idno>
+        <idno type="TM">971478</idno>
+        <idno type="ddb-filename">p.leid.inst.2.30</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;30</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 571 II</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Psinteo (Arsinoites)</origPlace>
+              <origDate notBefore="0148" notAfter="0149">148 - 149</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1991 https://pleiades.stoa.org/places/741580">Psinteo</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Bericht</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">30</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 88, 95</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971478.xml
+++ b/HGV_meta_EpiDoc/HGV972/971478.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">30</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971479.xml
+++ b/HGV_meta_EpiDoc/HGV972/971479.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of wine</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971479</idno>
+        <idno type="TM">971479</idno>
+        <idno type="ddb-filename">p.leid.inst.2.31</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;31</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 141</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Herakleopolis (?)</origPlace>
+              <origDate notBefore="0151" notAfter="0200" precision="low">2. Hälfte II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/801 https://pleiades.stoa.org/places/736920" cert="low">Herakleopolis</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+          <term n="2">Wein</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">31</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 99</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971479.xml
+++ b/HGV_meta_EpiDoc/HGV972/971479.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">31</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971480.xml
+++ b/HGV_meta_EpiDoc/HGV972/971480.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">32</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971480.xml
+++ b/HGV_meta_EpiDoc/HGV972/971480.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Calculation at the end of a tax roll</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971480</idno>
+        <idno type="TM">971480</idno>
+        <idno type="ddb-filename">p.leid.inst.2.32</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;32</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. Warren 15</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoites</origPlace>
+              <origDate notBefore="0151" notAfter="0200" precision="low">2. Hälfte II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Berechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">32</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 103</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971481.xml
+++ b/HGV_meta_EpiDoc/HGV972/971481.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">33</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971481.xml
+++ b/HGV_meta_EpiDoc/HGV972/971481.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Register with former liturgists, houses and tax payment</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971481</idno>
+        <idno type="TM">971481</idno>
+        <idno type="ddb-filename">p.leid.inst.2.33</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;33</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 135</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Arsinoe</origPlace>
+              <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">Arsinoe</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Register</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">33</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 107</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971482.xml
+++ b/HGV_meta_EpiDoc/HGV972/971482.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of days worked</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971482</idno>
+        <idno type="TM">971482</idno>
+        <idno type="ddb-filename">p.leid.inst.2.34v</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;34v</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 143</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">34</biblScope>
+            <biblScope n="3" type="side">V</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite P.Lugd. Bat. 40 34 recto.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971482.xml
+++ b/HGV_meta_EpiDoc/HGV972/971482.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">34</biblScope>
             <biblScope n="3" type="side">V</biblScope>
           </bibl>

--- a/HGV_meta_EpiDoc/HGV972/971483.xml
+++ b/HGV_meta_EpiDoc/HGV972/971483.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of payments for donkeys, donkey drivers and workmen</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971483</idno>
+        <idno type="TM">971483</idno>
+        <idno type="ddb-filename">p.leid.inst.2.35</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;35</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 129</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate n="1" xml:id="dateAlternativeX" notBefore="0184-08-31" notAfter="0184-09-03">31. Aug. - 3. Sept. 184 (Jahr unsicher)
+                <certainty locus="value" match="../year-from-date(@notBefore)"/>
+              </origDate>
+              <origDate n="2" xml:id="dateAlternativeY" notBefore="0216-08-31" notAfter="0216-09-03">31. Aug. - 3. Sept. 216 (Jahr unsicher)
+                <certainty locus="value" match="../year-from-date(@notBefore)"/>
+              </origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">35</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 113</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971483.xml
+++ b/HGV_meta_EpiDoc/HGV972/971483.xml
@@ -77,8 +77,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">35</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971484.xml
+++ b/HGV_meta_EpiDoc/HGV972/971484.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971484</idno>
+        <idno type="TM">971484</idno>
+        <idno type="ddb-filename">p.leid.inst.2.36</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;36</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 113</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0101" notAfter="0225" precision="low">II - Anfang III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">36</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 117</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971484.xml
+++ b/HGV_meta_EpiDoc/HGV972/971484.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">36</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971485.xml
+++ b/HGV_meta_EpiDoc/HGV972/971485.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Proposal for nomination by a secretary</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971485</idno>
+        <idno type="TM">971485</idno>
+        <idno type="ddb-filename">p.leid.inst.2.37</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;37</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 115</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos</origPlace>
+              <origDate notBefore="0101" notAfter="0225" precision="low">II - Anfang III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vorschlag</term>
+          <term n="2">Nominierung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">37</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 119</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971485.xml
+++ b/HGV_meta_EpiDoc/HGV972/971485.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">37</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971486.xml
+++ b/HGV_meta_EpiDoc/HGV972/971486.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">38</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971486.xml
+++ b/HGV_meta_EpiDoc/HGV972/971486.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Farm estate report of deliveries in kind</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971486</idno>
+        <idno type="TM">971486</idno>
+        <idno type="ddb-filename">p.leid.inst.2.38</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;38</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 119</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Panopolites</origPlace>
+              <origDate notBefore="0176" notAfter="0225" precision="low">Ende II - Anfang III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2719 https://pleiades.stoa.org/places/756614">Panopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Bericht</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">38</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 123</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971487.xml
+++ b/HGV_meta_EpiDoc/HGV972/971487.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">39</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971487.xml
+++ b/HGV_meta_EpiDoc/HGV972/971487.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Day-to-day account of wages</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971487</idno>
+        <idno type="TM">971487</idno>
+        <idno type="ddb-filename">p.leid.inst.2.39</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;39</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 119</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Panopolites</origPlace>
+              <origDate notBefore="0176" notAfter="0225" precision="low">Ende II - Anfang III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2719 https://pleiades.stoa.org/places/756614">Panopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">39</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 130</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971488.xml
+++ b/HGV_meta_EpiDoc/HGV972/971488.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Concerning an offer on confiscated property</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971488</idno>
+        <idno type="TM">971488</idno>
+        <idno type="ddb-filename">p.leid.inst.2.40</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;40</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 112</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0176" notAfter="0225" precision="low">Ende II - Anfang III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Pachtangebot</term>
+          <term n="2">Kaufangebot</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">40</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 136</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971488.xml
+++ b/HGV_meta_EpiDoc/HGV972/971488.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">40</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971489.xml
+++ b/HGV_meta_EpiDoc/HGV972/971489.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Contract for the employment of a substitute in a liturgy</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971489</idno>
+        <idno type="TM">971489</idno>
+        <idno type="ddb-filename">p.leid.inst.2.41</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;41</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 136</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos</origPlace>
+              <origDate notBefore="0200" notAfter="0211">200 - 211</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">41</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 140</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971489.xml
+++ b/HGV_meta_EpiDoc/HGV972/971489.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">41</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971490.xml
+++ b/HGV_meta_EpiDoc/HGV972/971490.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Document mentioning city magistrates</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971490</idno>
+        <idno type="TM">971490</idno>
+        <idno type="ddb-filename">p.leid.inst.2.42</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;42</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 126</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos (?)</origPlace>
+              <origDate notBefore="0212"><offset type="after" n="1">nach</offset>212</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983" cert="low">Oxyrhynchos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Dokument</term>
+          <term n="2">Magister</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">42</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 143, 144</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971490.xml
+++ b/HGV_meta_EpiDoc/HGV972/971490.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">42</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971491.xml
+++ b/HGV_meta_EpiDoc/HGV972/971491.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">43</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971491.xml
+++ b/HGV_meta_EpiDoc/HGV972/971491.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of wages</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971491</idno>
+        <idno type="TM">971491</idno>
+        <idno type="ddb-filename">p.leid.inst.2.43</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;43</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 106</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0226" notAfter="0275" precision="low">Mitte III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">43</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 146, 147</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971492.xml
+++ b/HGV_meta_EpiDoc/HGV972/971492.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">44</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971492.xml
+++ b/HGV_meta_EpiDoc/HGV972/971492.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of payments in kind for private land</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971492</idno>
+        <idno type="TM">971492</idno>
+        <idno type="ddb-filename">p.leid.inst.2.44</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;44</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 111</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">44</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 151</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971494.xml
+++ b/HGV_meta_EpiDoc/HGV972/971494.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Examination of liturgists</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971494</idno>
+        <idno type="TM">971494</idno>
+        <idno type="ddb-filename">p.leid.inst.2.46r</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;46r</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 132</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+          <term n="2">Liturgen</term>
+          <term n="3">Untersuchung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">46</biblScope>
+            <biblScope n="3" type="side">R</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 161</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite P.Lugd. Bat. 40 46 verso.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971494.xml
+++ b/HGV_meta_EpiDoc/HGV972/971494.xml
@@ -74,8 +74,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">46</biblScope>
             <biblScope n="3" type="side">R</biblScope>
           </bibl>

--- a/HGV_meta_EpiDoc/HGV972/971495.xml
+++ b/HGV_meta_EpiDoc/HGV972/971495.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Keiner</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971495</idno>
+        <idno type="TM">971495</idno>
+        <idno type="ddb-filename">p.leid.inst.2.46v</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;46v</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 132</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">46</biblScope>
+            <biblScope n="3" type="side">V</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite P.Lugd. Bat. 40 46 recto.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971495.xml
+++ b/HGV_meta_EpiDoc/HGV972/971495.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">46</biblScope>
             <biblScope n="3" type="side">V</biblScope>
           </bibl>

--- a/HGV_meta_EpiDoc/HGV972/971496.xml
+++ b/HGV_meta_EpiDoc/HGV972/971496.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">47</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971496.xml
+++ b/HGV_meta_EpiDoc/HGV972/971496.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of report of proceedings</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971496</idno>
+        <idno type="TM">971496</idno>
+        <idno type="ddb-filename">p.leid.inst.2.47</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;47</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 121</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0251" notAfter="0300" precision="low">2. Hälfte III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Bericht</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">47</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 164</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971497.xml
+++ b/HGV_meta_EpiDoc/HGV972/971497.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">48</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971497.xml
+++ b/HGV_meta_EpiDoc/HGV972/971497.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Private letter mentioning a Palmyrene</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971497</idno>
+        <idno type="TM">971497</idno>
+        <idno type="ddb-filename">p.leid.inst.2.48</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;48</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 118</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0276" notAfter="0300" precision="low">Ende III</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (privat)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">48</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 168</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971498.xml
+++ b/HGV_meta_EpiDoc/HGV972/971498.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971498</idno>
+        <idno type="TM">971498</idno>
+        <idno type="ddb-filename">p.leid.inst.2.49</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;49</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 122</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0201" notAfter="0400" precision="low">III - IV</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (privat)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">49</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 172</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971498.xml
+++ b/HGV_meta_EpiDoc/HGV972/971498.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">49</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971499.xml
+++ b/HGV_meta_EpiDoc/HGV972/971499.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">50</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971499.xml
+++ b/HGV_meta_EpiDoc/HGV972/971499.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Notification of deceased soldiers (thetati)</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971499</idno>
+        <idno type="TM">971499</idno>
+        <idno type="ddb-filename">p.leid.inst.2.50</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;50</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 191</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0276" notAfter="0325" precision="low">Ende III - Anfang IV</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Todesanzeige</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">50</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 175</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971500.xml
+++ b/HGV_meta_EpiDoc/HGV972/971500.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">51</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971500.xml
+++ b/HGV_meta_EpiDoc/HGV972/971500.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971500</idno>
+        <idno type="TM">971500</idno>
+        <idno type="ddb-filename">p.leid.inst.2.51</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;51</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 124</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0301" notAfter="0325" precision="low">Anfang IV</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">51</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 178</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971501.xml
+++ b/HGV_meta_EpiDoc/HGV972/971501.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of payments for adaeratio of wine</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971501</idno>
+        <idno type="TM">971501</idno>
+        <idno type="ddb-filename">p.leid.inst.2.52</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;52</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 116</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Teis (Oxyrhynchites)</origPlace>
+              <origDate notBefore="0301" notAfter="0350" precision="low">1. Hälfte IV</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2907 https://pleiades.stoa.org/places/741619">Teis</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">52</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 181</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971501.xml
+++ b/HGV_meta_EpiDoc/HGV972/971501.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">52</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971502.xml
+++ b/HGV_meta_EpiDoc/HGV972/971502.xml
@@ -74,8 +74,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">53</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971502.xml
+++ b/HGV_meta_EpiDoc/HGV972/971502.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Sworn declarations</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971502</idno>
+        <idno type="TM">971502</idno>
+        <idno type="ddb-filename">p.leid.inst.2.53</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;53</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 105</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Tinteris (Herakleopolites)</origPlace>
+              <origDate when="0375">375</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/3061 https://pleiades.stoa.org/places/737090">Tinteris</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Eid</term>
+          <term n="2">Erklärung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">53</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 183, 184</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971503.xml
+++ b/HGV_meta_EpiDoc/HGV972/971503.xml
@@ -74,8 +74,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">54</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971503.xml
+++ b/HGV_meta_EpiDoc/HGV972/971503.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of payments in hay</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971503</idno>
+        <idno type="TM">971503</idno>
+        <idno type="ddb-filename">p.leid.inst.2.54</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;54</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 109</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Nesminis (Oxyrhynchites)</origPlace>
+              <origDate xml:id="dateAlternativeX" when="0329">329 n.Chr.</origDate>
+              <origDate xml:id="dateAlternativeY" when="0360">360 n.Chr.</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2864 https://pleiades.stoa.org/places/741530">Nesminis</placeName>
+                <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">54</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 189</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971504.xml
+++ b/HGV_meta_EpiDoc/HGV972/971504.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">55</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971504.xml
+++ b/HGV_meta_EpiDoc/HGV972/971504.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of an account</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971504</idno>
+        <idno type="TM">971504</idno>
+        <idno type="ddb-filename">p.leid.inst.2.55</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;55</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 127</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0351" notAfter="0425" precision="low">2. Hälfte IV - Anfang V</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">55</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 193</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971505.xml
+++ b/HGV_meta_EpiDoc/HGV972/971505.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">56</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971505.xml
+++ b/HGV_meta_EpiDoc/HGV972/971505.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of deliveries in kind in the eparchy of Arcadia</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971505</idno>
+        <idno type="TM">971505</idno>
+        <idno type="ddb-filename">p.leid.inst.2.56</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;56</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 217</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos</origPlace>
+              <origDate notBefore="0404" notAfter="0435">404 - 435</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">56</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 198, 200</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971506.xml
+++ b/HGV_meta_EpiDoc/HGV972/971506.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>List of payments</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971506</idno>
+        <idno type="TM">971506</idno>
+        <idno type="ddb-filename">p.leid.inst.2.57</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;57</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 123</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos</origPlace>
+              <origDate notBefore="0401" notAfter="0425" precision="low">Anfang V</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Liste</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">57</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 211</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971506.xml
+++ b/HGV_meta_EpiDoc/HGV972/971506.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">57</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971507.xml
+++ b/HGV_meta_EpiDoc/HGV972/971507.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">58</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971507.xml
+++ b/HGV_meta_EpiDoc/HGV972/971507.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Letter from the town council of Oxyrhynchos</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971507</idno>
+        <idno type="TM">971507</idno>
+        <idno type="ddb-filename">p.leid.inst.2.58</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;58</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 114</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchos</origPlace>
+              <origDate notBefore="0401" notAfter="0450" precision="low">1. Hälfte V</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">58</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 214</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971508.xml
+++ b/HGV_meta_EpiDoc/HGV972/971508.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Private letter to Zenobios</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971508</idno>
+        <idno type="TM">971508</idno>
+        <idno type="ddb-filename">p.leid.inst.2.59</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;59</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 110</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0401" notAfter="0500" precision="low">V</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief (privat)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">59</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 218, 219</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971508.xml
+++ b/HGV_meta_EpiDoc/HGV972/971508.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">59</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971509.xml
+++ b/HGV_meta_EpiDoc/HGV972/971509.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Fragment of a Byzantine letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971509</idno>
+        <idno type="TM">971509</idno>
+        <idno type="ddb-filename">p.leid.inst.2.60</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;60</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 134</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0401" notAfter="0500" precision="low">V</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Brief</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">60</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 224</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971509.xml
+++ b/HGV_meta_EpiDoc/HGV972/971509.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">60</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971510.xml
+++ b/HGV_meta_EpiDoc/HGV972/971510.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">61</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971510.xml
+++ b/HGV_meta_EpiDoc/HGV972/971510.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Sale of wine for future delivery</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971510</idno>
+        <idno type="TM">971510</idno>
+        <idno type="ddb-filename">p.leid.inst.2.61</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;61</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 107</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites</origPlace>
+              <origDate notBefore="0401" notAfter="0525" precision="low">V - Anfang VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">61</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 228, 229</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971511.xml
+++ b/HGV_meta_EpiDoc/HGV972/971511.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">62</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971511.xml
+++ b/HGV_meta_EpiDoc/HGV972/971511.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>End of a lease contract</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971511</idno>
+        <idno type="TM">971511</idno>
+        <idno type="ddb-filename">p.leid.inst.2.62</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;62</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 130</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oxyrhynchites (?)</origPlace>
+              <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982" cert="low">Oxyrhynchites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Vertrag</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">62</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 232</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971512.xml
+++ b/HGV_meta_EpiDoc/HGV972/971512.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Account of tax payments</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971512</idno>
+        <idno type="TM">971512</idno>
+        <idno type="ddb-filename">p.leid.inst.2.63</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;63</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 133</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Hermopolites</origPlace>
+              <origDate notBefore="0551" notAfter="0600" precision="low">2. Hälfte VI</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+          <term n="2">Zahlungen</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">63</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 236, 238</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971512.xml
+++ b/HGV_meta_EpiDoc/HGV972/971512.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">63</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971513.xml
+++ b/HGV_meta_EpiDoc/HGV972/971513.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Draft of an official letter</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971513</idno>
+        <idno type="TM">971513</idno>
+        <idno type="ddb-filename">p.leid.inst.2.64</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;64</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 108</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0551" notAfter="0625" precision="low">2. Hälfte VI - Anfang VII</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Entwurf</term>
+          <term n="2">Brief (amtlich)</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">64</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 244</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971513.xml
+++ b/HGV_meta_EpiDoc/HGV972/971513.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">64</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971514.xml
+++ b/HGV_meta_EpiDoc/HGV972/971514.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Acknowledgement of debt Coptic Ostracon</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971514</idno>
+        <idno type="TM">971514</idno>
+        <idno type="ddb-filename">p.leid.inst.2.65</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;65</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 120</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Oberägypten</origPlace>
+              <origDate notBefore="0610" notAfter="0619">610 - 619</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2766">Oberägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Anerkentniss</term>
+          <term n="2">Schuld</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">65</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 249</bibl>
+        </p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971514.xml
+++ b/HGV_meta_EpiDoc/HGV972/971514.xml
@@ -73,8 +73,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">65</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971515.xml
+++ b/HGV_meta_EpiDoc/HGV972/971515.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Tax receipt written by Psate son of Pisrael</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971515</idno>
+        <idno type="TM">971515</idno>
+        <idno type="ddb-filename">p.leid.inst.2.66</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;66</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">O. 79</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Ostrakon</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>Djeme</origPlace>
+              <origDate when="0723">723</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/1341 https://pleiades.stoa.org/places/786067">Djeme</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Quittung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">66</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 255</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Koptisch.</p>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV972/971515.xml
+++ b/HGV_meta_EpiDoc/HGV972/971515.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">66</biblScope>
           </bibl>
         </listBibl>

--- a/HGV_meta_EpiDoc/HGV972/971516.xml
+++ b/HGV_meta_EpiDoc/HGV972/971516.xml
@@ -72,8 +72,8 @@
       <div type="bibliography" subtype="principalEdition">
         <listBibl>
           <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
-            <biblScope n="1" type="volume">40</biblScope>
+            <title level="s" type="abbreviated">P.Leid.Inst.</title>
+            <biblScope n="1" type="volume">2</biblScope>
             <biblScope n="2" type="numbers">34</biblScope>
             <biblScope n="3" type="side">R</biblScope>
           </bibl>

--- a/HGV_meta_EpiDoc/HGV972/971516.xml
+++ b/HGV_meta_EpiDoc/HGV972/971516.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Keiner</title>
+      </titleStmt>
+      <publicationStmt>
+        <idno type="filename">971516</idno>
+        <idno type="TM">971516</idno>
+        <idno type="ddb-filename">p.leid.inst.2.34r</idno>
+        <idno type="ddb-hybrid">p.leid.inst;2;34r</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <placeName>
+              <settlement>Leiden</settlement>
+            </placeName>
+            <collection>Papyrologiches Institut</collection>
+            <idno type="invNo">P. 143</idno>
+          </msIdentifier>
+          <physDesc>
+            <objectDesc>
+              <supportDesc>
+                <support>
+                  <material>Papyrus</material>
+                </support>
+              </supportDesc>
+            </objectDesc>
+          </physDesc>
+          <history>
+            <origin>
+              <origPlace>unbekannt</origPlace>
+              <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
+            </origin>
+            <provenance type="located">
+              <p>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
+              </p>
+            </provenance>
+          </history>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="fr">Französisch</language>
+        <language ident="en">Englisch</language>
+        <language ident="de">Deutsch</language>
+        <language ident="it">Italienisch</language>
+        <language ident="es">Spanisch</language>
+        <language ident="la">Latein</language>
+        <language ident="el">Griechisch</language>
+      </langUsage>
+      <textClass>
+        <keywords scheme="hgv">
+          <term n="1">Abrechnung</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change when="2023-08-11" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div type="bibliography" subtype="principalEdition">
+        <listBibl>
+          <bibl type="publication" subtype="principal">
+            <title level="s" type="abbreviated">P.Lugd. Bat.</title>
+            <biblScope n="1" type="volume">40</biblScope>
+            <biblScope n="2" type="numbers">34</biblScope>
+            <biblScope n="3" type="side">R</biblScope>
+          </bibl>
+        </listBibl>
+      </div>
+      <div type="bibliography" subtype ="illustrations">
+        <p>
+          <bibl type="illustration">S. 110, 111</bibl>
+        </p>
+      </div>
+      <div type="commentary" subtype="general">
+        <p>Rückseite P.Lugd. Bat. 40 34 verso.</p>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
As per spreadsheet. Two papyri required addition of recto/verso into idnos, `<biblScope>` metadata, and general commentary (re: Rückseite), which I have included. Otherwise, there were no major issues of note. I remain perplexed that idnos use the format `p.leid.inst;/d;/d` while `<biblScope>` refers to `P.Lugd. Bat.` (which invariably has its own volume number), but I have followed established practice (cf. P.Lugd.Bat. 25 and P.Batav.)