### PR TITLE
dclp-hybrids mpern.s; and na;

### DIFF
--- a/DCLP/114/113809.xml
+++ b/DCLP/114/113809.xml
@@ -12,7 +12,7 @@
             <idno type="TM">113809</idno>
             <idno type="LDAB">113809</idno>
             <idno type="filename">113809</idno>
-            <idno type="dclp-hybrid">mper;29;59</idno>
+            <idno type="dclp-hybrid">mper.ns;29;59</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117700.xml
+++ b/DCLP/118/117700.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117700</idno>
             <idno type="LDAB">11770</idno>
             <idno type="filename">117700</idno>
-            <idno type="dclp-hybrid">mpern.s;31;3</idno>
+            <idno type="dclp-hybrid">mper.ns;31;3</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117701.xml
+++ b/DCLP/118/117701.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117701</idno>
             <idno type="LDAB">117701</idno>
             <idno type="filename">117701</idno>
-            <idno type="dclp-hybrid">mpern.s;31;5</idno>
+            <idno type="dclp-hybrid">mper.ns;31;5</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117702.xml
+++ b/DCLP/118/117702.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117702</idno>
             <idno type="LDAB">117702</idno>
             <idno type="filename">117702</idno>
-            <idno type="dclp-hybrid">mpern.s;31;6</idno>
+            <idno type="dclp-hybrid">mper.ns;31;6</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117704.xml
+++ b/DCLP/118/117704.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117704</idno>
             <idno type="LDAB">117704</idno>
             <idno type="filename">117704</idno>
-            <idno type="dclp-hybrid">mpern.s;31;9</idno>
+            <idno type="dclp-hybrid">mper.ns;31;9</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117705.xml
+++ b/DCLP/118/117705.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117705</idno>
             <idno type="LDAB">117705</idno>
             <idno type="filename">117705</idno>
-            <idno type="dclp-hybrid">mpern.s;31;10</idno>
+            <idno type="dclp-hybrid">mper.ns;31;10</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117707.xml
+++ b/DCLP/118/117707.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117707</idno>
             <idno type="LDAB">117707</idno>
             <idno type="filename">117707</idno>
-            <idno type="dclp-hybrid">mpern.s;31;13</idno>
+            <idno type="dclp-hybrid">mper.ns;31;13</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117708.xml
+++ b/DCLP/118/117708.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117708</idno>
             <idno type="LDAB">117708</idno>
             <idno type="filename">117708</idno>
-            <idno type="dclp-hybrid">mpern.s;31;14</idno>
+            <idno type="dclp-hybrid">mper.ns;31;14</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117709.xml
+++ b/DCLP/118/117709.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117709</idno>
             <idno type="LDAB">117709</idno>
             <idno type="filename">117709</idno>
-            <idno type="dclp-hybrid">mpern.s;31;15</idno>
+            <idno type="dclp-hybrid">mper.ns;31;15</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117710.xml
+++ b/DCLP/118/117710.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117710</idno>
             <idno type="LDAB">117710</idno>
             <idno type="filename">117710</idno>
-            <idno type="dclp-hybrid">mpern.s;31;17</idno>
+            <idno type="dclp-hybrid">mper.ns;31;17</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117711.xml
+++ b/DCLP/118/117711.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117711</idno>
             <idno type="LDAB">117711</idno>
             <idno type="filename">117711</idno>
-            <idno type="dclp-hybrid">mpern.s;31;16</idno>
+            <idno type="dclp-hybrid">mper.ns;31;16</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117712.xml
+++ b/DCLP/118/117712.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117712</idno>
             <idno type="LDAB">117712</idno>
             <idno type="filename">117712</idno>
-            <idno type="dclp-hybrid">mpern.s;31;18</idno>
+            <idno type="dclp-hybrid">mper.ns;31;18</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117713.xml
+++ b/DCLP/118/117713.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117713</idno>
             <idno type="LDAB">117713</idno>
             <idno type="filename">117713</idno>
-            <idno type="dclp-hybrid">mpern.s;31;19</idno>
+            <idno type="dclp-hybrid">mper.ns;31;19</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117714.xml
+++ b/DCLP/118/117714.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117714</idno>
             <idno type="LDAB">117714</idno>
             <idno type="filename">117714</idno>
-            <idno type="dclp-hybrid">mpern.s;31;20</idno>
+            <idno type="dclp-hybrid">mper.ns;31;20</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117715.xml
+++ b/DCLP/118/117715.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117715</idno>
             <idno type="LDAB">117715</idno>
             <idno type="filename">117715</idno>
-            <idno type="dclp-hybrid">mpern.s;31;23</idno>
+            <idno type="dclp-hybrid">mper.ns;31;23</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117716.xml
+++ b/DCLP/118/117716.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117716</idno>
             <idno type="LDAB">117716</idno>
             <idno type="filename">117716</idno>
-            <idno type="dclp-hybrid">mpern.s;31;24</idno>
+            <idno type="dclp-hybrid">mper.ns;31;24</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117717.xml
+++ b/DCLP/118/117717.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117717</idno>
             <idno type="LDAB">117717</idno>
             <idno type="filename">117717</idno>
-            <idno type="dclp-hybrid">mpern.s;31;25</idno>
+            <idno type="dclp-hybrid">mper.ns;31;25</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/118/117718.xml
+++ b/DCLP/118/117718.xml
@@ -12,7 +12,7 @@
             <idno type="TM">117718</idno>
             <idno type="LDAB">117718</idno>
             <idno type="filename">117718</idno>
-            <idno type="dclp-hybrid">mpern.s;31;26</idno>
+            <idno type="dclp-hybrid">mper.ns;31;26</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/370/369038.xml
+++ b/DCLP/370/369038.xml
@@ -10,7 +10,7 @@
             <authority>Digital Corpus of Literary Papyri</authority>
             <idno type="filename">369038</idno>
             <idno type="dclp">369038</idno>
-            <idno type="dclp-hybrid">na;;369038</idno>
+            <idno type="dclp-hybrid">tm;;369038</idno>
             <idno type="TM">369038</idno>
             <availability>
                <p>

--- a/DCLP/370/369039.xml
+++ b/DCLP/370/369039.xml
@@ -10,7 +10,7 @@
             <authority>Digital Corpus of Literary Papyri</authority>
             <idno type="filename">369039</idno>
             <idno type="dclp">369039</idno>
-            <idno type="dclp-hybrid">na;;369039</idno>
+            <idno type="dclp-hybrid">tm;;369039</idno>
             <idno type="TM">369039</idno>
             <availability>
                <p>

--- a/DCLP/370/369040.xml
+++ b/DCLP/370/369040.xml
@@ -10,7 +10,7 @@
             <authority>Digital Corpus of Literary Papyri</authority>
             <idno type="filename">369040</idno>
             <idno type="dclp">369040</idno>
-            <idno type="dclp-hybrid">na;;369040</idno>
+            <idno type="dclp-hybrid">tm;;369040</idno>
             <idno type="TM">369040</idno>
             <availability>
                <p>

--- a/DCLP/402/401001.xml
+++ b/DCLP/402/401001.xml
@@ -10,7 +10,7 @@
             <authority>Digital Corpus of Literary Papyri</authority>
             <idno type="filename">401001</idno>
             <idno type="dclp">401001</idno>
-            <idno type="dclp-hybrid">na;;401001</idno>
+            <idno type="dclp-hybrid">tm;;401001</idno>
             <idno type="TM">401001</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/402/401002.xml
+++ b/DCLP/402/401002.xml
@@ -10,7 +10,7 @@
             <authority>Digital Corpus of Literary Papyri</authority>
             <idno type="filename">401002</idno>
             <idno type="dclp">401002</idno>
-            <idno type="dclp-hybrid">na;;401002</idno>
+            <idno type="dclp-hybrid">tm;;401002</idno>
             <idno type="TM">401002</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/512/511900.xml
+++ b/DCLP/512/511900.xml
@@ -10,7 +10,7 @@
             <authority>Digital Corpus of Literary Papyri</authority>
             <idno type="filename">511900</idno>
             <idno type="dclp">511900</idno>
-            <idno type="dclp-hybrid">na;;511900</idno>
+            <idno type="dclp-hybrid">tm;;511900</idno>
             <idno type="TM">511900</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/60/59081.xml
+++ b/DCLP/60/59081.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59081</idno>
             <idno type="LDAB">176</idno>
             <idno type="filename">59081</idno>
-            <idno type="dclp-hybrid">mpern.s;1;6</idno>
+            <idno type="dclp-hybrid">mper.ns;1;6</idno>
             <idno type="MP3">01899.000</idno>
             <availability>
                <p>

--- a/DCLP/60/59196.xml
+++ b/DCLP/60/59196.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59196</idno>
             <idno type="LDAB">291</idno>
             <idno type="filename">59196</idno>
-            <idno type="dclp-hybrid">mpern.s;3;16</idno>
+            <idno type="dclp-hybrid">mper.ns;3;16</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59278.xml
+++ b/DCLP/60/59278.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59278</idno>
             <idno type="LDAB">375</idno>
             <idno type="filename">59278</idno>
-            <idno type="dclp-hybrid">mpern.s;3;20</idno>
+            <idno type="dclp-hybrid">mper.ns;3;20</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59480.xml
+++ b/DCLP/60/59480.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59480</idno>
             <idno type="LDAB">580</idno>
             <idno type="filename">59480</idno>
-            <idno type="dclp-hybrid">mpern.s;3;23</idno>
+            <idno type="dclp-hybrid">mper.ns;3;23</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59487.xml
+++ b/DCLP/60/59487.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59487</idno>
             <idno type="LDAB">587</idno>
             <idno type="filename">59487</idno>
-            <idno type="dclp-hybrid">mpern.s;4;53</idno>
+            <idno type="dclp-hybrid">mper.ns;4;53</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59575.xml
+++ b/DCLP/60/59575.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59575</idno>
             <idno type="LDAB">677</idno>
             <idno type="filename">59575</idno>
-            <idno type="dclp-hybrid">mpern.s;1;10</idno>
+            <idno type="dclp-hybrid">mper.ns;1;10</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59636.xml
+++ b/DCLP/60/59636.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59636</idno>
             <idno type="LDAB">738</idno>
             <idno type="filename">59636</idno>
-            <idno type="dclp-hybrid">mpern.s;1;9</idno>
+            <idno type="dclp-hybrid">mper.ns;1;9</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59637.xml
+++ b/DCLP/60/59637.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59637</idno>
             <idno type="LDAB">739</idno>
             <idno type="filename">59637</idno>
-            <idno type="dclp-hybrid">mpern.s;1;25</idno>
+            <idno type="dclp-hybrid">mper.ns;1;25</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59640.xml
+++ b/DCLP/60/59640.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59640</idno>
             <idno type="LDAB">742</idno>
             <idno type="filename">59640</idno>
-            <idno type="dclp-hybrid">mpern.s;1;11</idno>
+            <idno type="dclp-hybrid">mper.ns;1;11</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59650.xml
+++ b/DCLP/60/59650.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59650</idno>
             <idno type="LDAB">752</idno>
             <idno type="filename">59650</idno>
-            <idno type="dclp-hybrid">mpern.s;3;47</idno>
+            <idno type="dclp-hybrid">mper.ns;3;47</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59684.xml
+++ b/DCLP/60/59684.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59684</idno>
             <idno type="LDAB">788</idno>
             <idno type="filename">59684</idno>
-            <idno type="dclp-hybrid">mpern.s;3;32</idno>
+            <idno type="dclp-hybrid">mper.ns;3;32</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59690.xml
+++ b/DCLP/60/59690.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59690</idno>
             <idno type="LDAB">794</idno>
             <idno type="filename">59690</idno>
-            <idno type="dclp-hybrid">mpern.s;3;11</idno>
+            <idno type="dclp-hybrid">mper.ns;3;11</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59839.xml
+++ b/DCLP/60/59839.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59839</idno>
             <idno type="LDAB">944</idno>
             <idno type="filename">59839</idno>
-            <idno type="dclp-hybrid">mpern.s;3;19</idno>
+            <idno type="dclp-hybrid">mper.ns;3;19</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59853.xml
+++ b/DCLP/60/59853.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59853</idno>
             <idno type="LDAB">959</idno>
             <idno type="filename">59853</idno>
-            <idno type="dclp-hybrid">mpern.s;3;18</idno>
+            <idno type="dclp-hybrid">mper.ns;3;18</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59894.xml
+++ b/DCLP/60/59894.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59894</idno>
             <idno type="LDAB">1001</idno>
             <idno type="filename">59894</idno>
-            <idno type="dclp-hybrid">mpern.s;3;21</idno>
+            <idno type="dclp-hybrid">mper.ns;3;21</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/60/59963.xml
+++ b/DCLP/60/59963.xml
@@ -12,7 +12,7 @@
             <idno type="TM">59963</idno>
             <idno type="LDAB">1075</idno>
             <idno type="filename">59963</idno>
-            <idno type="dclp-hybrid">mpern.s;17;11</idno>
+            <idno type="dclp-hybrid">mper.ns;17;11</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/61/60104.xml
+++ b/DCLP/61/60104.xml
@@ -12,7 +12,7 @@
             <idno type="TM">60104</idno>
             <idno type="LDAB">1218</idno>
             <idno type="filename">60104</idno>
-            <idno type="dclp-hybrid">mpern.s;3;5</idno>
+            <idno type="dclp-hybrid">mper.ns;3;5</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/61/60124.xml
+++ b/DCLP/61/60124.xml
@@ -12,7 +12,7 @@
             <idno type="TM">60124</idno>
             <idno type="LDAB">1238</idno>
             <idno type="filename">60124</idno>
-            <idno type="dclp-hybrid">mpern.s;3;7</idno>
+            <idno type="dclp-hybrid">mper.ns;3;7</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/61/60142.xml
+++ b/DCLP/61/60142.xml
@@ -12,7 +12,7 @@
             <idno type="TM">60142</idno>
             <idno type="LDAB">1256</idno>
             <idno type="filename">60142</idno>
-            <idno type="dclp-hybrid">mpern.s;3;6</idno>
+            <idno type="dclp-hybrid">mper.ns;3;6</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/61/60148.xml
+++ b/DCLP/61/60148.xml
@@ -12,7 +12,7 @@
             <idno type="TM">60148</idno>
             <idno type="LDAB">1262</idno>
             <idno type="filename">60148</idno>
-            <idno type="dclp-hybrid">mpern.s;3;8</idno>
+            <idno type="dclp-hybrid">mper.ns;3;8</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/61/60157.xml
+++ b/DCLP/61/60157.xml
@@ -12,7 +12,7 @@
             <idno type="TM">60157</idno>
             <idno type="LDAB">1272</idno>
             <idno type="filename">60157</idno>
-            <idno type="dclp-hybrid">mpern.s;3;9</idno>
+            <idno type="dclp-hybrid">mper.ns;3;9</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/61/60366.xml
+++ b/DCLP/61/60366.xml
@@ -12,7 +12,7 @@
             <idno type="TM">60366</idno>
             <idno type="LDAB">1487</idno>
             <idno type="filename">60366</idno>
-            <idno type="dclp-hybrid">mpern.s;1;3</idno>
+            <idno type="dclp-hybrid">mper.ns;1;3</idno>
             <idno type="MP3">00853.000</idno>
             <availability>
                <p>

--- a/DCLP/62/61005.xml
+++ b/DCLP/62/61005.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61005</idno>
             <idno type="LDAB">2138</idno>
             <idno type="filename">61005</idno>
-            <idno type="dclp-hybrid">mpern.s;3;3</idno>
+            <idno type="dclp-hybrid">mper.ns;3;3</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61060.xml
+++ b/DCLP/62/61060.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61060</idno>
             <idno type="LDAB">2197</idno>
             <idno type="filename">61060</idno>
-            <idno type="dclp-hybrid">mpern.s;3;4</idno>
+            <idno type="dclp-hybrid">mper.ns;3;4</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61083.xml
+++ b/DCLP/62/61083.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61083</idno>
             <idno type="LDAB">2220</idno>
             <idno type="filename">61083</idno>
-            <idno type="dclp-hybrid">mpern.s;1;2</idno>
+            <idno type="dclp-hybrid">mper.ns;1;2</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61304.xml
+++ b/DCLP/62/61304.xml
@@ -12,7 +12,7 @@
         <idno type="TM">61304</idno>
         <idno type="LDAB">2446</idno>
         <idno type="filename">61304</idno>
-        <idno type="dclp-hybrid">mpern.s;3;24</idno>
+        <idno type="dclp-hybrid">mper.ns;3;24</idno>
         <availability>
           <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
         </availability>

--- a/DCLP/62/61315.xml
+++ b/DCLP/62/61315.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61315</idno>
             <idno type="LDAB">2457</idno>
             <idno type="filename">61315</idno>
-            <idno type="dclp-hybrid">mpern.s;3;36</idno>
+            <idno type="dclp-hybrid">mper.ns;3;36</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61320.xml
+++ b/DCLP/62/61320.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61320</idno>
             <idno type="LDAB">2462</idno>
             <idno type="filename">61320</idno>
-            <idno type="dclp-hybrid">mpern.s;1;12</idno>
+            <idno type="dclp-hybrid">mper.ns;1;12</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61395.xml
+++ b/DCLP/62/61395.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61395</idno>
             <idno type="LDAB">2539</idno>
             <idno type="filename">61395</idno>
-            <idno type="dclp-hybrid">mpern.s;3;40</idno>
+            <idno type="dclp-hybrid">mper.ns;3;40</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61397.xml
+++ b/DCLP/62/61397.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61397</idno>
             <idno type="LDAB">2541</idno>
             <idno type="filename">61397</idno>
-            <idno type="dclp-hybrid">mpern.s;3;42</idno>
+            <idno type="dclp-hybrid">mper.ns;3;42</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61422.xml
+++ b/DCLP/62/61422.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61422</idno>
             <idno type="LDAB">2567</idno>
             <idno type="filename">61422</idno>
-            <idno type="dclp-hybrid">mpern.s;4;54</idno>
+            <idno type="dclp-hybrid">mper.ns;4;54</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61427.xml
+++ b/DCLP/62/61427.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61427</idno>
             <idno type="LDAB">2572</idno>
             <idno type="filename">61427</idno>
-            <idno type="dclp-hybrid">mpern.s;3;60</idno>
+            <idno type="dclp-hybrid">mper.ns;3;60</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61451.xml
+++ b/DCLP/62/61451.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61451</idno>
             <idno type="LDAB">2596</idno>
             <idno type="filename">61451</idno>
-            <idno type="dclp-hybrid">mpern.s;1;13</idno>
+            <idno type="dclp-hybrid">mper.ns;1;13</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61612.xml
+++ b/DCLP/62/61612.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61612</idno>
             <idno type="LDAB">2761</idno>
             <idno type="filename">61612</idno>
-            <idno type="dclp-hybrid">mpern.s;1;17</idno>
+            <idno type="dclp-hybrid">mper.ns;1;17</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61657.xml
+++ b/DCLP/62/61657.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61657</idno>
             <idno type="LDAB">2807</idno>
             <idno type="filename">61657</idno>
-            <idno type="dclp-hybrid">mpern.s;29;45</idno>
+            <idno type="dclp-hybrid">mper.ns;29;45</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61658.xml
+++ b/DCLP/62/61658.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61658</idno>
             <idno type="LDAB">2808</idno>
             <idno type="filename">61658</idno>
-            <idno type="dclp-hybrid">mpern.s;29;43</idno>
+            <idno type="dclp-hybrid">mper.ns;29;43</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61659.xml
+++ b/DCLP/62/61659.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61659</idno>
             <idno type="LDAB">2809</idno>
             <idno type="filename">61659</idno>
-            <idno type="dclp-hybrid">mpern.s;29;44</idno>
+            <idno type="dclp-hybrid">mper.ns;29;44</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61669.xml
+++ b/DCLP/62/61669.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61669</idno>
             <idno type="LDAB">2820</idno>
             <idno type="filename">61669</idno>
-            <idno type="dclp-hybrid">mpern.s;29;6</idno>
+            <idno type="dclp-hybrid">mper.ns;29;6</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61671.xml
+++ b/DCLP/62/61671.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61671</idno>
             <idno type="LDAB">2822</idno>
             <idno type="filename">61671</idno>
-            <idno type="dclp-hybrid">mpern.s;29;5</idno>
+            <idno type="dclp-hybrid">mper.ns;29;5</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61672.xml
+++ b/DCLP/62/61672.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61672</idno>
             <idno type="LDAB">2823</idno>
             <idno type="filename">61672</idno>
-            <idno type="dclp-hybrid">mpern.s;17;10</idno>
+            <idno type="dclp-hybrid">mper.ns;17;10</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61682.xml
+++ b/DCLP/62/61682.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61682</idno>
             <idno type="LDAB">2833</idno>
             <idno type="filename">61682</idno>
-            <idno type="dclp-hybrid">mpern.s;29;38</idno>
+            <idno type="dclp-hybrid">mper.ns;29;38</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61686.xml
+++ b/DCLP/62/61686.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61686</idno>
             <idno type="LDAB">2837</idno>
             <idno type="filename">61686</idno>
-            <idno type="dclp-hybrid">mpern.s;29;39</idno>
+            <idno type="dclp-hybrid">mper.ns;29;39</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61707.xml
+++ b/DCLP/62/61707.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61707</idno>
             <idno type="LDAB">2859</idno>
             <idno type="filename">61707</idno>
-            <idno type="dclp-hybrid">mpern.s;29;9</idno>
+            <idno type="dclp-hybrid">mper.ns;29;9</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61708.xml
+++ b/DCLP/62/61708.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61708</idno>
             <idno type="LDAB">2860</idno>
             <idno type="filename">61708</idno>
-            <idno type="dclp-hybrid">mpern.s;29;31</idno>
+            <idno type="dclp-hybrid">mper.ns;29;31</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61722.xml
+++ b/DCLP/62/61722.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61722</idno>
             <idno type="LDAB">2874</idno>
             <idno type="filename">61722</idno>
-            <idno type="dclp-hybrid">mpern.s;29;35</idno>
+            <idno type="dclp-hybrid">mper.ns;29;35</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61731.xml
+++ b/DCLP/62/61731.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61731</idno>
             <idno type="LDAB">2883</idno>
             <idno type="filename">61731</idno>
-            <idno type="dclp-hybrid">mpern.s;29;10</idno>
+            <idno type="dclp-hybrid">mper.ns;29;10</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61732.xml
+++ b/DCLP/62/61732.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61732</idno>
             <idno type="LDAB">2884</idno>
             <idno type="filename">61732</idno>
-            <idno type="dclp-hybrid">mpern.s;29;4</idno>
+            <idno type="dclp-hybrid">mper.ns;29;4</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61759.xml
+++ b/DCLP/62/61759.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61759</idno>
             <idno type="LDAB">2911</idno>
             <idno type="filename">61759</idno>
-            <idno type="dclp-hybrid">mpern.s;29;26</idno>
+            <idno type="dclp-hybrid">mper.ns;29;26</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61762.xml
+++ b/DCLP/62/61762.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61762</idno>
             <idno type="LDAB">2914</idno>
             <idno type="filename">61762</idno>
-            <idno type="dclp-hybrid">mpern.s;29;25</idno>
+            <idno type="dclp-hybrid">mper.ns;29;25</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61799.xml
+++ b/DCLP/62/61799.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61799</idno>
             <idno type="LDAB">2952</idno>
             <idno type="filename">61799</idno>
-            <idno type="dclp-hybrid">mpern.s;29;23</idno>
+            <idno type="dclp-hybrid">mper.ns;29;23</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61832.xml
+++ b/DCLP/62/61832.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61832</idno>
             <idno type="LDAB">2986</idno>
             <idno type="filename">61832</idno>
-            <idno type="dclp-hybrid">mpern.s;29;58</idno>
+            <idno type="dclp-hybrid">mper.ns;29;58</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61864.xml
+++ b/DCLP/62/61864.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61864</idno>
             <idno type="LDAB">3021</idno>
             <idno type="filename">61864</idno>
-            <idno type="dclp-hybrid">mpern.s;29;57</idno>
+            <idno type="dclp-hybrid">mper.ns;29;57</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61865.xml
+++ b/DCLP/62/61865.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61865</idno>
             <idno type="LDAB">3022</idno>
             <idno type="filename">61865</idno>
-            <idno type="dclp-hybrid">mpern.s;29;48</idno>
+            <idno type="dclp-hybrid">mper.ns;29;48</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61870.xml
+++ b/DCLP/62/61870.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61870</idno>
             <idno type="LDAB">3027</idno>
             <idno type="filename">61870</idno>
-            <idno type="dclp-hybrid">mpern.s;29;49</idno>
+            <idno type="dclp-hybrid">mper.ns;29;49</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61882.xml
+++ b/DCLP/62/61882.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61882</idno>
             <idno type="LDAB">3039</idno>
             <idno type="filename">61882</idno>
-            <idno type="dclp-hybrid">mpern.s;29;56</idno>
+            <idno type="dclp-hybrid">mper.ns;29;56</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61883.xml
+++ b/DCLP/62/61883.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61883</idno>
             <idno type="LDAB">3040</idno>
             <idno type="filename">61883</idno>
-            <idno type="dclp-hybrid">mpern.s;29;55</idno>
+            <idno type="dclp-hybrid">mper.ns;29;55</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61884.xml
+++ b/DCLP/62/61884.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61884</idno>
             <idno type="LDAB">3041</idno>
             <idno type="filename">61884</idno>
-            <idno type="dclp-hybrid">mpern.s;29;46</idno>
+            <idno type="dclp-hybrid">mper.ns;29;46</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61888.xml
+++ b/DCLP/62/61888.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61888</idno>
             <idno type="LDAB">3045</idno>
             <idno type="filename">61888</idno>
-            <idno type="dclp-hybrid">mpern.s;29;52</idno>
+            <idno type="dclp-hybrid">mper.ns;29;52</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61892.xml
+++ b/DCLP/62/61892.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61892</idno>
             <idno type="LDAB">3049</idno>
             <idno type="filename">61892</idno>
-            <idno type="dclp-hybrid">mpern.s;29;53</idno>
+            <idno type="dclp-hybrid">mper.ns;29;53</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61893.xml
+++ b/DCLP/62/61893.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61893</idno>
             <idno type="LDAB">3050</idno>
             <idno type="filename">61893</idno>
-            <idno type="dclp-hybrid">mpern.s;29;50</idno>
+            <idno type="dclp-hybrid">mper.ns;29;50</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61895.xml
+++ b/DCLP/62/61895.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61895</idno>
             <idno type="LDAB">3052</idno>
             <idno type="filename">61895</idno>
-            <idno type="dclp-hybrid">mpern.s;29;51</idno>
+            <idno type="dclp-hybrid">mper.ns;29;51</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61903.xml
+++ b/DCLP/62/61903.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61903</idno>
             <idno type="LDAB">3060</idno>
             <idno type="filename">61903</idno>
-            <idno type="dclp-hybrid">mpern.s;29;20</idno>
+            <idno type="dclp-hybrid">mper.ns;29;20</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61909.xml
+++ b/DCLP/62/61909.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61909</idno>
             <idno type="LDAB">3066</idno>
             <idno type="filename">61909</idno>
-            <idno type="dclp-hybrid">mpern.s;29;54</idno>
+            <idno type="dclp-hybrid">mper.ns;29;54</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/62/61967.xml
+++ b/DCLP/62/61967.xml
@@ -12,7 +12,7 @@
             <idno type="TM">61967</idno>
             <idno type="LDAB">3125</idno>
             <idno type="filename">61967</idno>
-            <idno type="dclp-hybrid">mpern.s;4;12</idno>
+            <idno type="dclp-hybrid">mper.ns;4;12</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62033.xml
+++ b/DCLP/63/62033.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62033</idno>
             <idno type="LDAB">3192</idno>
             <idno type="filename">62033</idno>
-            <idno type="dclp-hybrid">mpern.s;4;9</idno>
+            <idno type="dclp-hybrid">mper.ns;4;9</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62034.xml
+++ b/DCLP/63/62034.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62034</idno>
             <idno type="LDAB">3193</idno>
             <idno type="filename">62034</idno>
-            <idno type="dclp-hybrid">mpern.s;4;6</idno>
+            <idno type="dclp-hybrid">mper.ns;4;6</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62093.xml
+++ b/DCLP/63/62093.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62093</idno>
             <idno type="LDAB">3253</idno>
             <idno type="filename">62093</idno>
-            <idno type="dclp-hybrid">mpern.s;4;1</idno>
+            <idno type="dclp-hybrid">mper.ns;4;1</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62094.xml
+++ b/DCLP/63/62094.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62094</idno>
             <idno type="LDAB">3254</idno>
             <idno type="filename">62094</idno>
-            <idno type="dclp-hybrid">mpern.s;4;2</idno>
+            <idno type="dclp-hybrid">mper.ns;4;2</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62095.xml
+++ b/DCLP/63/62095.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62095</idno>
             <idno type="LDAB">3255</idno>
             <idno type="filename">62095</idno>
-            <idno type="dclp-hybrid">mpern.s;4;28</idno>
+            <idno type="dclp-hybrid">mper.ns;4;28</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62096.xml
+++ b/DCLP/63/62096.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62096</idno>
             <idno type="LDAB">3256</idno>
             <idno type="filename">62096</idno>
-            <idno type="dclp-hybrid">mpern.s;4;15</idno>
+            <idno type="dclp-hybrid">mper.ns;4;15</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62097.xml
+++ b/DCLP/63/62097.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62097</idno>
             <idno type="LDAB">3257</idno>
             <idno type="filename">62097</idno>
-            <idno type="dclp-hybrid">mpern.s;4;26</idno>
+            <idno type="dclp-hybrid">mper.ns;4;26</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62098.xml
+++ b/DCLP/63/62098.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62098</idno>
             <idno type="LDAB">3258</idno>
             <idno type="filename">62098</idno>
-            <idno type="dclp-hybrid">mpern.s;4;3</idno>
+            <idno type="dclp-hybrid">mper.ns;4;3</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62129.xml
+++ b/DCLP/63/62129.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62129</idno>
             <idno type="LDAB">3289</idno>
             <idno type="filename">62129</idno>
-            <idno type="dclp-hybrid">mpern.s;4;31</idno>
+            <idno type="dclp-hybrid">mper.ns;4;31</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62130.xml
+++ b/DCLP/63/62130.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62130</idno>
             <idno type="LDAB">3290</idno>
             <idno type="filename">62130</idno>
-            <idno type="dclp-hybrid">mpern.s;4;29</idno>
+            <idno type="dclp-hybrid">mper.ns;4;29</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62131.xml
+++ b/DCLP/63/62131.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62131</idno>
             <idno type="LDAB">3291</idno>
             <idno type="filename">62131</idno>
-            <idno type="dclp-hybrid">mpern.s;4;11</idno>
+            <idno type="dclp-hybrid">mper.ns;4;11</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62132.xml
+++ b/DCLP/63/62132.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62132</idno>
             <idno type="LDAB">3292</idno>
             <idno type="filename">62132</idno>
-            <idno type="dclp-hybrid">mpern.s;4;20</idno>
+            <idno type="dclp-hybrid">mper.ns;4;20</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62133.xml
+++ b/DCLP/63/62133.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62133</idno>
             <idno type="LDAB">3293</idno>
             <idno type="filename">62133</idno>
-            <idno type="dclp-hybrid">mpern.s;4;30</idno>
+            <idno type="dclp-hybrid">mper.ns;4;30</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62136.xml
+++ b/DCLP/63/62136.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62136</idno>
             <idno type="LDAB">3296</idno>
             <idno type="filename">62136</idno>
-            <idno type="dclp-hybrid">mpern.s;4;27</idno>
+            <idno type="dclp-hybrid">mper.ns;4;27</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62137.xml
+++ b/DCLP/63/62137.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62137</idno>
             <idno type="LDAB">3297</idno>
             <idno type="filename">62137</idno>
-            <idno type="dclp-hybrid">mpern.s;4;25</idno>
+            <idno type="dclp-hybrid">mper.ns;4;25</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62185.xml
+++ b/DCLP/63/62185.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62185</idno>
             <idno type="LDAB">3345</idno>
             <idno type="filename">62185</idno>
-            <idno type="dclp-hybrid">mpern.s;17;2</idno>
+            <idno type="dclp-hybrid">mper.ns;17;2</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62186.xml
+++ b/DCLP/63/62186.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62186</idno>
             <idno type="LDAB">3346</idno>
             <idno type="filename">62186</idno>
-            <idno type="dclp-hybrid">mpern.s;4;4</idno>
+            <idno type="dclp-hybrid">mper.ns;4;4</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62189.xml
+++ b/DCLP/63/62189.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62189</idno>
             <idno type="LDAB">3349</idno>
             <idno type="filename">62189</idno>
-            <idno type="dclp-hybrid">mpern.s;4;17</idno>
+            <idno type="dclp-hybrid">mper.ns;4;17</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62190.xml
+++ b/DCLP/63/62190.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62190</idno>
             <idno type="LDAB">3350</idno>
             <idno type="filename">62190</idno>
-            <idno type="dclp-hybrid">mpern.s;4;23</idno>
+            <idno type="dclp-hybrid">mper.ns;4;23</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62192.xml
+++ b/DCLP/63/62192.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62192</idno>
             <idno type="LDAB">3352</idno>
             <idno type="filename">62192</idno>
-            <idno type="dclp-hybrid">mpern.s;4;19</idno>
+            <idno type="dclp-hybrid">mper.ns;4;19</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62223.xml
+++ b/DCLP/63/62223.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62223</idno>
             <idno type="LDAB">3383</idno>
             <idno type="filename">62223</idno>
-            <idno type="dclp-hybrid">mpern.s;4;8</idno>
+            <idno type="dclp-hybrid">mper.ns;4;8</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62224.xml
+++ b/DCLP/63/62224.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62224</idno>
             <idno type="LDAB">3384</idno>
             <idno type="filename">62224</idno>
-            <idno type="dclp-hybrid">mpern.s;4;22</idno>
+            <idno type="dclp-hybrid">mper.ns;4;22</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62226.xml
+++ b/DCLP/63/62226.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62226</idno>
             <idno type="LDAB">3386</idno>
             <idno type="filename">62226</idno>
-            <idno type="dclp-hybrid">mpern.s;17;8</idno>
+            <idno type="dclp-hybrid">mper.ns;17;8</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62228.xml
+++ b/DCLP/63/62228.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62228</idno>
             <idno type="LDAB">3388</idno>
             <idno type="filename">62228</idno>
-            <idno type="dclp-hybrid">mpern.s;17;1</idno>
+            <idno type="dclp-hybrid">mper.ns;17;1</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62229.xml
+++ b/DCLP/63/62229.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62229</idno>
             <idno type="LDAB">3389</idno>
             <idno type="filename">62229</idno>
-            <idno type="dclp-hybrid">mpern.s;4;13</idno>
+            <idno type="dclp-hybrid">mper.ns;4;13</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62230.xml
+++ b/DCLP/63/62230.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62230</idno>
             <idno type="LDAB">3390</idno>
             <idno type="filename">62230</idno>
-            <idno type="dclp-hybrid">mpern.s;4;21</idno>
+            <idno type="dclp-hybrid">mper.ns;4;21</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62231.xml
+++ b/DCLP/63/62231.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62231</idno>
             <idno type="LDAB">3391</idno>
             <idno type="filename">62231</idno>
-            <idno type="dclp-hybrid">mpern.s;17;3</idno>
+            <idno type="dclp-hybrid">mper.ns;17;3</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62248.xml
+++ b/DCLP/63/62248.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62248</idno>
             <idno type="LDAB">3408</idno>
             <idno type="filename">62248</idno>
-            <idno type="dclp-hybrid">mpern.s;4;14</idno>
+            <idno type="dclp-hybrid">mper.ns;4;14</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62250.xml
+++ b/DCLP/63/62250.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62250</idno>
             <idno type="LDAB">3410</idno>
             <idno type="filename">62250</idno>
-            <idno type="dclp-hybrid">mpern.s;4;10</idno>
+            <idno type="dclp-hybrid">mper.ns;4;10</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62251.xml
+++ b/DCLP/63/62251.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62251</idno>
             <idno type="LDAB">3411</idno>
             <idno type="filename">62251</idno>
-            <idno type="dclp-hybrid">mpern.s;4;16</idno>
+            <idno type="dclp-hybrid">mper.ns;4;16</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62277.xml
+++ b/DCLP/63/62277.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62277</idno>
             <idno type="LDAB">3438</idno>
             <idno type="filename">62277</idno>
-            <idno type="dclp-hybrid">mpern.s;4;7</idno>
+            <idno type="dclp-hybrid">mper.ns;4;7</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62278.xml
+++ b/DCLP/63/62278.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62278</idno>
             <idno type="LDAB">3439</idno>
             <idno type="filename">62278</idno>
-            <idno type="dclp-hybrid">mpern.s;17;5</idno>
+            <idno type="dclp-hybrid">mper.ns;17;5</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62280.xml
+++ b/DCLP/63/62280.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62280</idno>
             <idno type="LDAB">3441</idno>
             <idno type="filename">62280</idno>
-            <idno type="dclp-hybrid">mpern.s;17;6</idno>
+            <idno type="dclp-hybrid">mper.ns;17;6</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62285.xml
+++ b/DCLP/63/62285.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62285</idno>
             <idno type="LDAB">3446</idno>
             <idno type="filename">62285</idno>
-            <idno type="dclp-hybrid">mpern.s;17;4</idno>
+            <idno type="dclp-hybrid">mper.ns;17;4</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62343.xml
+++ b/DCLP/63/62343.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62343</idno>
             <idno type="LDAB">3507</idno>
             <idno type="filename">62343</idno>
-            <idno type="dclp-hybrid">mpern.s;4;51</idno>
+            <idno type="dclp-hybrid">mper.ns;4;51</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62559.xml
+++ b/DCLP/63/62559.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62559</idno>
             <idno type="LDAB">3741</idno>
             <idno type="filename">62559</idno>
-            <idno type="dclp-hybrid">mpern.s;1;23</idno>
+            <idno type="dclp-hybrid">mper.ns;1;23</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62669.xml
+++ b/DCLP/63/62669.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62669</idno>
             <idno type="LDAB">3857</idno>
             <idno type="filename">62669</idno>
-            <idno type="dclp-hybrid">mpern.s;3;35</idno>
+            <idno type="dclp-hybrid">mper.ns;3;35</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62684.xml
+++ b/DCLP/63/62684.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62684</idno>
             <idno type="LDAB">3872</idno>
             <idno type="filename">62684</idno>
-            <idno type="dclp-hybrid">mpern.s;3;41</idno>
+            <idno type="dclp-hybrid">mper.ns;3;41</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62720.xml
+++ b/DCLP/63/62720.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62720</idno>
             <idno type="LDAB">3908</idno>
             <idno type="filename">62720</idno>
-            <idno type="dclp-hybrid">mpern.s;17;12</idno>
+            <idno type="dclp-hybrid">mper.ns;17;12</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/63/62760.xml
+++ b/DCLP/63/62760.xml
@@ -12,7 +12,7 @@
             <idno type="TM">62760</idno>
             <idno type="LDAB">3948</idno>
             <idno type="filename">62760</idno>
-            <idno type="dclp-hybrid">mpern.s;1;24</idno>
+            <idno type="dclp-hybrid">mper.ns;1;24</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63193.xml
+++ b/DCLP/64/63193.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63193</idno>
             <idno type="LDAB">4398</idno>
             <idno type="filename">63193</idno>
-            <idno type="dclp-hybrid">mpern.s;1;22</idno>
+            <idno type="dclp-hybrid">mper.ns;1;22</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63196.xml
+++ b/DCLP/64/63196.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63196</idno>
             <idno type="LDAB">4401</idno>
             <idno type="filename">63196</idno>
-            <idno type="dclp-hybrid">mpern.s;3;29</idno>
+            <idno type="dclp-hybrid">mper.ns;3;29</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63197.xml
+++ b/DCLP/64/63197.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63197</idno>
             <idno type="LDAB">4402</idno>
             <idno type="filename">63197</idno>
-            <idno type="dclp-hybrid">mpern.s;3;27</idno>
+            <idno type="dclp-hybrid">mper.ns;3;27</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63198.xml
+++ b/DCLP/64/63198.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63198</idno>
             <idno type="LDAB">4403</idno>
             <idno type="filename">63198</idno>
-            <idno type="dclp-hybrid">mpern.s;3;28</idno>
+            <idno type="dclp-hybrid">mper.ns;3;28</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63199.xml
+++ b/DCLP/64/63199.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63199</idno>
             <idno type="LDAB">4404</idno>
             <idno type="filename">63199</idno>
-            <idno type="dclp-hybrid">mpern.s;1;18</idno>
+            <idno type="dclp-hybrid">mper.ns;1;18</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63201.xml
+++ b/DCLP/64/63201.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63201</idno>
             <idno type="LDAB">4406</idno>
             <idno type="filename">63201</idno>
-            <idno type="dclp-hybrid">mpern.s;3;31</idno>
+            <idno type="dclp-hybrid">mper.ns;3;31</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63202.xml
+++ b/DCLP/64/63202.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63202</idno>
             <idno type="LDAB">4407</idno>
             <idno type="filename">63202</idno>
-            <idno type="dclp-hybrid">mpern.s;3;30</idno>
+            <idno type="dclp-hybrid">mper.ns;3;30</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63308.xml
+++ b/DCLP/64/63308.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63308</idno>
             <idno type="LDAB">4514</idno>
             <idno type="filename">63308</idno>
-            <idno type="dclp-hybrid">mpern.s;3;26</idno>
+            <idno type="dclp-hybrid">mper.ns;3;26</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63309.xml
+++ b/DCLP/64/63309.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63309</idno>
             <idno type="LDAB">4515</idno>
             <idno type="filename">63309</idno>
-            <idno type="dclp-hybrid">mpern.s;1;27</idno>
+            <idno type="dclp-hybrid">mper.ns;1;27</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63723.xml
+++ b/DCLP/64/63723.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63723</idno>
             <idno type="LDAB">4934</idno>
             <idno type="filename">63723</idno>
-            <idno type="dclp-hybrid">mpern.s;1;32</idno>
+            <idno type="dclp-hybrid">mper.ns;1;32</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63724.xml
+++ b/DCLP/64/63724.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63724</idno>
             <idno type="LDAB">4935</idno>
             <idno type="filename">63724</idno>
-            <idno type="dclp-hybrid">mpern.s;3;53</idno>
+            <idno type="dclp-hybrid">mper.ns;3;53</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63725.xml
+++ b/DCLP/64/63725.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63725</idno>
             <idno type="LDAB">4936</idno>
             <idno type="filename">63725</idno>
-            <idno type="dclp-hybrid">mpern.s;3;48</idno>
+            <idno type="dclp-hybrid">mper.ns;3;48</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/64/63931.xml
+++ b/DCLP/64/63931.xml
@@ -12,7 +12,7 @@
             <idno type="TM">63931</idno>
             <idno type="LDAB">5146</idno>
             <idno type="filename">63931</idno>
-            <idno type="dclp-hybrid">mpern.s;3;15</idno>
+            <idno type="dclp-hybrid">mper.ns;3;15</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64092.xml
+++ b/DCLP/65/64092.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64092</idno>
             <idno type="LDAB">5310</idno>
             <idno type="filename">64092</idno>
-            <idno type="dclp-hybrid">mpern.s;1;14</idno>
+            <idno type="dclp-hybrid">mper.ns;1;14</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64243.xml
+++ b/DCLP/65/64243.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64243</idno>
             <idno type="LDAB">5462</idno>
             <idno type="filename">64243</idno>
-            <idno type="dclp-hybrid">mpern.s;29;62</idno>
+            <idno type="dclp-hybrid">mper.ns;29;62</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64246.xml
+++ b/DCLP/65/64246.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64246</idno>
             <idno type="LDAB">5466</idno>
             <idno type="filename">64246</idno>
-            <idno type="dclp-hybrid">mpern.s;3;44</idno>
+            <idno type="dclp-hybrid">mper.ns;3;44</idno>
             <idno type="MP3">02461.000</idno>
             <availability>
                <p>

--- a/DCLP/65/64248.xml
+++ b/DCLP/65/64248.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64248</idno>
             <idno type="LDAB">5468</idno>
             <idno type="filename">64248</idno>
-            <idno type="dclp-hybrid">mpern.s;3;10</idno>
+            <idno type="dclp-hybrid">mper.ns;3;10</idno>
             <idno type="MP3">01790.000</idno>
             <availability>
                <p>

--- a/DCLP/65/64249.xml
+++ b/DCLP/65/64249.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64249</idno>
             <idno type="LDAB">5469</idno>
             <idno type="filename">64249</idno>
-            <idno type="dclp-hybrid">mpern.s;1;26</idno>
+            <idno type="dclp-hybrid">mper.ns;1;26</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64353.xml
+++ b/DCLP/65/64353.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64353</idno>
             <idno type="LDAB">5575</idno>
             <idno type="filename">64353</idno>
-            <idno type="dclp-hybrid">mpern.s;13;5</idno>
+            <idno type="dclp-hybrid">mper.ns;13;5</idno>
             <idno type="MP3">02422.600</idno>
             <availability>
                <p>

--- a/DCLP/65/64356.xml
+++ b/DCLP/65/64356.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64356</idno>
             <idno type="LDAB">5578</idno>
             <idno type="filename">64356</idno>
-            <idno type="dclp-hybrid">mpern.s;3;14</idno>
+            <idno type="dclp-hybrid">mper.ns;3;14</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64357.xml
+++ b/DCLP/65/64357.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64357</idno>
             <idno type="LDAB">5579</idno>
             <idno type="filename">64357</idno>
-            <idno type="dclp-hybrid">mpern.s;3;54</idno>
+            <idno type="dclp-hybrid">mper.ns;3;54</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64523.xml
+++ b/DCLP/65/64523.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64523</idno>
             <idno type="LDAB">5750</idno>
             <idno type="filename">64523</idno>
-            <idno type="dclp-hybrid">mpern.s;3;50</idno>
+            <idno type="dclp-hybrid">mper.ns;3;50</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64524.xml
+++ b/DCLP/65/64524.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64524</idno>
             <idno type="LDAB">5751</idno>
             <idno type="filename">64524</idno>
-            <idno type="dclp-hybrid">mpern.s;3;57</idno>
+            <idno type="dclp-hybrid">mper.ns;3;57</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64525.xml
+++ b/DCLP/65/64525.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64525</idno>
             <idno type="LDAB">5752</idno>
             <idno type="filename">64525</idno>
-            <idno type="dclp-hybrid">mpern.s;3;7</idno>
+            <idno type="dclp-hybrid">mper.ns;3;7</idno>
             <idno type="MP3">02423.500</idno>
             <availability>
                <p>

--- a/DCLP/65/64618.xml
+++ b/DCLP/65/64618.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64618</idno>
             <idno type="LDAB">5848</idno>
             <idno type="filename">64618</idno>
-            <idno type="dclp-hybrid">mpern.s;17;75</idno>
+            <idno type="dclp-hybrid">mper.ns;17;75</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64619.xml
+++ b/DCLP/65/64619.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64619</idno>
             <idno type="LDAB">5849</idno>
             <idno type="filename">64619</idno>
-            <idno type="dclp-hybrid">mpern.s;3;12</idno>
+            <idno type="dclp-hybrid">mper.ns;3;12</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64621.xml
+++ b/DCLP/65/64621.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64621</idno>
             <idno type="LDAB">5852</idno>
             <idno type="filename">64621</idno>
-            <idno type="dclp-hybrid">mpern.s;3;55</idno>
+            <idno type="dclp-hybrid">mper.ns;3;55</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64782.xml
+++ b/DCLP/65/64782.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64782</idno>
             <idno type="LDAB">6020</idno>
             <idno type="filename">64782</idno>
-            <idno type="dclp-hybrid">mpern.s;3;39</idno>
+            <idno type="dclp-hybrid">mper.ns;3;39</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64785.xml
+++ b/DCLP/65/64785.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64785</idno>
             <idno type="LDAB">6023</idno>
             <idno type="filename">64785</idno>
-            <idno type="dclp-hybrid">mpern.s;3;46</idno>
+            <idno type="dclp-hybrid">mper.ns;3;46</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64793.xml
+++ b/DCLP/65/64793.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64793</idno>
             <idno type="LDAB">6031</idno>
             <idno type="filename">64793</idno>
-            <idno type="dclp-hybrid">mpern.s;13;8</idno>
+            <idno type="dclp-hybrid">mper.ns;13;8</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64794.xml
+++ b/DCLP/65/64794.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64794</idno>
             <idno type="LDAB">6032</idno>
             <idno type="filename">64794</idno>
-            <idno type="dclp-hybrid">mpern.s;1;21</idno>
+            <idno type="dclp-hybrid">mper.ns;1;21</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64795.xml
+++ b/DCLP/65/64795.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64795</idno>
             <idno type="LDAB">6033</idno>
             <idno type="filename">64795</idno>
-            <idno type="dclp-hybrid">mpern.s;13;9</idno>
+            <idno type="dclp-hybrid">mper.ns;13;9</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64796.xml
+++ b/DCLP/65/64796.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64796</idno>
             <idno type="LDAB">6034</idno>
             <idno type="filename">64796</idno>
-            <idno type="dclp-hybrid">mpern.s;3;58</idno>
+            <idno type="dclp-hybrid">mper.ns;3;58</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64797.xml
+++ b/DCLP/65/64797.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64797</idno>
             <idno type="LDAB">6035</idno>
             <idno type="filename">64797</idno>
-            <idno type="dclp-hybrid">mpern.s;3;38</idno>
+            <idno type="dclp-hybrid">mper.ns;3;38</idno>
             <idno type="MP3">02286.000</idno>
             <availability>
                <p>

--- a/DCLP/65/64798.xml
+++ b/DCLP/65/64798.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64798</idno>
             <idno type="LDAB">6036</idno>
             <idno type="filename">64798</idno>
-            <idno type="dclp-hybrid">mpern.s;1;35</idno>
+            <idno type="dclp-hybrid">mper.ns;1;35</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64800.xml
+++ b/DCLP/65/64800.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64800</idno>
             <idno type="LDAB">6038</idno>
             <idno type="filename">64800</idno>
-            <idno type="dclp-hybrid">mpern.s;17;80</idno>
+            <idno type="dclp-hybrid">mper.ns;17;80</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64801.xml
+++ b/DCLP/65/64801.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64801</idno>
             <idno type="LDAB">6039</idno>
             <idno type="filename">64801</idno>
-            <idno type="dclp-hybrid">mpern.s;13;10</idno>
+            <idno type="dclp-hybrid">mper.ns;13;10</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64807.xml
+++ b/DCLP/65/64807.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64807</idno>
             <idno type="LDAB">6045</idno>
             <idno type="filename">64807</idno>
-            <idno type="dclp-hybrid">mpern.s;4;59</idno>
+            <idno type="dclp-hybrid">mper.ns;4;59</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64921.xml
+++ b/DCLP/65/64921.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64921</idno>
             <idno type="LDAB">6160</idno>
             <idno type="filename">64921</idno>
-            <idno type="dclp-hybrid">mpern.s;17;60</idno>
+            <idno type="dclp-hybrid">mper.ns;17;60</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64926.xml
+++ b/DCLP/65/64926.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64926</idno>
             <idno type="LDAB">6165</idno>
             <idno type="filename">64926</idno>
-            <idno type="dclp-hybrid">mpern.s;17;50</idno>
+            <idno type="dclp-hybrid">mper.ns;17;50</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64927.xml
+++ b/DCLP/65/64927.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64927</idno>
             <idno type="LDAB">6166</idno>
             <idno type="filename">64927</idno>
-            <idno type="dclp-hybrid">mpern.s;17;69</idno>
+            <idno type="dclp-hybrid">mper.ns;17;69</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64928.xml
+++ b/DCLP/65/64928.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64928</idno>
             <idno type="LDAB">6167</idno>
             <idno type="filename">64928</idno>
-            <idno type="dclp-hybrid">mpern.s;3;51</idno>
+            <idno type="dclp-hybrid">mper.ns;3;51</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64929.xml
+++ b/DCLP/65/64929.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64929</idno>
             <idno type="LDAB">6168</idno>
             <idno type="filename">64929</idno>
-            <idno type="dclp-hybrid">mpern.s;17;70</idno>
+            <idno type="dclp-hybrid">mper.ns;17;70</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64930.xml
+++ b/DCLP/65/64930.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64930</idno>
             <idno type="LDAB">6169</idno>
             <idno type="filename">64930</idno>
-            <idno type="dclp-hybrid">mpern.s;17;48</idno>
+            <idno type="dclp-hybrid">mper.ns;17;48</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64931.xml
+++ b/DCLP/65/64931.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64931</idno>
             <idno type="LDAB">6170</idno>
             <idno type="filename">64931</idno>
-            <idno type="dclp-hybrid">mpern.s;17;39</idno>
+            <idno type="dclp-hybrid">mper.ns;17;39</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64932.xml
+++ b/DCLP/65/64932.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64932</idno>
             <idno type="LDAB">6173</idno>
             <idno type="filename">64932</idno>
-            <idno type="dclp-hybrid">mpern.s;17;72</idno>
+            <idno type="dclp-hybrid">mper.ns;17;72</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64934.xml
+++ b/DCLP/65/64934.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64934</idno>
             <idno type="LDAB">6175</idno>
             <idno type="filename">64934</idno>
-            <idno type="dclp-hybrid">mpern.s;17;63</idno>
+            <idno type="dclp-hybrid">mper.ns;17;63</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64935.xml
+++ b/DCLP/65/64935.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64935</idno>
             <idno type="LDAB">6176</idno>
             <idno type="filename">64935</idno>
-            <idno type="dclp-hybrid">mpern.s;17;59</idno>
+            <idno type="dclp-hybrid">mper.ns;17;59</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64936.xml
+++ b/DCLP/65/64936.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64936</idno>
             <idno type="LDAB">6177</idno>
             <idno type="filename">64936</idno>
-            <idno type="dclp-hybrid">mpern.s;3;61</idno>
+            <idno type="dclp-hybrid">mper.ns;3;61</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64937.xml
+++ b/DCLP/65/64937.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64937</idno>
             <idno type="LDAB">6178</idno>
             <idno type="filename">64937</idno>
-            <idno type="dclp-hybrid">mpern.s;17;81</idno>
+            <idno type="dclp-hybrid">mper.ns;17;81</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64940.xml
+++ b/DCLP/65/64940.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64940</idno>
             <idno type="LDAB">6181</idno>
             <idno type="filename">64940</idno>
-            <idno type="dclp-hybrid">mpern.s;1;20</idno>
+            <idno type="dclp-hybrid">mper.ns;1;20</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64941.xml
+++ b/DCLP/65/64941.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64941</idno>
             <idno type="LDAB">6182</idno>
             <idno type="filename">64941</idno>
-            <idno type="dclp-hybrid">mpern.s;1;15</idno>
+            <idno type="dclp-hybrid">mper.ns;1;15</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/65/64943.xml
+++ b/DCLP/65/64943.xml
@@ -12,7 +12,7 @@
             <idno type="TM">64943</idno>
             <idno type="LDAB">6184</idno>
             <idno type="filename">64943</idno>
-            <idno type="dclp-hybrid">mpern.s;4;56</idno>
+            <idno type="dclp-hybrid">mper.ns;4;56</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65116.xml
+++ b/DCLP/66/65116.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65116</idno>
             <idno type="LDAB">6357</idno>
             <idno type="filename">65116</idno>
-            <idno type="dclp-hybrid">mpern.s;17;33</idno>
+            <idno type="dclp-hybrid">mper.ns;17;33</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65121.xml
+++ b/DCLP/66/65121.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65121</idno>
             <idno type="LDAB">6362</idno>
             <idno type="filename">65121</idno>
-            <idno type="dclp-hybrid">mpern.s;17;66</idno>
+            <idno type="dclp-hybrid">mper.ns;17;66</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65122.xml
+++ b/DCLP/66/65122.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65122</idno>
             <idno type="LDAB">6363</idno>
             <idno type="filename">65122</idno>
-            <idno type="dclp-hybrid">mpern.s;17;67</idno>
+            <idno type="dclp-hybrid">mper.ns;17;67</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65124.xml
+++ b/DCLP/66/65124.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65124</idno>
             <idno type="LDAB">6365</idno>
             <idno type="filename">65124</idno>
-            <idno type="dclp-hybrid">mpern.s;17;13</idno>
+            <idno type="dclp-hybrid">mper.ns;17;13</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65125.xml
+++ b/DCLP/66/65125.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65125</idno>
             <idno type="LDAB">6366</idno>
             <idno type="filename">65125</idno>
-            <idno type="dclp-hybrid">mpern.s;17;31</idno>
+            <idno type="dclp-hybrid">mper.ns;17;31</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65126.xml
+++ b/DCLP/66/65126.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65126</idno>
             <idno type="LDAB">6367</idno>
             <idno type="filename">65126</idno>
-            <idno type="dclp-hybrid">mpern.s;17;61</idno>
+            <idno type="dclp-hybrid">mper.ns;17;61</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65127.xml
+++ b/DCLP/66/65127.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65127</idno>
             <idno type="LDAB">6368</idno>
             <idno type="filename">65127</idno>
-            <idno type="dclp-hybrid">mpern.s;17;78</idno>
+            <idno type="dclp-hybrid">mper.ns;17;78</idno>
             <availability>
                <p>
             © Digital Corpus of Literary Papyri. This work is licensed under a

--- a/DCLP/66/65134.xml
+++ b/DCLP/66/65134.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65134</idno>
             <idno type="LDAB">6375</idno>
             <idno type="filename">65134</idno>
-            <idno type="dclp-hybrid">mpern.s;3;37</idno>
+            <idno type="dclp-hybrid">mper.ns;3;37</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65135.xml
+++ b/DCLP/66/65135.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65135</idno>
             <idno type="LDAB">6376</idno>
             <idno type="filename">65135</idno>
-            <idno type="dclp-hybrid">mpern.s;17;35</idno>
+            <idno type="dclp-hybrid">mper.ns;17;35</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65137.xml
+++ b/DCLP/66/65137.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65137</idno>
             <idno type="LDAB">6378</idno>
             <idno type="filename">65137</idno>
-            <idno type="dclp-hybrid">mpern.s;17;43</idno>
+            <idno type="dclp-hybrid">mper.ns;17;43</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65138.xml
+++ b/DCLP/66/65138.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65138</idno>
             <idno type="LDAB">6379</idno>
             <idno type="filename">65138</idno>
-            <idno type="dclp-hybrid">mpern.s;17;62</idno>
+            <idno type="dclp-hybrid">mper.ns;17;62</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65139.xml
+++ b/DCLP/66/65139.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65139</idno>
             <idno type="LDAB">6380</idno>
             <idno type="filename">65139</idno>
-            <idno type="dclp-hybrid">mpern.s;4;57</idno>
+            <idno type="dclp-hybrid">mper.ns;4;57</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65140.xml
+++ b/DCLP/66/65140.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65140</idno>
             <idno type="LDAB">6381</idno>
             <idno type="filename">65140</idno>
-            <idno type="dclp-hybrid">mpern.s;3;43</idno>
+            <idno type="dclp-hybrid">mper.ns;3;43</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65141.xml
+++ b/DCLP/66/65141.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65141</idno>
             <idno type="LDAB">6382</idno>
             <idno type="filename">65141</idno>
-            <idno type="dclp-hybrid">mpern.s;3;59</idno>
+            <idno type="dclp-hybrid">mper.ns;3;59</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65143.xml
+++ b/DCLP/66/65143.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65143</idno>
             <idno type="LDAB">6384</idno>
             <idno type="filename">65143</idno>
-            <idno type="dclp-hybrid">mpern.s;3;13</idno>
+            <idno type="dclp-hybrid">mper.ns;3;13</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65150.xml
+++ b/DCLP/66/65150.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65150</idno>
             <idno type="LDAB">6392</idno>
             <idno type="filename">65150</idno>
-            <idno type="dclp-hybrid">mpern.s;17;36</idno>
+            <idno type="dclp-hybrid">mper.ns;17;36</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65258.xml
+++ b/DCLP/66/65258.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65258</idno>
             <idno type="LDAB">6501</idno>
             <idno type="filename">65258</idno>
-            <idno type="dclp-hybrid">mpern.s;17;49</idno>
+            <idno type="dclp-hybrid">mper.ns;17;49</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65259.xml
+++ b/DCLP/66/65259.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65259</idno>
             <idno type="LDAB">6502</idno>
             <idno type="filename">65259</idno>
-            <idno type="dclp-hybrid">mpern.s;17;29</idno>
+            <idno type="dclp-hybrid">mper.ns;17;29</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65262.xml
+++ b/DCLP/66/65262.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65262</idno>
             <idno type="LDAB">6505</idno>
             <idno type="filename">65262</idno>
-            <idno type="dclp-hybrid">mpern.s;17;46</idno>
+            <idno type="dclp-hybrid">mper.ns;17;46</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65269.xml
+++ b/DCLP/66/65269.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65269</idno>
             <idno type="LDAB">6512</idno>
             <idno type="filename">65269</idno>
-            <idno type="dclp-hybrid">mpern.s;17;54</idno>
+            <idno type="dclp-hybrid">mper.ns;17;54</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65271.xml
+++ b/DCLP/66/65271.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65271</idno>
             <idno type="LDAB">6514</idno>
             <idno type="filename">65271</idno>
-            <idno type="dclp-hybrid">mpern.s;17;73</idno>
+            <idno type="dclp-hybrid">mper.ns;17;73</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65272.xml
+++ b/DCLP/66/65272.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65272</idno>
             <idno type="LDAB">6515</idno>
             <idno type="filename">65272</idno>
-            <idno type="dclp-hybrid">mpern.s;3;45</idno>
+            <idno type="dclp-hybrid">mper.ns;3;45</idno>
             <idno type="MP3">02868.000</idno>
             <availability>
                <p>

--- a/DCLP/66/65274.xml
+++ b/DCLP/66/65274.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65274</idno>
             <idno type="LDAB">6517</idno>
             <idno type="filename">65274</idno>
-            <idno type="dclp-hybrid">mpern.s;17;40</idno>
+            <idno type="dclp-hybrid">mper.ns;17;40</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65276.xml
+++ b/DCLP/66/65276.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65276</idno>
             <idno type="LDAB">6519</idno>
             <idno type="filename">65276</idno>
-            <idno type="dclp-hybrid">mpern.s;13;12</idno>
+            <idno type="dclp-hybrid">mper.ns;13;12</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65277.xml
+++ b/DCLP/66/65277.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65277</idno>
             <idno type="LDAB">6520</idno>
             <idno type="filename">65277</idno>
-            <idno type="dclp-hybrid">mpern.s;4;55</idno>
+            <idno type="dclp-hybrid">mper.ns;4;55</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65285.xml
+++ b/DCLP/66/65285.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65285</idno>
             <idno type="LDAB">6528</idno>
             <idno type="filename">65285</idno>
-            <idno type="dclp-hybrid">mpern.s;17;47</idno>
+            <idno type="dclp-hybrid">mper.ns;17;47</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65287.xml
+++ b/DCLP/66/65287.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65287</idno>
             <idno type="LDAB">6530</idno>
             <idno type="filename">65287</idno>
-            <idno type="dclp-hybrid">mpern.s;17;44</idno>
+            <idno type="dclp-hybrid">mper.ns;17;44</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65355.xml
+++ b/DCLP/66/65355.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65355</idno>
             <idno type="LDAB">6601</idno>
             <idno type="filename">65355</idno>
-            <idno type="dclp-hybrid">mpern.s;17;79</idno>
+            <idno type="dclp-hybrid">mper.ns;17;79</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65361.xml
+++ b/DCLP/66/65361.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65361</idno>
             <idno type="LDAB">6606</idno>
             <idno type="filename">65361</idno>
-            <idno type="dclp-hybrid">mpern.s;17;74</idno>
+            <idno type="dclp-hybrid">mper.ns;17;74</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65376.xml
+++ b/DCLP/66/65376.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65376</idno>
             <idno type="LDAB">6622</idno>
             <idno type="filename">65376</idno>
-            <idno type="dclp-hybrid">mpern.s;17;38</idno>
+            <idno type="dclp-hybrid">mper.ns;17;38</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65377.xml
+++ b/DCLP/66/65377.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65377</idno>
             <idno type="LDAB">6623</idno>
             <idno type="filename">65377</idno>
-            <idno type="dclp-hybrid">mpern.s;13;14</idno>
+            <idno type="dclp-hybrid">mper.ns;13;14</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65379.xml
+++ b/DCLP/66/65379.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65379</idno>
             <idno type="LDAB">6625</idno>
             <idno type="filename">65379</idno>
-            <idno type="dclp-hybrid">mpern.s;17;45</idno>
+            <idno type="dclp-hybrid">mper.ns;17;45</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65387.xml
+++ b/DCLP/66/65387.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65387</idno>
             <idno type="LDAB">6634</idno>
             <idno type="filename">65387</idno>
-            <idno type="dclp-hybrid">mpern.s;17;77</idno>
+            <idno type="dclp-hybrid">mper.ns;17;77</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65473.xml
+++ b/DCLP/66/65473.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65473</idno>
             <idno type="LDAB">6721</idno>
             <idno type="filename">65473</idno>
-            <idno type="dclp-hybrid">mpern.s;17;57</idno>
+            <idno type="dclp-hybrid">mper.ns;17;57</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65474.xml
+++ b/DCLP/66/65474.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65474</idno>
             <idno type="LDAB">6722</idno>
             <idno type="filename">65474</idno>
-            <idno type="dclp-hybrid">mpern.s;17;55</idno>
+            <idno type="dclp-hybrid">mper.ns;17;55</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65475.xml
+++ b/DCLP/66/65475.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65475</idno>
             <idno type="LDAB">6723</idno>
             <idno type="filename">65475</idno>
-            <idno type="dclp-hybrid">mpern.s;17;34</idno>
+            <idno type="dclp-hybrid">mper.ns;17;34</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65477.xml
+++ b/DCLP/66/65477.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65477</idno>
             <idno type="LDAB">6725</idno>
             <idno type="filename">65477</idno>
-            <idno type="dclp-hybrid">mpern.s;17;37</idno>
+            <idno type="dclp-hybrid">mper.ns;17;37</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65479.xml
+++ b/DCLP/66/65479.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65479</idno>
             <idno type="LDAB">6728</idno>
             <idno type="filename">65479</idno>
-            <idno type="dclp-hybrid">mpern.s;17;68</idno>
+            <idno type="dclp-hybrid">mper.ns;17;68</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65480.xml
+++ b/DCLP/66/65480.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65480</idno>
             <idno type="LDAB">6729</idno>
             <idno type="filename">65480</idno>
-            <idno type="dclp-hybrid">mpern.s;17;56</idno>
+            <idno type="dclp-hybrid">mper.ns;17;56</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65481.xml
+++ b/DCLP/66/65481.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65481</idno>
             <idno type="LDAB">6730</idno>
             <idno type="filename">65481</idno>
-            <idno type="dclp-hybrid">mpern.s;17;27</idno>
+            <idno type="dclp-hybrid">mper.ns;17;27</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65482.xml
+++ b/DCLP/66/65482.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65482</idno>
             <idno type="LDAB">6731</idno>
             <idno type="filename">65482</idno>
-            <idno type="dclp-hybrid">mpern.s;17;42</idno>
+            <idno type="dclp-hybrid">mper.ns;17;42</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65483.xml
+++ b/DCLP/66/65483.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65483</idno>
             <idno type="LDAB">6732</idno>
             <idno type="filename">65483</idno>
-            <idno type="dclp-hybrid">mpern.s;17;71</idno>
+            <idno type="dclp-hybrid">mper.ns;17;71</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65490.xml
+++ b/DCLP/66/65490.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65490</idno>
             <idno type="LDAB">6740</idno>
             <idno type="filename">65490</idno>
-            <idno type="dclp-hybrid">mpern.s;17;64</idno>
+            <idno type="dclp-hybrid">mper.ns;17;64</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65491.xml
+++ b/DCLP/66/65491.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65491</idno>
             <idno type="LDAB">6741</idno>
             <idno type="filename">65491</idno>
-            <idno type="dclp-hybrid">mpern.s;17;65</idno>
+            <idno type="dclp-hybrid">mper.ns;17;65</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65492.xml
+++ b/DCLP/66/65492.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65492</idno>
             <idno type="LDAB">6742</idno>
             <idno type="filename">65492</idno>
-            <idno type="dclp-hybrid">mpern.s;17;58</idno>
+            <idno type="dclp-hybrid">mper.ns;17;58</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65581.xml
+++ b/DCLP/66/65581.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65581</idno>
             <idno type="LDAB">6832</idno>
             <idno type="filename">65581</idno>
-            <idno type="dclp-hybrid">mpern.s;1;7</idno>
+            <idno type="dclp-hybrid">mper.ns;1;7</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65639.xml
+++ b/DCLP/66/65639.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65639</idno>
             <idno type="LDAB">6891</idno>
             <idno type="filename">65639</idno>
-            <idno type="dclp-hybrid">mpern.s;3;56</idno>
+            <idno type="dclp-hybrid">mper.ns;3;56</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/66/65766.xml
+++ b/DCLP/66/65766.xml
@@ -12,7 +12,7 @@
             <idno type="TM">65766</idno>
             <idno type="LDAB">7020</idno>
             <idno type="filename">65766</idno>
-            <idno type="dclp-hybrid">mpern.s;3;22</idno>
+            <idno type="dclp-hybrid">mper.ns;3;22</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/67/66065.xml
+++ b/DCLP/67/66065.xml
@@ -12,7 +12,7 @@
             <idno type="TM">66065</idno>
             <idno type="LDAB">7311</idno>
             <idno type="filename">66065</idno>
-            <idno type="dclp-hybrid">mpern.s;29;21</idno>
+            <idno type="dclp-hybrid">mper.ns;29;21</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/67/66364.xml
+++ b/DCLP/67/66364.xml
@@ -12,7 +12,7 @@
             <idno type="TM">66364</idno>
             <idno type="LDAB">7777</idno>
             <idno type="filename">66364</idno>
-            <idno type="dclp-hybrid">mpern.s;17;28</idno>
+            <idno type="dclp-hybrid">mper.ns;17;28</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/68/67939.xml
+++ b/DCLP/68/67939.xml
@@ -12,7 +12,7 @@
             <idno type="TM">67939</idno>
             <idno type="LDAB">9210</idno>
             <idno type="filename">67939</idno>
-            <idno type="dclp-hybrid">mpern.s;29;27</idno>
+            <idno type="dclp-hybrid">mper.ns;29;27</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/69/68784.xml
+++ b/DCLP/69/68784.xml
@@ -12,7 +12,7 @@
             <idno type="TM">68784</idno>
             <idno type="LDAB">10058</idno>
             <idno type="filename">68784</idno>
-            <idno type="dclp-hybrid">mpern.s;29;24</idno>
+            <idno type="dclp-hybrid">mper.ns;29;24</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/69/68854.xml
+++ b/DCLP/69/68854.xml
@@ -12,7 +12,7 @@
             <idno type="TM">68854</idno>
             <idno type="LDAB">10124</idno>
             <idno type="filename">68854</idno>
-            <idno type="dclp-hybrid">mpern.s;31;4</idno>
+            <idno type="dclp-hybrid">mper.ns;31;4</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DCLP/91/90868.xml
+++ b/DCLP/91/90868.xml
@@ -12,7 +12,7 @@
             <idno type="TM">90868</idno>
             <idno type="LDAB">10660</idno>
             <idno type="filename">90868</idno>
-            <idno type="dclp-hybrid">mpern.s;29;40</idno>
+            <idno type="dclp-hybrid">mper.ns;29;40</idno>
             <availability>
                <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>


### PR DESCRIPTION
Updated `dclp-hybrid` idnos for `mpern.s` > `mper.ns` as per https://github.com/Edelweiss/hgv/issues/198. Also updated `na;` idnos to `tm;`.