### PR TITLE
Pathyris `@ref` wrangling

### DIFF
--- a/HGV_meta_EpiDoc/HGV1/1.xml
+++ b/HGV_meta_EpiDoc/HGV1/1.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/1.xml
+++ b/HGV_meta_EpiDoc/HGV1/1.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/10.xml
+++ b/HGV_meta_EpiDoc/HGV1/10.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/10.xml
+++ b/HGV_meta_EpiDoc/HGV1/10.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/100.xml
+++ b/HGV_meta_EpiDoc/HGV1/100.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/100.xml
+++ b/HGV_meta_EpiDoc/HGV1/100.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/101.xml
+++ b/HGV_meta_EpiDoc/HGV1/101.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/101.xml
+++ b/HGV_meta_EpiDoc/HGV1/101.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/102.xml
+++ b/HGV_meta_EpiDoc/HGV1/102.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/102.xml
+++ b/HGV_meta_EpiDoc/HGV1/102.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/103.xml
+++ b/HGV_meta_EpiDoc/HGV1/103.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/103.xml
+++ b/HGV_meta_EpiDoc/HGV1/103.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/105.xml
+++ b/HGV_meta_EpiDoc/HGV1/105.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/105.xml
+++ b/HGV_meta_EpiDoc/HGV1/105.xml
@@ -95,7 +95,7 @@
             <head>BL-Einträge nach BL-Konkordanz</head>
             <listBibl>
                <bibl type="BL-online">
-                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/105" />
+                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/105"/>
                </bibl>
                <bibl type="BL">
                   <biblScope type="volume">XIII</biblScope>

--- a/HGV_meta_EpiDoc/HGV1/105.xml
+++ b/HGV_meta_EpiDoc/HGV1/105.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -91,7 +95,7 @@
             <head>BL-Einträge nach BL-Konkordanz</head>
             <listBibl>
                <bibl type="BL-online">
-                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/105"/>
+                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/105" />
                </bibl>
                <bibl type="BL">
                   <biblScope type="volume">XIII</biblScope>

--- a/HGV_meta_EpiDoc/HGV1/106.xml
+++ b/HGV_meta_EpiDoc/HGV1/106.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/106.xml
+++ b/HGV_meta_EpiDoc/HGV1/106.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/107.xml
+++ b/HGV_meta_EpiDoc/HGV1/107.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/107.xml
+++ b/HGV_meta_EpiDoc/HGV1/107.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -90,7 +94,7 @@
             <head>BL-Einträge nach BL-Konkordanz</head>
             <listBibl>
                <bibl type="BL-online">
-                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/107"/>
+                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/107" />
                </bibl>
                <bibl type="BL">
                   <biblScope type="volume">XIII</biblScope>

--- a/HGV_meta_EpiDoc/HGV1/109.xml
+++ b/HGV_meta_EpiDoc/HGV1/109.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/109.xml
+++ b/HGV_meta_EpiDoc/HGV1/109.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/11.xml
+++ b/HGV_meta_EpiDoc/HGV1/11.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/11.xml
+++ b/HGV_meta_EpiDoc/HGV1/11.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/114.xml
+++ b/HGV_meta_EpiDoc/HGV1/114.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -96,10 +100,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_677"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_677" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462633.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462633.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/114.xml
+++ b/HGV_meta_EpiDoc/HGV1/114.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/115.xml
+++ b/HGV_meta_EpiDoc/HGV1/115.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/115.xml
+++ b/HGV_meta_EpiDoc/HGV1/115.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -118,10 +122,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_679"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_679" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462646.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462646.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/116.xml
+++ b/HGV_meta_EpiDoc/HGV1/116.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/116.xml
+++ b/HGV_meta_EpiDoc/HGV1/116.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -100,10 +104,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_676"/>
+                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_676" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469265.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469265.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/12.xml
+++ b/HGV_meta_EpiDoc/HGV1/12.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/12.xml
+++ b/HGV_meta_EpiDoc/HGV1/12.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/121.xml
+++ b/HGV_meta_EpiDoc/HGV1/121.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/121.xml
+++ b/HGV_meta_EpiDoc/HGV1/121.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -91,7 +95,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350251"/>
+                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350251" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/122.xml
+++ b/HGV_meta_EpiDoc/HGV1/122.xml
@@ -33,13 +33,18 @@
                   <origin>
                      <origPlace>Pathyris (?)</origPlace>
                      <origDate notBefore="-0113-11-19" notAfter="-0113-12-18">
-                        <certainty locus="value" match="../day-from-date(@notBefore)"/>19. Nov. - 18. Dez. 113 v.Chr. (Tag unsicher)</origDate>
+                        <certainty locus="value" match="../day-from-date(@notBefore)" />19. Nov. -
+                        18. Dez. 113 v.Chr. (Tag unsicher)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           cert="low"
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -47,8 +52,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -106,7 +111,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350252"/>
+                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350252" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/122.xml
+++ b/HGV_meta_EpiDoc/HGV1/122.xml
@@ -39,7 +39,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/123.xml
+++ b/HGV_meta_EpiDoc/HGV1/123.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/123.xml
+++ b/HGV_meta_EpiDoc/HGV1/123.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -99,7 +103,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350253"/>
+                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350253" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/124.xml
+++ b/HGV_meta_EpiDoc/HGV1/124.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -98,7 +102,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350256"/>
+                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350256" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/124.xml
+++ b/HGV_meta_EpiDoc/HGV1/124.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/125.xml
+++ b/HGV_meta_EpiDoc/HGV1/125.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/125.xml
+++ b/HGV_meta_EpiDoc/HGV1/125.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -76,7 +80,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Vgl. Harrauer, Paläographie, Textband, S. 238f., Nr. 56. Vgl. Harrauer, Paläographie, Textband, S. 238f., Nr. 56.</p>
+            <p>Vgl. Harrauer, Paläographie, Textband, S. 238f., Nr. 56. Vgl. Harrauer, Paläographie,
+               Textband, S. 238f., Nr. 56.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -102,7 +107,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350257"/>
+                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350257" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/126.xml
+++ b/HGV_meta_EpiDoc/HGV1/126.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/126.xml
+++ b/HGV_meta_EpiDoc/HGV1/126.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -76,7 +80,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Zur Datierung vgl. BL VIII, S. 38; P.Lugd. Bat. XXIII, S. 18 - 20, 25 - 26, 34, 48. Der Vertrag wurde in Kraft gesetzt am 23. Okt. 107.</p>
+            <p>Zur Datierung vgl. BL VIII, S. 38; P.Lugd. Bat. XXIII, S. 18 - 20, 25 - 26, 34, 48.
+               Der Vertrag wurde in Kraft gesetzt am 23. Okt. 107.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -102,20 +107,22 @@
          </div>
          <div type="bibliography" subtype="illustrations">
             <p>
-               <bibl type="illustration">Schubart, Griechische Paläographie, S. 38 (Ausschnitt von Kol. II, Z. 1 - 11)</bibl>
+               <bibl type="illustration">Schubart, Griechische Paläographie, S. 38 (Ausschnitt von
+                  Kol. II, Z. 1 - 11)</bibl>
             </p>
          </div>
          <div type="bibliography" subtype="translations">
             <head xml:lang="de">Übersetzungen</head>
             <listBibl xml:lang="de">
                <head xml:lang="de">Deutsch:</head>
-               <bibl type="translations">Erman - Krebs, Aus den Papyrus der königlichen Museen (1899), S. 118-119</bibl>
+               <bibl type="translations">Erman - Krebs, Aus den Papyrus der königlichen Museen
+                  (1899), S. 118-119</bibl>
             </listBibl>
          </div>
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02584/"/>
+                  <graphic url="http://berlpap.smb.museum/02584/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/127.xml
+++ b/HGV_meta_EpiDoc/HGV1/127.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -76,7 +80,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Zu Kol. II, Z. 1 vgl. P.Lugd. Bat. XXIII, S. 51, Anm. 14. Zur scriptura interior vgl. P.Lugd. Bat. XXIII, S. 34, Anm. 16.</p>
+            <p>Zu Kol. II, Z. 1 vgl. P.Lugd. Bat. XXIII, S. 51, Anm. 14. Zur scriptura interior vgl.
+               P.Lugd. Bat. XXIII, S. 34, Anm. 16.</p>
          </div>
          <div type="commentary" subtype="mentionedDates">
             <head>Erwähnte Daten</head>
@@ -104,7 +109,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02591/"/>
+                  <graphic url="http://berlpap.smb.museum/02591/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/127.xml
+++ b/HGV_meta_EpiDoc/HGV1/127.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/128.xml
+++ b/HGV_meta_EpiDoc/HGV1/128.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/128.xml
+++ b/HGV_meta_EpiDoc/HGV1/128.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -101,7 +105,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02592/"/>
+                  <graphic url="http://berlpap.smb.museum/02592/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/131.xml
+++ b/HGV_meta_EpiDoc/HGV1/131.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/131.xml
+++ b/HGV_meta_EpiDoc/HGV1/131.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -84,7 +88,7 @@
             <note type="source">MentionedDates.fp7</note>
             <list>
                <item>
-                  <ref/>
+                  <ref />
                   <date type="mentioned" when="-0109-02-18">18. Febr. 109 v.Chr.</date>
                </item>
             </list>
@@ -130,7 +134,8 @@
             <head xml:lang="de">Übersetzungen</head>
             <listBibl xml:lang="de">
                <head xml:lang="de">Deutsch:</head>
-               <bibl type="translations">Erman - Krebs, Aus den Papyrus der königlichen Museen (1899), S. 117-118 (Auszüge).</bibl>
+               <bibl type="translations">Erman - Krebs, Aus den Papyrus der königlichen Museen
+                  (1899), S. 117-118 (Auszüge).</bibl>
             </listBibl>
             <listBibl xml:lang="en">
                <head xml:lang="de">Englisch:</head>
@@ -144,7 +149,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02578/"/>
+                  <graphic url="http://berlpap.smb.museum/02578/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/132.xml
+++ b/HGV_meta_EpiDoc/HGV1/132.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/132.xml
+++ b/HGV_meta_EpiDoc/HGV1/132.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -106,10 +110,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.ville-ge.ch/musinfo/imageZoom/?iip=bgeiip/papyrus/pgen1-ri.ptif"/>
+                  <graphic
+                     url="http://www.ville-ge.ch/musinfo/imageZoom/?iip=bgeiip/papyrus/pgen1-ri.ptif" />
                </figure>
                <figure>
-                  <graphic url="https://archives.bge-geneve.ch/ark:/17786/vta4d4c0bbf6b3896ad"/>
+                  <graphic url="https://archives.bge-geneve.ch/ark:/17786/vta4d4c0bbf6b3896ad" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/133.xml
+++ b/HGV_meta_EpiDoc/HGV1/133.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/133.xml
+++ b/HGV_meta_EpiDoc/HGV1/133.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -99,10 +103,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_23"/>
+                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_23" />
                </figure>
                <figure>
-                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/003/VBP_II_3.html"/>
+                  <graphic
+                     url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/003/VBP_II_3.html" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/13b.xml
+++ b/HGV_meta_EpiDoc/HGV1/13b.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/13b.xml
+++ b/HGV_meta_EpiDoc/HGV1/13b.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/14.xml
+++ b/HGV_meta_EpiDoc/HGV1/14.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/14.xml
+++ b/HGV_meta_EpiDoc/HGV1/14.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/144.xml
+++ b/HGV_meta_EpiDoc/HGV1/144.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/144.xml
+++ b/HGV_meta_EpiDoc/HGV1/144.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -78,11 +82,13 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Andere Redaktion dieses Textes: SB I 4512 A, Z. 1 - 21. Zur Datierung vgl. ebenda und BL VII, S 17. Zu den Daten in Kol. I, Z. 3 und 8 vgl. BL IX, S. 24 und BL X, S. 18.</p>
+            <p>Andere Redaktion dieses Textes: SB I 4512 A, Z. 1 - 21. Zur Datierung vgl. ebenda und
+               BL VII, S 17. Zu den Daten in Kol. I, Z. 3 und 8 vgl. BL IX, S. 24 und BL X, S. 18.</p>
          </div>
          <div type="commentary" subtype="mentionedDates">
             <head>Erwähnte Daten</head>
-            <note type="original">Kol. I, Z. 4: 7. Dez. 191 v. Chr.; Z. 8: 9. - 14. Nov. 191 v. Chr., 15. Nov. 191 v. Chr.; Kol. II, Z. 8: 190 - 189 v. Chr.</note>
+            <note type="original">Kol. I, Z. 4: 7. Dez. 191 v. Chr.; Z. 8: 9. - 14. Nov. 191 v.
+               Chr., 15. Nov. 191 v. Chr.; Kol. II, Z. 8: 190 - 189 v. Chr.</note>
             <note type="source">MentionedDates.fp7</note>
             <list>
                <item>
@@ -91,7 +97,8 @@
                </item>
                <item>
                   <ref>Kol. I, Z. 8</ref>
-                  <date type="mentioned" notBefore="-0191-11-09" notAfter="-0191-11-14">9. - 14. Nov. 191 v.Chr.</date>
+                  <date type="mentioned" notBefore="-0191-11-09" notAfter="-0191-11-14">9. - 14.
+                     Nov. 191 v.Chr.</date>
                </item>
                <item>
                   <ref>Kol. I, Z. 8</ref>
@@ -141,7 +148,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02598/"/>
+                  <graphic url="http://berlpap.smb.museum/02598/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/15.xml
+++ b/HGV_meta_EpiDoc/HGV1/15.xml
@@ -38,7 +38,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/15.xml
+++ b/HGV_meta_EpiDoc/HGV1/15.xml
@@ -36,9 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" cert="low" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/16.xml
+++ b/HGV_meta_EpiDoc/HGV1/16.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/16.xml
+++ b/HGV_meta_EpiDoc/HGV1/16.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName> 
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/163.xml
+++ b/HGV_meta_EpiDoc/HGV1/163.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/163.xml
+++ b/HGV_meta_EpiDoc/HGV1/163.xml
@@ -32,12 +32,17 @@
                <history>
                   <origin>
                      <origPlace>Pathyris</origPlace>
-                     <origDate notBefore="-0103-10" notAfter="-0103-12" precision="low">Ende 103 v.Chr.</origDate>
+                     <origDate notBefore="-0103-10" notAfter="-0103-12" precision="low">Ende 103
+                        v.Chr.</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -95,7 +100,8 @@
          </div>
          <div type="bibliography" subtype="illustrations">
             <p>
-               <bibl type="illustration">Clarysse - Cohen - Quaegebeur - van't Dack - Winnicki, The Judean - Syrian - Egyptian Conflict, 4</bibl>
+               <bibl type="illustration">Clarysse - Cohen - Quaegebeur - van't Dack - Winnicki, The
+                  Judean - Syrian - Egyptian Conflict, 4</bibl>
             </p>
          </div>
          <div type="bibliography" subtype="otherPublications">

--- a/HGV_meta_EpiDoc/HGV1/164.xml
+++ b/HGV_meta_EpiDoc/HGV1/164.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/164.xml
+++ b/HGV_meta_EpiDoc/HGV1/164.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -102,7 +106,8 @@
          </div>
          <div type="bibliography" subtype="illustrations">
             <p>
-               <bibl type="illustration">Clarysse - Cohen - Quaegebeur - van't Dack - Winnicki, The Judean - Syrian - Egyptian Conflict, 1 - 3</bibl>
+               <bibl type="illustration">Clarysse - Cohen - Quaegebeur - van't Dack - Winnicki, The
+                  Judean - Syrian - Egyptian Conflict, 1 - 3</bibl>
                <bibl type="illustration">P.Amh. II, Plate VII</bibl>
             </p>
          </div>
@@ -119,13 +124,14 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350245"/>
+                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350245" />
                </figure>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_626"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_626" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100120697208.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100120697208.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/18.xml
+++ b/HGV_meta_EpiDoc/HGV1/18.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/18.xml
+++ b/HGV_meta_EpiDoc/HGV1/18.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/19.xml
+++ b/HGV_meta_EpiDoc/HGV1/19.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/19.xml
+++ b/HGV_meta_EpiDoc/HGV1/19.xml
@@ -32,12 +32,17 @@
                <history>
                   <origin>
                      <origPlace>Pathyris</origPlace>
-                     <origDate notBefore="-0098-03-16" notAfter="-0098-04-14">16. März - 14. Apr. 98 v.Chr.</origDate>
+                     <origDate notBefore="-0098-03-16" notAfter="-0098-04-14">16. März - 14. Apr. 98
+                        v.Chr.</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/202.xml
+++ b/HGV_meta_EpiDoc/HGV1/202.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/202.xml
+++ b/HGV_meta_EpiDoc/HGV1/202.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/203.xml
+++ b/HGV_meta_EpiDoc/HGV1/203.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/203.xml
+++ b/HGV_meta_EpiDoc/HGV1/203.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/204.xml
+++ b/HGV_meta_EpiDoc/HGV1/204.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/204.xml
+++ b/HGV_meta_EpiDoc/HGV1/204.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/21.xml
+++ b/HGV_meta_EpiDoc/HGV1/21.xml
@@ -37,8 +37,12 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           cert="low"
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -46,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -81,7 +85,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Gehört zum Archiv des Horos, Sohn des Nechutes; vgl. AnalPap 2, 1990, S. 54 Anm. 2. Zum Ort vgl. BL V, S. 3.</p>
+            <p>Gehört zum Archiv des Horos, Sohn des Nechutes; vgl. AnalPap 2, 1990, S. 54 Anm. 2.
+               Zum Ort vgl. BL V, S. 3.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>

--- a/HGV_meta_EpiDoc/HGV1/21.xml
+++ b/HGV_meta_EpiDoc/HGV1/21.xml
@@ -38,7 +38,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/212.xml
+++ b/HGV_meta_EpiDoc/HGV1/212.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -115,7 +119,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/03171/"/>
+                  <graphic url="http://berlpap.smb.museum/03171/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/212.xml
+++ b/HGV_meta_EpiDoc/HGV1/212.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/213.xml
+++ b/HGV_meta_EpiDoc/HGV1/213.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/213.xml
+++ b/HGV_meta_EpiDoc/HGV1/213.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -96,10 +100,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_218"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_218" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143123959.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143123959.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/215.xml
+++ b/HGV_meta_EpiDoc/HGV1/215.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/215.xml
+++ b/HGV_meta_EpiDoc/HGV1/215.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,9 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>
-        This file encoded to comply with EpiDoc Guidelines and Schema version 8
-        <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p> This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -70,11 +73,12 @@
       </profileDesc>
       <revisionDesc>
          <change when="2023-09-26T05:41:47-04:00"
-                 who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
+            who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
          <change when="2023-09-26T05:32:11-04:00"
-                 who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
+            who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
          <change when="2023-09-25T12:47:10-04:00"
-                 who="http://papyri.info/editor/users/LaviniaFerretti">Submit - Added link to new BL database</change>
+            who="http://papyri.info/editor/users/LaviniaFerretti">Submit - Added link to new BL
+            database</change>
          <change who="HGV" when="2003-05-17">Record created</change>
          <change who="HGV" when="2009-07-02">Record last modified</change>
          <change when="2011-04-20" who="IDP">Crosswalked to EpiDoc XML</change>
@@ -106,10 +110,11 @@
          <div type="figure">
             <p>
                <figure n="1">
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_619"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_619" />
                </figure>
                <figure n="2">
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128883.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128883.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/216.xml
+++ b/HGV_meta_EpiDoc/HGV1/216.xml
@@ -40,7 +40,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="http://pleiades.stoa.org/places/786084 http://www.trismegistos.org/place/2849 http://www.trismegistos.org/place/1628 http://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="http://pleiades.stoa.org/places/786084 http://www.trismegistos.org/place/2849 http://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/218.xml
+++ b/HGV_meta_EpiDoc/HGV1/218.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/218.xml
+++ b/HGV_meta_EpiDoc/HGV1/218.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -114,10 +118,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_671"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_671" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462592.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462592.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/219.xml
+++ b/HGV_meta_EpiDoc/HGV1/219.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/219.xml
+++ b/HGV_meta_EpiDoc/HGV1/219.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -75,7 +79,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Rückseite: Demotisch. Zur Datierung vgl. PP IX 7689 und Maehler - Strocka, Das ptolemäische Ägypten, S. 209.</p>
+            <p>Rückseite: Demotisch. Zur Datierung vgl. PP IX 7689 und Maehler - Strocka, Das
+               ptolemäische Ägypten, S. 209.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -105,10 +110,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1302"/>
+                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1302" />
                </figure>
                <figure>
-                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/004/VBP_II_4.html"/>
+                  <graphic
+                     url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/004/VBP_II_4.html" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/229.xml
+++ b/HGV_meta_EpiDoc/HGV1/229.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/229.xml
+++ b/HGV_meta_EpiDoc/HGV1/229.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -99,19 +103,21 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_682"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_682" />
                </figure>
                <figure>
-                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1283"/>
+                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1283" />
                </figure>
                <figure>
-                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1300"/>
+                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1300" />
                </figure>
                <figure>
-                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/010/VBP_II_10.html"/>
+                  <graphic
+                     url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/010/VBP_II_10.html" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462659.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462659.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/231.xml
+++ b/HGV_meta_EpiDoc/HGV1/231.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -112,10 +116,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_672"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_672" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462598.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462598.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/231.xml
+++ b/HGV_meta_EpiDoc/HGV1/231.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/235.xml
+++ b/HGV_meta_EpiDoc/HGV1/235.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -108,10 +112,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_630"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_630" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129010.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129010.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/235.xml
+++ b/HGV_meta_EpiDoc/HGV1/235.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/236.xml
+++ b/HGV_meta_EpiDoc/HGV1/236.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/236.xml
+++ b/HGV_meta_EpiDoc/HGV1/236.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -79,7 +83,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Vgl. P.Lugd. Bat. XXIII, S. 49. Der Vertrag wurde in Kraft gesetzt am 11. Sept. 101 v. Chr.</p>
+            <p>Vgl. P.Lugd. Bat. XXIII, S. 49. Der Vertrag wurde in Kraft gesetzt am 11. Sept. 101
+               v. Chr.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -111,10 +116,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_675"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_675" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462621.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462621.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/237.xml
+++ b/HGV_meta_EpiDoc/HGV1/237.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/237.xml
+++ b/HGV_meta_EpiDoc/HGV1/237.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -96,10 +100,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_670"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_670" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462577.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462577.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/238.xml
+++ b/HGV_meta_EpiDoc/HGV1/238.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/238.xml
+++ b/HGV_meta_EpiDoc/HGV1/238.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -83,7 +87,8 @@
             <list>
                <item>
                   <ref>Z. 13</ref>
-                  <date type="mentioned" notBefore="-0121-12-21" notAfter="-0120-01-19">21. Dez. 121 - 19. Jan. 120 v.Chr.</date>
+                  <date type="mentioned" notBefore="-0121-12-21" notAfter="-0120-01-19">21. Dez. 121
+                     - 19. Jan. 120 v.Chr.</date>
                </item>
             </list>
          </div>
@@ -108,10 +113,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_669"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_669" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462566.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462566.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/242.xml
+++ b/HGV_meta_EpiDoc/HGV1/242.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/242.xml
+++ b/HGV_meta_EpiDoc/HGV1/242.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -92,7 +96,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02579/"/>
+                  <graphic url="http://berlpap.smb.museum/02579/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/243.xml
+++ b/HGV_meta_EpiDoc/HGV1/243.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/243.xml
+++ b/HGV_meta_EpiDoc/HGV1/243.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -82,7 +86,8 @@
          </div>
          <div type="commentary" subtype="mentionedDates">
             <head>Erwähnte Daten</head>
-            <note type="original">Kol. I: bis auf das Datum wahrscheinlich im Oktober 101 v. Chr. geschrieben</note>
+            <note type="original">Kol. I: bis auf das Datum wahrscheinlich im Oktober 101 v. Chr.
+               geschrieben</note>
             <note type="source">MentionedDates.fp7</note>
             <list>
                <item>
@@ -105,7 +110,8 @@
                <bibl type="illustration">Schubart, Papyri Graecae Berolinenses, 10</bibl>
                <bibl type="illustration">Cohen, Notariaat, nach S. 52</bibl>
                <bibl type="illustration">Seider, Paläographie I, Tafel 12, 18, vor S. 55</bibl>
-               <bibl type="illustration">Mandilaras, Papyroi (1980), 44, S. 177 und (1994), 46, S. 375</bibl>
+               <bibl type="illustration">Mandilaras, Papyroi (1980), 44, S. 177 und (1994), 46, S.
+                  375</bibl>
                <bibl type="illustration">Cavallo, Scrittura, S. 43 [19] (Auschnitt)</bibl>
                <bibl type="illustration">Bagnall, Oxford Handbook of Papyrology, S. 109, Figure 5.5</bibl>
             </p>
@@ -121,7 +127,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02593/"/>
+                  <graphic url="http://berlpap.smb.museum/02593/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/254.xml
+++ b/HGV_meta_EpiDoc/HGV1/254.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,9 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>
-        This file encoded to comply with EpiDoc Guidelines and Schema version 8
-        <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p> This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -70,11 +73,12 @@
       </profileDesc>
       <revisionDesc>
          <change when="2023-09-26T05:43:40-04:00"
-                 who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
+            who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
          <change when="2023-09-26T05:28:53-04:00"
-                 who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
+            who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
          <change when="2023-09-25T12:34:17-04:00"
-                 who="http://papyri.info/editor/users/LaviniaFerretti">Submit - Added link to new BL Database</change>
+            who="http://papyri.info/editor/users/LaviniaFerretti">Submit - Added link to new BL
+            Database</change>
          <change who="HGV" when="2003-04-15">Record created</change>
          <change who="HGV" when="2009-07-02">Record last modified</change>
          <change when="2011-04-20" who="IDP">Crosswalked to EpiDoc XML</change>
@@ -113,10 +117,11 @@
          <div type="figure">
             <p>
                <figure n="1">
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_613"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_613" />
                </figure>
                <figure n="2">
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128805.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128805.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/254.xml
+++ b/HGV_meta_EpiDoc/HGV1/254.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/255.xml
+++ b/HGV_meta_EpiDoc/HGV1/255.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/255.xml
+++ b/HGV_meta_EpiDoc/HGV1/255.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,9 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>
-        This file encoded to comply with EpiDoc Guidelines and Schema version 8
-        <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p> This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -74,11 +77,12 @@
       </profileDesc>
       <revisionDesc>
          <change when="2023-09-26T05:46:05-04:00"
-                 who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
+            who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
          <change when="2023-09-26T05:29:12-04:00"
-                 who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
+            who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
          <change when="2023-09-25T12:37:23-04:00"
-                 who="http://papyri.info/editor/users/LaviniaFerretti">Submit - Added link to new BL database</change>
+            who="http://papyri.info/editor/users/LaviniaFerretti">Submit - Added link to new BL
+            database</change>
          <change who="HGV" when="2003-04-24">Record created</change>
          <change who="HGV" when="2011-04-19">Record last modified</change>
          <change when="2011-04-20" who="IDP">Crosswalked to EpiDoc XML</change>
@@ -106,7 +110,8 @@
          <div type="bibliography" subtype="otherPublications">
             <head>Andere Publikationen</head>
             <listBibl>
-               <bibl type="publication" subtype="other" n="1">Z. 1-9: P.Grenf. I 19 und P.Lond. III 614 descr.</bibl>
+               <bibl type="publication" subtype="other" n="1">Z. 1-9: P.Grenf. I 19 und P.Lond. III
+                  614 descr.</bibl>
                <bibl type="publication" subtype="other" n="2">Z. 24-27: P.Amh. II 166 descr.</bibl>
                <bibl type="publication" subtype="other" n="3">Z. 1-9 und 20-27: SB XVI 12716</bibl>
             </listBibl>
@@ -121,13 +126,14 @@
          <div type="figure">
             <p>
                <figure n="1">
-                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350502"/>
+                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350502" />
                </figure>
                <figure n="2">
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_614"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_614" />
                </figure>
                <figure n="3">
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100120697203.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100120697203.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/258.xml
+++ b/HGV_meta_EpiDoc/HGV1/258.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,9 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>
-        This file encoded to comply with EpiDoc Guidelines and Schema version 8
-        <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p> This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -68,11 +71,12 @@
       </profileDesc>
       <revisionDesc>
          <change when="2023-09-26T05:37:49-04:00"
-                 who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
+            who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
          <change when="2023-09-25T15:51:42-04:00"
-                 who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
+            who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
          <change when="2023-09-25T12:33:05-04:00"
-                 who="http://papyri.info/editor/users/LaviniaFerretti">Submit - Added link to new BL website</change>
+            who="http://papyri.info/editor/users/LaviniaFerretti">Submit - Added link to new BL
+            website</change>
          <change who="HGV" when="2003-04-02">Record created</change>
          <change who="HGV" when="2010-01-20">Record last modified</change>
          <change when="2011-04-20" who="IDP">Crosswalked to EpiDoc XML</change>
@@ -90,7 +94,8 @@
             <list>
                <item>
                   <ref>Z. 5</ref>
-                  <date type="mentioned" notBefore="-0164-05-31" notAfter="-0164-06-29">31. Mai 164 - 29. Juni 164 v.Chr.</date>
+                  <date type="mentioned" notBefore="-0164-05-31" notAfter="-0164-06-29">31. Mai 164
+                     - 29. Juni 164 v.Chr.</date>
                </item>
             </list>
          </div>
@@ -132,10 +137,11 @@
          <div type="figure">
             <p>
                <figure n="1">
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_617"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_617" />
                </figure>
                <figure n="2">
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128843.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128843.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/258.xml
+++ b/HGV_meta_EpiDoc/HGV1/258.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/263a.xml
+++ b/HGV_meta_EpiDoc/HGV1/263a.xml
@@ -41,7 +41,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/263a.xml
+++ b/HGV_meta_EpiDoc/HGV1/263a.xml
@@ -33,15 +33,21 @@
                   <origin>
                      <origPlace>Pathyris (?)</origPlace>
                      <origDate xml:id="dateAlternativeX" when="-0169-06-12">
-                        <certainty locus="value" match="../year-from-date(@when)"/>12. Juni 169 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />12. Juni 169
+                        v.Chr. (Jahr unsicher)</origDate>
                      <origDate xml:id="dateAlternativeY" when="-0193-06-18">
-                        <certainty locus="value" match="../year-from-date(@when)"/>18. Juni 193 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />18. Juni 193
+                        v.Chr. (Jahr unsicher)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           cert="low"
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -49,8 +55,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -80,7 +86,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Zur Datierung vgl. BL III, S. 70 und JEA 47, 1961, S. 108. Alternativdatierung: 19. Juni 193 v. Chr.</p>
+            <p>Zur Datierung vgl. BL III, S. 70 und JEA 47, 1961, S. 108. Alternativdatierung: 19.
+               Juni 193 v. Chr.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -113,10 +120,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_635"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_635" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469222.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469222.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/263b.xml
+++ b/HGV_meta_EpiDoc/HGV1/263b.xml
@@ -37,8 +37,12 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           cert="low"
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -46,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -101,10 +105,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_635"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_635" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469222.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469222.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/263b.xml
+++ b/HGV_meta_EpiDoc/HGV1/263b.xml
@@ -38,7 +38,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/268.xml
+++ b/HGV_meta_EpiDoc/HGV1/268.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/268.xml
+++ b/HGV_meta_EpiDoc/HGV1/268.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -105,16 +109,18 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_640"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_640" />
                </figure>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_687"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_687" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129085.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129085.0x000001" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462671.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462671.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/273.xml
+++ b/HGV_meta_EpiDoc/HGV1/273.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -46,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -110,10 +114,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_666"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_666" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129349.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129349.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/273.xml
+++ b/HGV_meta_EpiDoc/HGV1/273.xml
@@ -38,7 +38,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/279.xml
+++ b/HGV_meta_EpiDoc/HGV1/279.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/279.xml
+++ b/HGV_meta_EpiDoc/HGV1/279.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -94,7 +98,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147472022.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147472022.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/288.xml
+++ b/HGV_meta_EpiDoc/HGV1/288.xml
@@ -38,8 +38,12 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           cert="low"
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -47,8 +51,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -103,10 +107,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_889"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_889" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147463651.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147463651.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/288.xml
+++ b/HGV_meta_EpiDoc/HGV1/288.xml
@@ -39,7 +39,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/290.xml
+++ b/HGV_meta_EpiDoc/HGV1/290.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv290">
-  <teiHeader>
+   <teiHeader>
       <fileDesc>
          <titleStmt>
             <title>Greek letter from Esthladas to Dryton and Apollonia</title>
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -47,9 +51,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>
-        This file encoded to comply with EpiDoc Guidelines and Schema version 8
-        <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p> This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -66,7 +69,8 @@
             <keywords scheme="hgv">
                <term n="1">Brief (privat)</term>
                <term n="2">Esthladas an seine Eltern</term>
-               <term n="3">Nachricht über bevorstehende Strafaktion gegen das aufständische Hermonthis</term>
+               <term n="3">Nachricht über bevorstehende Strafaktion gegen das aufständische
+                  Hermonthis</term>
                <term n="4">Ermutigung</term>
                <term n="5">Soldat</term>
             </keywords>
@@ -74,27 +78,33 @@
       </profileDesc>
       <revisionDesc>
          <change when="2023-09-17T08:39:08-04:00"
-                 who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
+            who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
          <change when="2023-09-17T08:34:56-04:00"
-                 who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
+            who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
          <change when="2023-09-16T11:42:44-04:00"
-                 who="http://papyri.info/editor/users/Laudenbach">Submit - Link to image added (and button "add" pressed!)</change>
+            who="http://papyri.info/editor/users/Laudenbach">Submit - Link to image added (and
+            button "add" pressed!)</change>
          <change when="2023-09-16T11:42:27-04:00"
-                 who="http://papyri.info/editor/users/Laudenbach">Commit - Link added (and button "add" pressed!)</change>
+            who="http://papyri.info/editor/users/Laudenbach">Commit - Link added (and button "add"
+            pressed!)</change>
          <change when="2023-09-15T06:14:32-04:00"
-                 who="http://papyri.info/editor/users/paulpeters">Vote - ReturnToSender - See Cowey's comment.</change>
+            who="http://papyri.info/editor/users/paulpeters">Vote - ReturnToSender - See Cowey's
+            comment.</change>
          <change when="2023-09-11T09:58:49-04:00"
-                 who="http://papyri.info/editor/users/james.cowey">Vote - ReturnToSender - In the section Bibliography, when you add the link, please click on the English word "add" at the end of the long entry box. If you do not click on the word add then the link is not preserved.</change>
+            who="http://papyri.info/editor/users/james.cowey">Vote - ReturnToSender - In the section
+            Bibliography, when you add the link, please click on the English word "add" at the end
+            of the long entry box. If you do not click on the word add then the link is not
+            preserved.</change>
          <change when="2023-09-11T04:27:11-04:00"
-                 who="http://papyri.info/editor/users/Laudenbach">Submit - Link to digital images added</change>
+            who="http://papyri.info/editor/users/Laudenbach">Submit - Link to digital images added</change>
          <change when="2023-09-11T04:26:54-04:00"
-                 who="http://papyri.info/editor/users/Laudenbach">Commit - Link to digital images added</change>
+            who="http://papyri.info/editor/users/Laudenbach">Commit - Link to digital images added</change>
          <change who="HGV" when="2003-06-20">Record created</change>
          <change who="HGV" when="2011-04-19">Record last modified</change>
          <change when="2011-04-20" who="IDP">Crosswalked to EpiDoc XML</change>
       </revisionDesc>
-  </teiHeader>
-  <text>
+   </teiHeader>
+   <text>
       <body>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -108,7 +118,7 @@
             <head>BL-Einträge nach BL-Konkordanz</head>
             <listBibl>
                <bibl type="BL-online">
-                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/290"/>
+                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/290" />
                </bibl>
                <bibl type="BL">
                   <biblScope type="volume">XIII</biblScope>
@@ -135,16 +145,17 @@
                <head xml:lang="de">Englisch:</head>
                <bibl type="translations" n="1">Lewis, Greeks in Ptolemaic Egypt (1986), S. 98</bibl>
                <bibl type="translations" n="2">White, Ancient Letters (1986), 43</bibl>
-               <bibl type="translations" n="3">Bagnall &amp; Derow, The Hellenistic Period (2004), Nr. 53</bibl>
+               <bibl type="translations" n="3">Bagnall &amp; Derow, The Hellenistic Period (2004),
+                  Nr. 53</bibl>
             </listBibl>
          </div>
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://collections.louvre.fr/ark:/53355/cl010429505"/>
+                  <graphic url="https://collections.louvre.fr/ark:/53355/cl010429505" />
                </figure>
             </p>
          </div>
       </body>
-  </text>
+   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV1/290.xml
+++ b/HGV_meta_EpiDoc/HGV1/290.xml
@@ -39,7 +39,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/291.xml
+++ b/HGV_meta_EpiDoc/HGV1/291.xml
@@ -38,8 +38,12 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           cert="low"
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -47,8 +51,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -98,10 +102,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1291"/>
+                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1291" />
                </figure>
                <figure>
-                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/006/VBP_II_6.html"/>
+                  <graphic
+                     url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/006/VBP_II_6.html" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/291.xml
+++ b/HGV_meta_EpiDoc/HGV1/291.xml
@@ -39,7 +39,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/2a.xml
+++ b/HGV_meta_EpiDoc/HGV1/2a.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/2a.xml
+++ b/HGV_meta_EpiDoc/HGV1/2a.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/2b.xml
+++ b/HGV_meta_EpiDoc/HGV1/2b.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/2b.xml
+++ b/HGV_meta_EpiDoc/HGV1/2b.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/300.xml
+++ b/HGV_meta_EpiDoc/HGV1/300.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/300.xml
+++ b/HGV_meta_EpiDoc/HGV1/300.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -97,7 +101,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.globalegyptianmuseum.org/detail.aspx?id=1467"/>
+                  <graphic url="http://www.globalegyptianmuseum.org/detail.aspx?id=1467" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/303.xml
+++ b/HGV_meta_EpiDoc/HGV1/303.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/303.xml
+++ b/HGV_meta_EpiDoc/HGV1/303.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -75,7 +79,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Zur Datierung vgl. VBP II, S. 24 - 25 und Clarysse - Cohen - Quaegebeur - van't Dack - Winnicki, The Judaean - Syrian - Egyptian Conflict, S. 148.</p>
+            <p>Zur Datierung vgl. VBP II, S. 24 - 25 und Clarysse - Cohen - Quaegebeur - van't Dack
+               - Winnicki, The Judaean - Syrian - Egyptian Conflict, S. 148.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -92,10 +97,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1287"/>
+                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1287" />
                </figure>
                <figure>
-                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/016/VBP_II_16.html"/>
+                  <graphic
+                     url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/VBP_II/016/VBP_II_16.html" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/304.xml
+++ b/HGV_meta_EpiDoc/HGV1/304.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/304.xml
+++ b/HGV_meta_EpiDoc/HGV1/304.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv304">
-  <teiHeader>
+   <teiHeader>
       <fileDesc>
          <titleStmt>
             <title>Lettre de Platon à Nechthyrès</title>
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,9 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>
-        This file encoded to comply with EpiDoc Guidelines and Schema version 8
-        <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p> This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -72,23 +75,23 @@
       </profileDesc>
       <revisionDesc>
          <change when="2019-02-12T07:01:19-05:00"
-                 who="http://papyri.info/users/james.cowey">Finalized - Ready.</change>
+            who="http://papyri.info/users/james.cowey">Finalized - Ready.</change>
          <change when="2019-02-12T06:21:44-05:00"
-                 who="http://papyri.info/users/james.cowey">Vote - HGVAccept - Fine</change>
+            who="http://papyri.info/users/james.cowey">Vote - HGVAccept - Fine</change>
          <change when="2019-02-12T03:18:44-05:00"
-                 who="http://papyri.info/users/ValentinB.">Submit - image ajoutée</change>
+            who="http://papyri.info/users/ValentinB.">Submit - image ajoutée</change>
          <change when="2019-02-11T15:38:53-05:00"
-                 who="http://papyri.info/users/james.cowey">Finalized - Ready</change>
+            who="http://papyri.info/users/james.cowey">Finalized - Ready</change>
          <change when="2019-02-11T13:05:31-05:00"
-                 who="http://papyri.info/users/james.cowey">Vote - HGVAccept - Fine</change>
+            who="http://papyri.info/users/james.cowey">Vote - HGVAccept - Fine</change>
          <change when="2019-02-11T10:31:16-05:00"
-                 who="http://papyri.info/users/ValentinB.">Submit - image ajoutée</change>
+            who="http://papyri.info/users/ValentinB.">Submit - image ajoutée</change>
          <change who="HGV" when="1993-10-07">Record created</change>
          <change who="HGV" when="2011-04-19">Record last modified</change>
          <change when="2011-04-20" who="IDP">Crosswalked to EpiDoc XML</change>
       </revisionDesc>
-  </teiHeader>
-  <text>
+   </teiHeader>
+   <text>
       <body>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -102,7 +105,7 @@
             <head>BL-Einträge nach BL-Konkordanz</head>
             <listBibl>
                <bibl type="BL-online">
-                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/304"/>
+                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/304" />
                </bibl>
                <bibl type="BL">
                   <biblScope type="volume">VIII</biblScope>
@@ -128,19 +131,20 @@
             <listBibl xml:lang="en">
                <head xml:lang="de">Englisch:</head>
                <bibl type="translations" n="1">White, Ancient Letters (1986), 57</bibl>
-               <bibl type="translations" n="2">Bagnall &amp; Derow, The Hellenistic Period (2004), Nr. 58</bibl>
+               <bibl type="translations" n="2">Bagnall &amp; Derow, The Hellenistic Period (2004),
+                  Nr. 58</bibl>
             </listBibl>
          </div>
          <div type="figure">
             <p>
                <figure n="1">
-                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2010835.jpg"/>
+                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2010835.jpg" />
                </figure>
                <figure n="2">
-                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2020835.jpg"/>
+                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2020835.jpg" />
                </figure>
             </p>
          </div>
       </body>
-  </text>
+   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV1/305.xml
+++ b/HGV_meta_EpiDoc/HGV1/305.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/305.xml
+++ b/HGV_meta_EpiDoc/HGV1/305.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv305">
-  <teiHeader>
+   <teiHeader>
       <fileDesc>
          <titleStmt>
             <title>Lettre de Platon aux prêtres de Pathyris</title>
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,9 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>
-        This file encoded to comply with EpiDoc Guidelines and Schema version 8
-        <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p> This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -71,17 +74,17 @@
       </profileDesc>
       <revisionDesc>
          <change when="2019-02-11T13:29:03-05:00"
-                 who="http://papyri.info/users/james.cowey">Finalized - Ready.</change>
+            who="http://papyri.info/users/james.cowey">Finalized - Ready.</change>
          <change when="2019-02-11T13:19:38-05:00"
-                 who="http://papyri.info/users/james.cowey">Vote - HGVAccept - Fine</change>
+            who="http://papyri.info/users/james.cowey">Vote - HGVAccept - Fine</change>
          <change when="2019-02-11T10:34:56-05:00"
-                 who="http://papyri.info/users/ValentinB.">Submit - images ajoutées</change>
+            who="http://papyri.info/users/ValentinB.">Submit - images ajoutées</change>
          <change who="HGV" when="1993-10-07">Record created</change>
          <change who="HGV" when="2011-04-19">Record last modified</change>
          <change when="2011-04-20" who="IDP">Crosswalked to EpiDoc XML</change>
       </revisionDesc>
-  </teiHeader>
-  <text>
+   </teiHeader>
+   <text>
       <body>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -95,7 +98,7 @@
             <head>BL-Einträge nach BL-Konkordanz</head>
             <listBibl>
                <bibl type="BL-online">
-                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/305"/>
+                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/305" />
                </bibl>
                <bibl type="BL">
                   <biblScope type="volume">VIII</biblScope>
@@ -129,19 +132,20 @@
             <listBibl xml:lang="en">
                <head xml:lang="de">Englisch:</head>
                <bibl type="translations" n="1">White, Ancient Letters (1986), 58</bibl>
-               <bibl type="translations" n="2">Bagnall &amp; Derow, The Hellenistic Period (2004), Nr. 58</bibl>
+               <bibl type="translations" n="2">Bagnall &amp; Derow, The Hellenistic Period (2004),
+                  Nr. 58</bibl>
             </listBibl>
          </div>
          <div type="figure">
             <p>
                <figure n="1">
-                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2010837.jpg"/>
+                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2010837.jpg" />
                </figure>
                <figure n="2">
-                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2020837.jpg"/>
+                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2020837.jpg" />
                </figure>
             </p>
          </div>
       </body>
-  </text>
+   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV1/306.xml
+++ b/HGV_meta_EpiDoc/HGV1/306.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/306.xml
+++ b/HGV_meta_EpiDoc/HGV1/306.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv306">
-  <teiHeader>
+   <teiHeader>
       <fileDesc>
          <titleStmt>
             <title>Lettre de Platon à Nechthyrès</title>
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,9 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>
-        This file encoded to comply with EpiDoc Guidelines and Schema version 8
-        <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p> This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -70,17 +73,17 @@
       </profileDesc>
       <revisionDesc>
          <change when="2019-02-12T05:32:55-05:00"
-                 who="http://papyri.info/users/james.cowey">Finalized - Ready.</change>
+            who="http://papyri.info/users/james.cowey">Finalized - Ready.</change>
          <change when="2019-02-11T13:13:28-05:00"
-                 who="http://papyri.info/users/james.cowey">Vote - HGVAccept - Fine</change>
+            who="http://papyri.info/users/james.cowey">Vote - HGVAccept - Fine</change>
          <change when="2019-02-11T10:32:42-05:00"
-                 who="http://papyri.info/users/ValentinB.">Submit - images ajoutées</change>
+            who="http://papyri.info/users/ValentinB.">Submit - images ajoutées</change>
          <change who="HGV" when="1993-10-07">Record created</change>
          <change who="HGV" when="2011-04-19">Record last modified</change>
          <change when="2011-04-20" who="IDP">Crosswalked to EpiDoc XML</change>
       </revisionDesc>
-  </teiHeader>
-  <text>
+   </teiHeader>
+   <text>
       <body>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -102,13 +105,13 @@
          <div type="figure">
             <p>
                <figure n="1">
-                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2010836.jpg"/>
+                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2010836.jpg" />
                </figure>
                <figure n="2">
-                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2020836.jpg"/>
+                  <graphic url="http://www.papyrologie.paris-sorbonne.fr/photos/2020836.jpg" />
                </figure>
             </p>
          </div>
       </body>
-  </text>
+   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV1/371.xml
+++ b/HGV_meta_EpiDoc/HGV1/371.xml
@@ -35,7 +35,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/371.xml
+++ b/HGV_meta_EpiDoc/HGV1/371.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -43,8 +47,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/379.xml
+++ b/HGV_meta_EpiDoc/HGV1/379.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/379.xml
+++ b/HGV_meta_EpiDoc/HGV1/379.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/468.xml
+++ b/HGV_meta_EpiDoc/HGV1/468.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/468.xml
+++ b/HGV_meta_EpiDoc/HGV1/468.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -77,7 +81,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Rückseite: Demotisch. Zu Z. 13 vgl. Tyche 17, 2002, S. 260; zu Z. 10 und 13 vgl. ZPE 150, 2004, S. 175.</p>
+            <p>Rückseite: Demotisch. Zu Z. 13 vgl. Tyche 17, 2002, S. 260; zu Z. 10 und 13 vgl. ZPE
+               150, 2004, S. 175.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -96,7 +101,7 @@
             <head>BL-Einträge nach BL-Konkordanz</head>
             <listBibl>
                <bibl type="BL-online">
-                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/468"/>
+                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/468" />
                </bibl>
                <bibl type="BL">
                   <biblScope type="volume">IX</biblScope>
@@ -121,7 +126,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://ipap.csad.ox.ac.uk/4DLink4/4DACTION/IPAPwebquery?vPub=APF&amp;vVol=1&amp;vNum=p.62"/>
+                  <graphic
+                     url="http://ipap.csad.ox.ac.uk/4DLink4/4DACTION/IPAPwebquery?vPub=APF&amp;vVol=1&amp;vNum=p.62" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/495.xml
+++ b/HGV_meta_EpiDoc/HGV1/495.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/495.xml
+++ b/HGV_meta_EpiDoc/HGV1/495.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/5.xml
+++ b/HGV_meta_EpiDoc/HGV1/5.xml
@@ -38,8 +38,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/5.xml
+++ b/HGV_meta_EpiDoc/HGV1/5.xml
@@ -39,7 +39,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/52.xml
+++ b/HGV_meta_EpiDoc/HGV1/52.xml
@@ -39,7 +39,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/52.xml
+++ b/HGV_meta_EpiDoc/HGV1/52.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv52">
-  <teiHeader>
+   <teiHeader>
       <fileDesc>
          <titleStmt>
             <title>Vente d’un terrain à bâtir</title>
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -47,9 +51,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>
-        This file encoded to comply with EpiDoc Guidelines and Schema version 8
-        <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p> This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -71,20 +74,22 @@
       </profileDesc>
       <revisionDesc>
          <change when="2021-02-23T07:49:31-05:00"
-                 who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
+            who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
          <change when="2021-02-22T10:36:26-05:00"
-                 who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
+            who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
          <change when="2021-02-21T10:12:27-05:00"
-                 who="http://papyri.info/editor/users/dkaltsas">Submit - Added bibliographical reference under ‘Notes / Bemerkungen’ and ‘Print Illustration’.</change>
+            who="http://papyri.info/editor/users/dkaltsas">Submit - Added bibliographical reference
+            under ‘Notes / Bemerkungen’ and ‘Print Illustration’.</change>
          <change who="HGV" when="1991-03-22">Record created</change>
          <change who="HGV" when="2011-04-19">Record last modified</change>
          <change when="2011-04-20" who="IDP">Crosswalked to EpiDoc XML</change>
       </revisionDesc>
-  </teiHeader>
-  <text>
+   </teiHeader>
+   <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Demotisch - griechisch. Vervollständigt durch neues Fragment in T.M. Hickey – K. Vandorpe, ZPE 202, 2017, S. 214–218.</p>
+            <p>Demotisch - griechisch. Vervollständigt durch neues Fragment in T.M. Hickey – K.
+               Vandorpe, ZPE 202, 2017, S. 214–218.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -105,5 +110,5 @@
             </p>
          </div>
       </body>
-  </text>
+   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV1/53.xml
+++ b/HGV_meta_EpiDoc/HGV1/53.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/53.xml
+++ b/HGV_meta_EpiDoc/HGV1/53.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -77,7 +81,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Gehört zum Archiv des Horos, Sohn des Nechutes; vgl.  AnalPap 2, 1990, S. 54 Anm. 2. Zur Datierung vgl. ZPE 106, 1995, S. 194.</p>
+            <p>Gehört zum Archiv des Horos, Sohn des Nechutes; vgl. AnalPap 2, 1990, S. 54 Anm. 2.
+               Zur Datierung vgl. ZPE 106, 1995, S. 194.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -94,7 +99,8 @@
          <div type="bibliography" subtype="otherPublications">
             <head>Andere Publikation</head>
             <listBibl>
-               <bibl type="publication" subtype="other">P.Med. I (1. Auflage) 2, Fr. C, D, E (Fragm. rechts)</bibl>
+               <bibl type="publication" subtype="other">P.Med. I (1. Auflage) 2, Fr. C, D, E (Fragm.
+                  rechts)</bibl>
             </listBibl>
          </div>
       </body>

--- a/HGV_meta_EpiDoc/HGV1/54.xml
+++ b/HGV_meta_EpiDoc/HGV1/54.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/54.xml
+++ b/HGV_meta_EpiDoc/HGV1/54.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -94,10 +98,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://quod.lib.umich.edu/a/apis/x-1209"/>
+                  <graphic url="http://quod.lib.umich.edu/a/apis/x-1209" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV1/56.xml
+++ b/HGV_meta_EpiDoc/HGV1/56.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/56.xml
+++ b/HGV_meta_EpiDoc/HGV1/56.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -76,7 +80,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Der Vertrag wurde in Kraft gesetzt am 27. Juni 111 v. Chr. (vgl. P.Lugd. Bat. XXIII, S. 18, 25, 34, 47).</p>
+            <p>Der Vertrag wurde in Kraft gesetzt am 27. Juni 111 v. Chr. (vgl. P.Lugd. Bat. XXIII,
+               S. 18, 25, 34, 47).</p>
          </div>
          <div type="commentary" subtype="mentionedDates">
             <head>Erwähnte Daten</head>
@@ -113,7 +118,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02466/"/>
+                  <graphic url="http://berlpap.smb.museum/02466/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/57.xml
+++ b/HGV_meta_EpiDoc/HGV1/57.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -103,7 +107,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/03172/"/>
+                  <graphic url="http://berlpap.smb.museum/03172/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/57.xml
+++ b/HGV_meta_EpiDoc/HGV1/57.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/58.xml
+++ b/HGV_meta_EpiDoc/HGV1/58.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/58.xml
+++ b/HGV_meta_EpiDoc/HGV1/58.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -98,10 +102,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02468/"/>
+                  <graphic url="http://berlpap.smb.museum/02468/" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV1/59.xml
+++ b/HGV_meta_EpiDoc/HGV1/59.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/59.xml
+++ b/HGV_meta_EpiDoc/HGV1/59.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -101,10 +105,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_654"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_654" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129199.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129199.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/6.xml
+++ b/HGV_meta_EpiDoc/HGV1/6.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/6.xml
+++ b/HGV_meta_EpiDoc/HGV1/6.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/61.xml
+++ b/HGV_meta_EpiDoc/HGV1/61.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/61.xml
+++ b/HGV_meta_EpiDoc/HGV1/61.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -98,10 +102,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_655"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_655" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129226.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129226.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/610.xml
+++ b/HGV_meta_EpiDoc/HGV1/610.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/610.xml
+++ b/HGV_meta_EpiDoc/HGV1/610.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/643.xml
+++ b/HGV_meta_EpiDoc/HGV1/643.xml
@@ -38,8 +38,12 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           cert="low"
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -47,8 +51,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -79,7 +83,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Griechisch - demotisch. Auf dem Rekto steht auch ein demotischer Text: P.Dryton 43 App. dem.</p>
+            <p>Griechisch - demotisch. Auf dem Rekto steht auch ein demotischer Text: P.Dryton 43
+               App. dem.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -97,13 +102,14 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_315"/>
+                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_315" />
                </figure>
                <figure>
-                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Dryton/044/P.Dryton_44.html"/>
+                  <graphic
+                     url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Dryton/044/P.Dryton_44.html" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV1/643.xml
+++ b/HGV_meta_EpiDoc/HGV1/643.xml
@@ -39,7 +39,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/644.xml
+++ b/HGV_meta_EpiDoc/HGV1/644.xml
@@ -38,8 +38,12 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           cert="low"
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -47,8 +51,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -100,13 +104,14 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_313"/>
+                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_313" />
                </figure>
                <figure>
-                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Dryton/020/P.Dryton_20.html"/>
+                  <graphic
+                     url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/P.Dryton/020/P.Dryton_20.html" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV1/644.xml
+++ b/HGV_meta_EpiDoc/HGV1/644.xml
@@ -39,7 +39,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/654.xml
+++ b/HGV_meta_EpiDoc/HGV1/654.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/654.xml
+++ b/HGV_meta_EpiDoc/HGV1/654.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/66.xml
+++ b/HGV_meta_EpiDoc/HGV1/66.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/66.xml
+++ b/HGV_meta_EpiDoc/HGV1/66.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -107,10 +111,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_625"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_625" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128981.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128981.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/662.xml
+++ b/HGV_meta_EpiDoc/HGV1/662.xml
@@ -31,12 +31,16 @@
                   <origin>
                      <origPlace>Pathyris</origPlace>
                      <origDate notBefore="-0136" notAfter="-0097">
-                        <precision match="../@notBefore" degree="0.5"/>ca. 136 - 97 v.Chr.</origDate>
+                        <precision match="../@notBefore" degree="0.5" />ca. 136 - 97 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -44,8 +48,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV1/662.xml
+++ b/HGV_meta_EpiDoc/HGV1/662.xml
@@ -36,7 +36,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/69.xml
+++ b/HGV_meta_EpiDoc/HGV1/69.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/69.xml
+++ b/HGV_meta_EpiDoc/HGV1/69.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -107,10 +111,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_659"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_659" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129279.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129279.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/7.xml
+++ b/HGV_meta_EpiDoc/HGV1/7.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/7.xml
+++ b/HGV_meta_EpiDoc/HGV1/7.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/70.xml
+++ b/HGV_meta_EpiDoc/HGV1/70.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/70.xml
+++ b/HGV_meta_EpiDoc/HGV1/70.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -98,10 +102,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_660"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_660" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129295.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129295.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/71.xml
+++ b/HGV_meta_EpiDoc/HGV1/71.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/71.xml
+++ b/HGV_meta_EpiDoc/HGV1/71.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -96,10 +100,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_661"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_661" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129307.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129307.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/72.xml
+++ b/HGV_meta_EpiDoc/HGV1/72.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/72.xml
+++ b/HGV_meta_EpiDoc/HGV1/72.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -119,10 +123,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_662"/>
+                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_662" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469258.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469258.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/73.xml
+++ b/HGV_meta_EpiDoc/HGV1/73.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/73.xml
+++ b/HGV_meta_EpiDoc/HGV1/73.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -88,7 +92,7 @@
             <head>BL-Einträge nach BL-Konkordanz</head>
             <listBibl>
                <bibl type="BL-online">
-                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/73"/>
+                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/73" />
                </bibl>
                <bibl type="BL">
                   <biblScope type="volume">XIII</biblScope>
@@ -108,10 +112,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_674"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_674" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462611.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462611.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/74.xml
+++ b/HGV_meta_EpiDoc/HGV1/74.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -108,10 +112,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_663"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_663" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129335.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129335.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/74.xml
+++ b/HGV_meta_EpiDoc/HGV1/74.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/75.xml
+++ b/HGV_meta_EpiDoc/HGV1/75.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/75.xml
+++ b/HGV_meta_EpiDoc/HGV1/75.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -105,10 +109,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_673"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_673" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462607.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462607.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/76.xml
+++ b/HGV_meta_EpiDoc/HGV1/76.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/76.xml
+++ b/HGV_meta_EpiDoc/HGV1/76.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -123,10 +127,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_680"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_680" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462650.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147462650.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/77.xml
+++ b/HGV_meta_EpiDoc/HGV1/77.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/77.xml
+++ b/HGV_meta_EpiDoc/HGV1/77.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -106,10 +110,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1278"/>
+                  <graphic url="https://digi.ub.uni-heidelberg.de/diglit/p_g_1278" />
                </figure>
                <figure>
-                  <graphic url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Verstreutes/1278_GerGra/1278_GerGra.html"/>
+                  <graphic
+                     url="https://papy.zaw.uni-heidelberg.de/gv0/Papyri/Verstreutes/1278_GerGra/1278_GerGra.html" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/78.xml
+++ b/HGV_meta_EpiDoc/HGV1/78.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/78.xml
+++ b/HGV_meta_EpiDoc/HGV1/78.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -61,7 +65,8 @@
          </langUsage>
          <textClass>
             <keywords scheme="hgv">
-               <term>Urkunde (Verkauf von Ackerland, agoranomische Doppelurkunde mit Innen- und Außenschrift)</term>
+               <term>Urkunde (Verkauf von Ackerland, agoranomische Doppelurkunde mit Innen- und
+                  Außenschrift)</term>
                <term>genaue Personenbeschreibung</term>
                <term>Lagebeschreibung</term>
                <term>Namen (Käufer, Verkäufer)</term>
@@ -115,7 +120,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.uni-koeln.de/phil-fak/ifa/NRWakademie/papyrologie/Karte/I_050.html"/>
+                  <graphic
+                     url="http://www.uni-koeln.de/phil-fak/ifa/NRWakademie/papyrologie/Karte/I_050.html" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/79.xml
+++ b/HGV_meta_EpiDoc/HGV1/79.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/79.xml
+++ b/HGV_meta_EpiDoc/HGV1/79.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -111,7 +115,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.uni-koeln.de/phil-fak/ifa/NRWakademie/papyrologie/Karte/I_051.html"/>
+                  <graphic
+                     url="http://www.uni-koeln.de/phil-fak/ifa/NRWakademie/papyrologie/Karte/I_051.html" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/8.xml
+++ b/HGV_meta_EpiDoc/HGV1/8.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/8.xml
+++ b/HGV_meta_EpiDoc/HGV1/8.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/80.xml
+++ b/HGV_meta_EpiDoc/HGV1/80.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/80.xml
+++ b/HGV_meta_EpiDoc/HGV1/80.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -94,7 +98,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://papyri-leipzig.dl.uni-leipzig.de/receive/UBLPapyri_schrift_00000010"/>
+                  <graphic
+                     url="http://papyri-leipzig.dl.uni-leipzig.de/receive/UBLPapyri_schrift_00000010" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/81.xml
+++ b/HGV_meta_EpiDoc/HGV1/81.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -96,7 +100,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://papyri-leipzig.dl.uni-leipzig.de/receive/UBLPapyri_schrift_00000020"/>
+                  <graphic
+                     url="http://papyri-leipzig.dl.uni-leipzig.de/receive/UBLPapyri_schrift_00000020" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/81.xml
+++ b/HGV_meta_EpiDoc/HGV1/81.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/84.xml
+++ b/HGV_meta_EpiDoc/HGV1/84.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/84.xml
+++ b/HGV_meta_EpiDoc/HGV1/84.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -76,7 +80,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Datierung der Scriptura Interior: 19. Nov. 123 v. Chr. Dazu vgl. P.Lugd. Bat. XXIII, S. 34.</p>
+            <p>Datierung der Scriptura Interior: 19. Nov. 123 v. Chr. Dazu vgl. P.Lugd. Bat. XXIII,
+               S. 34.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -97,10 +102,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_879"/>
+                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_879" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469447.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469447.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/85.xml
+++ b/HGV_meta_EpiDoc/HGV1/85.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/85.xml
+++ b/HGV_meta_EpiDoc/HGV1/85.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -93,10 +97,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_880"/>
+                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_880" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469454.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469454.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/86.xml
+++ b/HGV_meta_EpiDoc/HGV1/86.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/86.xml
+++ b/HGV_meta_EpiDoc/HGV1/86.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -116,10 +120,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_881"/>
+                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_881" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469459.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469459.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/88.xml
+++ b/HGV_meta_EpiDoc/HGV1/88.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/88.xml
+++ b/HGV_meta_EpiDoc/HGV1/88.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -100,16 +104,18 @@
          <div type="bibliography" subtype="illustrations">
             <p>
                <bibl type="illustration">P.Lond. III, Plate 12</bibl>
-               <bibl type="illustration">Seider, Paläographie I, Tafel 13, 19, nach S. 57 (Kol. II, Ausschnitt)</bibl>
+               <bibl type="illustration">Seider, Paläographie I, Tafel 13, 19, nach S. 57 (Kol. II,
+                  Ausschnitt)</bibl>
             </p>
          </div>
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_883"/>
+                  <graphic url="https://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_883" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469468.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147469468.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/89.xml
+++ b/HGV_meta_EpiDoc/HGV1/89.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/89.xml
+++ b/HGV_meta_EpiDoc/HGV1/89.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -83,7 +87,8 @@
             <list>
                <item>
                   <ref>Z. 13</ref>
-                  <date type="mentioned" when="-0108-03-07">7. März 108 v.Chr. (Tag unsicher)<certainty locus="value" match="../date/day-from-date(@when)"/>
+                  <date type="mentioned" when="-0108-03-07">7. März 108 v.Chr. (Tag unsicher)<certainty
+                        locus="value" match="../date/day-from-date(@when)" />
                   </date>
                </item>
             </list>
@@ -109,7 +114,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147472145.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147472145.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/90.xml
+++ b/HGV_meta_EpiDoc/HGV1/90.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/90.xml
+++ b/HGV_meta_EpiDoc/HGV1/90.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -100,10 +104,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1203"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1203" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464522.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464522.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/91.xml
+++ b/HGV_meta_EpiDoc/HGV1/91.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -110,10 +114,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1204"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1204" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464528.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464528.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/91.xml
+++ b/HGV_meta_EpiDoc/HGV1/91.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/92.xml
+++ b/HGV_meta_EpiDoc/HGV1/92.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -100,10 +104,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1205"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1205" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464534.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464534.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/92.xml
+++ b/HGV_meta_EpiDoc/HGV1/92.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/93.xml
+++ b/HGV_meta_EpiDoc/HGV1/93.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/93.xml
+++ b/HGV_meta_EpiDoc/HGV1/93.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -114,10 +118,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1206"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1206" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464539.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464539.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/94.xml
+++ b/HGV_meta_EpiDoc/HGV1/94.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/94.xml
+++ b/HGV_meta_EpiDoc/HGV1/94.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -93,10 +97,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1207"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1207" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464546.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464546.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/95.xml
+++ b/HGV_meta_EpiDoc/HGV1/95.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/95.xml
+++ b/HGV_meta_EpiDoc/HGV1/95.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -110,10 +114,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1209"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_1209" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464563.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100147464563.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV1/9a.xml
+++ b/HGV_meta_EpiDoc/HGV1/9a.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/9a.xml
+++ b/HGV_meta_EpiDoc/HGV1/9a.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName> 
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/9b.xml
+++ b/HGV_meta_EpiDoc/HGV1/9b.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV1/9b.xml
+++ b/HGV_meta_EpiDoc/HGV1/9b.xml
@@ -36,8 +36,8 @@
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" n="1" ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2" ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV113/112490.xml
+++ b/HGV_meta_EpiDoc/HGV113/112490.xml
@@ -36,7 +36,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                         <placeName type="ancient"
                                    subtype="nome"
                                    ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>

--- a/HGV_meta_EpiDoc/HGV12/11503.xml
+++ b/HGV_meta_EpiDoc/HGV12/11503.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                         <placeName type="ancient"
                                    subtype="nome"
                                    ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>

--- a/HGV_meta_EpiDoc/HGV141/140869.xml
+++ b/HGV_meta_EpiDoc/HGV141/140869.xml
@@ -35,7 +35,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV141/140878.xml
+++ b/HGV_meta_EpiDoc/HGV141/140878.xml
@@ -35,7 +35,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV2/1234.xml
+++ b/HGV_meta_EpiDoc/HGV2/1234.xml
@@ -38,7 +38,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV2/1478.xml
+++ b/HGV_meta_EpiDoc/HGV2/1478.xml
@@ -32,12 +32,17 @@
                <history>
                   <origin>
                      <origPlace>Pathyris</origPlace>
-                     <origDate notBefore="-0099-12-16" notAfter="-0098-01-14">16. Dez. 99 - 14. Jan. 98 v.Chr.</origDate>
+                     <origDate notBefore="-0099-12-16" notAfter="-0098-01-14">16. Dez. 99 - 14. Jan.
+                        98 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV2/1478.xml
+++ b/HGV_meta_EpiDoc/HGV2/1478.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV2/1488.xml
+++ b/HGV_meta_EpiDoc/HGV2/1488.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV2/1488.xml
+++ b/HGV_meta_EpiDoc/HGV2/1488.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -99,7 +103,7 @@
             <head>BL-Einträge nach BL-Konkordanz</head>
             <listBibl>
                <bibl type="BL-online">
-                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/1488"/>
+                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/1488" />
                </bibl>
                <bibl type="BL">
                   <biblScope type="volume">XIII</biblScope>
@@ -116,7 +120,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_2850"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_2850" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV2/1499.xml
+++ b/HGV_meta_EpiDoc/HGV2/1499.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV2/1499.xml
+++ b/HGV_meta_EpiDoc/HGV2/1499.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -93,7 +97,7 @@
             <head>BL-Einträge nach BL-Konkordanz</head>
             <listBibl>
                <bibl type="BL-online">
-                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/1499"/>
+                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/1499" />
                </bibl>
                <bibl type="BL">
                   <biblScope type="volume">XIII</biblScope>
@@ -114,10 +118,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_632"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_632" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129019.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143129019.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV2/1881.xml
+++ b/HGV_meta_EpiDoc/HGV2/1881.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV2/1928.xml
+++ b/HGV_meta_EpiDoc/HGV2/1928.xml
@@ -38,7 +38,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23020.xml
+++ b/HGV_meta_EpiDoc/HGV24/23020.xml
@@ -44,7 +44,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV3/2828.xml
+++ b/HGV_meta_EpiDoc/HGV3/2828.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                         <placeName type="ancient" subtype="region">Gau unbekannt</placeName>
                      </p>
                   </provenance>

--- a/HGV_meta_EpiDoc/HGV30/29448.xml
+++ b/HGV_meta_EpiDoc/HGV30/29448.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                         <placeName type="ancient"
                                    subtype="nome"
                                    ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>

--- a/HGV_meta_EpiDoc/HGV32/31096.xml
+++ b/HGV_meta_EpiDoc/HGV32/31096.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34765.xml
+++ b/HGV_meta_EpiDoc/HGV35/34765.xml
@@ -38,7 +38,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36124.xml
+++ b/HGV_meta_EpiDoc/HGV37/36124.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36124.xml
+++ b/HGV_meta_EpiDoc/HGV37/36124.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -76,7 +80,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Zur Datierung vgl. BL VIII, S. 359. Datierung: 2. (3.) Okt., 4. Indiktion. Zu Z. 1 vgl. SPP III2.2 S. 136.</p>
+            <p>Zur Datierung vgl. BL VIII, S. 359. Datierung: 2. (3.) Okt., 4. Indiktion. Zu Z. 1
+               vgl. SPP III2.2 S. 136.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -109,10 +114,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02572/"/>
+                  <graphic url="http://berlpap.smb.museum/02572/" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV37/36125.xml
+++ b/HGV_meta_EpiDoc/HGV37/36125.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36125.xml
+++ b/HGV_meta_EpiDoc/HGV37/36125.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -113,10 +117,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02570/"/>
+                  <graphic url="http://berlpap.smb.museum/02570/" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV37/36126.xml
+++ b/HGV_meta_EpiDoc/HGV37/36126.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36126.xml
+++ b/HGV_meta_EpiDoc/HGV37/36126.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -78,7 +82,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Zur Datierung vgl. BL VIII, S. 359. Datierung: 17. (18.) Febr., 13. Indiktion. Zu Z. 1 und 5-7 vgl. SPP III2.2 S. 136.</p>
+            <p>Zur Datierung vgl. BL VIII, S. 359. Datierung: 17. (18.) Febr., 13. Indiktion. Zu Z.
+               1 und 5-7 vgl. SPP III2.2 S. 136.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -110,10 +115,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/04629/"/>
+                  <graphic url="http://berlpap.smb.museum/04629/" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV37/36282.xml
+++ b/HGV_meta_EpiDoc/HGV37/36282.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36282.xml
+++ b/HGV_meta_EpiDoc/HGV37/36282.xml
@@ -4,7 +4,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Griechische Unterschrift zu einer koptischen Freilassungsurkunde des Blemmyerkönigs Barachia</title>
+            <title>Griechische Unterschrift zu einer koptischen Freilassungsurkunde des
+               Blemmyerkönigs Barachia</title>
          </titleStmt>
          <publicationStmt>
             <idno type="filename">36282</idno>
@@ -37,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV38/37078.xml
+++ b/HGV_meta_EpiDoc/HGV38/37078.xml
@@ -35,7 +35,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37078.xml
+++ b/HGV_meta_EpiDoc/HGV38/37078.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -43,8 +47,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -102,7 +106,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02569/"/>
+                  <graphic url="http://berlpap.smb.museum/02569/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV38/37079.xml
+++ b/HGV_meta_EpiDoc/HGV38/37079.xml
@@ -35,7 +35,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37079.xml
+++ b/HGV_meta_EpiDoc/HGV38/37079.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -43,8 +47,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -102,7 +106,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02571/"/>
+                  <graphic url="http://berlpap.smb.museum/02571/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV38/37080.xml
+++ b/HGV_meta_EpiDoc/HGV38/37080.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -43,8 +47,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -102,7 +106,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02573/"/>
+                  <graphic url="http://berlpap.smb.museum/02573/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV38/37080.xml
+++ b/HGV_meta_EpiDoc/HGV38/37080.xml
@@ -35,7 +35,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37603.xml
+++ b/HGV_meta_EpiDoc/HGV38/37603.xml
@@ -38,7 +38,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37603.xml
+++ b/HGV_meta_EpiDoc/HGV38/37603.xml
@@ -31,14 +31,20 @@
                   <origin>
                      <origPlace>Pathyris</origPlace>
                      <origDate xml:id="dateAlternativeX" when="0582-10-21">
-                        <certainty locus="value" match="../year-from-date(@when)"/>21. Okt. 582 (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />21. Okt. 582
+                        (Jahr unsicher)</origDate>
                      <origDate xml:id="dateAlternativeY" when="0597-10-21">
-                        <certainty locus="value" match="../year-from-date(@when)"/>21. Okt. 597 (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />21. Okt. 597
+                        (Jahr unsicher)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -46,8 +52,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -78,7 +84,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Alternativdatierung: 21. Okt. 597. Gehört zum Dossier der Blemmyer - Urkunden aus Gebelên.</p>
+            <p>Alternativdatierung: 21. Okt. 597. Gehört zum Dossier der Blemmyer - Urkunden aus
+               Gebelên.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -106,7 +113,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://ipap.csad.ox.ac.uk/4DLink4/4DACTION/IPAPwebquery?vPub=SB&amp;vVol=3&amp;vNum=6257"/>
+                  <graphic
+                     url="http://ipap.csad.ox.ac.uk/4DLink4/4DACTION/IPAPwebquery?vPub=SB&amp;vVol=3&amp;vNum=6257" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV38/37604.xml
+++ b/HGV_meta_EpiDoc/HGV38/37604.xml
@@ -31,14 +31,20 @@
                   <origin>
                      <origPlace>Pathyris</origPlace>
                      <origDate xml:id="dateAlternativeX" when="0577-11-19">
-                        <certainty locus="value" match="../year-from-date(@when)"/>19. Nov. 577 (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />19. Nov. 577
+                        (Jahr unsicher)</origDate>
                      <origDate xml:id="dateAlternativeY" when="0592-11-19">
-                        <certainty locus="value" match="../year-from-date(@when)"/>19. Nov. 592 (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />19. Nov. 592
+                        (Jahr unsicher)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -46,8 +52,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -77,7 +83,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Alternativdatierung: 19. Nov. 592. Gehört zum Dossier der Blemmyer - Urkunden aus Gebelên.</p>
+            <p>Alternativdatierung: 19. Nov. 592. Gehört zum Dossier der Blemmyer - Urkunden aus
+               Gebelên.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -104,7 +111,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://ipap.csad.ox.ac.uk/4DLink4/4DACTION/IPAPwebquery?vPub=SB&amp;vVol=3&amp;vNum=6258"/>
+                  <graphic
+                     url="http://ipap.csad.ox.ac.uk/4DLink4/4DACTION/IPAPwebquery?vPub=SB&amp;vVol=3&amp;vNum=6258" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV38/37604.xml
+++ b/HGV_meta_EpiDoc/HGV38/37604.xml
@@ -38,7 +38,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3983.xml
+++ b/HGV_meta_EpiDoc/HGV4/3983.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3983.xml
+++ b/HGV_meta_EpiDoc/HGV4/3983.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV4/3986.xml
+++ b/HGV_meta_EpiDoc/HGV4/3986.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3986.xml
+++ b/HGV_meta_EpiDoc/HGV4/3986.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -92,7 +96,7 @@
             <head>BL-Einträge nach BL-Konkordanz</head>
             <listBibl>
                <bibl type="BL-online">
-                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/3986"/>
+                  <ptr target="https://aquila.zaw.uni-heidelberg.de/bl/hgv/3986" />
                </bibl>
                <bibl type="BL">
                   <biblScope type="volume">XIII</biblScope>

--- a/HGV_meta_EpiDoc/HGV44/43537.xml
+++ b/HGV_meta_EpiDoc/HGV44/43537.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV44/43537.xml
+++ b/HGV_meta_EpiDoc/HGV44/43537.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV44/43723.xml
+++ b/HGV_meta_EpiDoc/HGV44/43723.xml
@@ -33,12 +33,16 @@
                   <origin>
                      <origPlace>Pathyris</origPlace>
                      <origDate notBefore="-0116" notAfter="-0090">
-                        <precision match="../@notBefore" degree="0.5"/>ca. 116 - 90 v.Chr.</origDate>
+                        <precision match="../@notBefore" degree="0.5" />ca. 116 - 90 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -46,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV44/43723.xml
+++ b/HGV_meta_EpiDoc/HGV44/43723.xml
@@ -38,7 +38,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV45/44190.xml
+++ b/HGV_meta_EpiDoc/HGV45/44190.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV49/48346.xml
+++ b/HGV_meta_EpiDoc/HGV49/48346.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV49/48346.xml
+++ b/HGV_meta_EpiDoc/HGV49/48346.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -96,10 +100,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_621"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_621" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128924.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128924.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV49/48348.xml
+++ b/HGV_meta_EpiDoc/HGV49/48348.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV49/48348.xml
+++ b/HGV_meta_EpiDoc/HGV49/48348.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -87,7 +91,8 @@
             <list>
                <item>
                   <ref>Z. 4</ref>
-                  <date type="mentioned" notBefore="-0115-09-21" notAfter="-0115-10-20">21. Sept.  - 20. Okt. 115 v.Chr.</date>
+                  <date type="mentioned" notBefore="-0115-09-21" notAfter="-0115-10-20">21. Sept. -
+                     20. Okt. 115 v.Chr.</date>
                </item>
             </list>
          </div>
@@ -125,10 +130,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_622"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_622" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128948.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128948.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV49/48349.xml
+++ b/HGV_meta_EpiDoc/HGV49/48349.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV49/48349.xml
+++ b/HGV_meta_EpiDoc/HGV49/48349.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -112,10 +116,11 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_627"/>
+                  <graphic url="http://www.bl.uk/manuscripts/FullDisplay.aspx?ref=Papyrus_627" />
                </figure>
                <figure>
-                  <graphic url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128996.0x000001"/>
+                  <graphic
+                     url="https://access.bl.uk/item/viewer/ark:/81055/vdc_100143128996.0x000001" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV49/48897a.xml
+++ b/HGV_meta_EpiDoc/HGV49/48897a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -75,7 +79,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Vgl. APF 46, 2000, S. 231. Zur Datierung vgl. BL V, S. 125 und APF 46, 2000, S. 231 (versehentlich 21. Aug.). Griechisch - demotisch.</p>
+            <p>Vgl. APF 46, 2000, S. 231. Zur Datierung vgl. BL V, S. 125 und APF 46, 2000, S. 231
+               (versehentlich 21. Aug.). Griechisch - demotisch.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -110,7 +115,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.psi-online.it/documents/psi;8;988"/>
+                  <graphic url="http://www.psi-online.it/documents/psi;8;988" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV49/48897a.xml
+++ b/HGV_meta_EpiDoc/HGV49/48897a.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV49/48897b.xml
+++ b/HGV_meta_EpiDoc/HGV49/48897b.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV49/48897b.xml
+++ b/HGV_meta_EpiDoc/HGV49/48897b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -97,7 +101,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.psi-online.it/documents/psi;8;988"/>
+                  <graphic url="http://www.psi-online.it/documents/psi;8;988" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV5/4198.xml
+++ b/HGV_meta_EpiDoc/HGV5/4198.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV5/4198.xml
+++ b/HGV_meta_EpiDoc/HGV5/4198.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV5/4528.xml
+++ b/HGV_meta_EpiDoc/HGV5/4528.xml
@@ -41,7 +41,7 @@
                      </p>
                      <p xml:id="geog_2" exclude="#geog_1">
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV5/4579.xml
+++ b/HGV_meta_EpiDoc/HGV5/4579.xml
@@ -33,16 +33,23 @@
                   <origin>
                      <origPlace>Pathyris</origPlace>
                      <origDate xml:id="dateAlternativeX" when="-0180-09-29">
-                        <certainty locus="value" match="../year-from-date(@when)"/>29. Sept. 180 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />29. Sept. 180
+                        v.Chr. (Jahr unsicher)</origDate>
                      <origDate xml:id="dateAlternativeY" when="-0169-09-26">
-                        <certainty locus="value" match="../year-from-date(@when)"/>26. Sept. 169 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />26. Sept. 169
+                        v.Chr. (Jahr unsicher)</origDate>
                      <origDate xml:id="dateAlternativeZ" when="-0116-09-13">
-                        <certainty locus="value" match="../year-from-date(@when)"/>13. Sept. 116 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />13. Sept. 116
+                        v.Chr. (Jahr unsicher)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -50,8 +57,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV5/4579.xml
+++ b/HGV_meta_EpiDoc/HGV5/4579.xml
@@ -42,7 +42,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV5/4596.xml
+++ b/HGV_meta_EpiDoc/HGV5/4596.xml
@@ -40,7 +40,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV5/4596.xml
+++ b/HGV_meta_EpiDoc/HGV5/4596.xml
@@ -33,14 +33,20 @@
                   <origin>
                      <origPlace>Pathyris</origPlace>
                      <origDate xml:id="dateAlternativeX" when="-0151-09-09">
-                        <certainty locus="value" match="../year-from-date(@when)"/>9. Sept. 151 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />9. Sept. 151
+                        v.Chr. (Jahr unsicher)</origDate>
                      <origDate xml:id="dateAlternativeY" when="-0140-09-06">
-                        <certainty locus="value" match="../year-from-date(@when)"/>6. Sept. 140 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />6. Sept. 140
+                        v.Chr. (Jahr unsicher)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -48,8 +54,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -105,7 +111,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02472/"/>
+                  <graphic url="http://berlpap.smb.museum/02472/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV5/4597.xml
+++ b/HGV_meta_EpiDoc/HGV5/4597.xml
@@ -40,7 +40,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV5/4597.xml
+++ b/HGV_meta_EpiDoc/HGV5/4597.xml
@@ -33,14 +33,20 @@
                   <origin>
                      <origPlace>Pathyris</origPlace>
                      <origDate xml:id="dateAlternativeX" when="-0151-01-12">
-                        <certainty locus="value" match="../year-from-date(@when)"/>12. Jan. 151 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />12. Jan. 151
+                        v.Chr. (Jahr unsicher)</origDate>
                      <origDate xml:id="dateAlternativeY" when="-0140-01-09">
-                        <certainty locus="value" match="../year-from-date(@when)"/>9. Jan. 140 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />9. Jan. 140
+                        v.Chr. (Jahr unsicher)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -48,8 +54,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV5/4599.xml
+++ b/HGV_meta_EpiDoc/HGV5/4599.xml
@@ -40,7 +40,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV5/4599.xml
+++ b/HGV_meta_EpiDoc/HGV5/4599.xml
@@ -33,14 +33,20 @@
                   <origin>
                      <origPlace>Pathyris</origPlace>
                      <origDate xml:id="dateAlternativeX" when="-0146-12-29">
-                        <certainty locus="value" match="../year-from-date(@when)"/>29. Dez. 146 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />29. Dez. 146
+                        v.Chr. (Jahr unsicher)</origDate>
                      <origDate xml:id="dateAlternativeY" when="-0135-12-26">
-                        <certainty locus="value" match="../year-from-date(@when)"/>26. Dez. 135 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />26. Dez. 135
+                        v.Chr. (Jahr unsicher)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -48,8 +54,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV5/4726.xml
+++ b/HGV_meta_EpiDoc/HGV5/4726.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV5/4726.xml
+++ b/HGV_meta_EpiDoc/HGV5/4726.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -109,10 +113,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/00048/"/>
+                  <graphic url="http://berlpap.smb.museum/00048/" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV51/50356.xml
+++ b/HGV_meta_EpiDoc/HGV51/50356.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV51/50356.xml
+++ b/HGV_meta_EpiDoc/HGV51/50356.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV51/50357.xml
+++ b/HGV_meta_EpiDoc/HGV51/50357.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV51/50357.xml
+++ b/HGV_meta_EpiDoc/HGV51/50357.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV6/5281.xml
+++ b/HGV_meta_EpiDoc/HGV6/5281.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5281.xml
+++ b/HGV_meta_EpiDoc/HGV6/5281.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV6/5415.xml
+++ b/HGV_meta_EpiDoc/HGV6/5415.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5565.xml
+++ b/HGV_meta_EpiDoc/HGV6/5565.xml
@@ -40,7 +40,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5627.xml
+++ b/HGV_meta_EpiDoc/HGV6/5627.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -74,7 +78,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Tag: 1. Hathyr. Demotisch - griechisch. Zur Datierung vgl. BL VII, S. 184. Rückseite: 134 - 133 v. Chr.</p>
+            <p>Tag: 1. Hathyr. Demotisch - griechisch. Zur Datierung vgl. BL VII, S. 184. Rückseite:
+               134 - 133 v. Chr.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>

--- a/HGV_meta_EpiDoc/HGV6/5627.xml
+++ b/HGV_meta_EpiDoc/HGV6/5627.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5738.xml
+++ b/HGV_meta_EpiDoc/HGV6/5738.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5738.xml
+++ b/HGV_meta_EpiDoc/HGV6/5738.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV6/5803.xml
+++ b/HGV_meta_EpiDoc/HGV6/5803.xml
@@ -40,7 +40,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5803.xml
+++ b/HGV_meta_EpiDoc/HGV6/5803.xml
@@ -33,14 +33,20 @@
                   <origin>
                      <origPlace>Pathyris Gebelen</origPlace>
                      <origDate xml:id="dateAlternativeX" when="-0103-06-18">
-                        <certainty locus="value" match="../year-from-date(@when)"/>18. Juni 103 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />18. Juni 103
+                        v.Chr. (Jahr unsicher)</origDate>
                      <origDate xml:id="dateAlternativeY" when="-0100-06-17">
-                        <certainty locus="value" match="../year-from-date(@when)"/>17. Juni 100 v.Chr. (Jahr unsicher)</origDate>
+                        <certainty locus="value" match="../year-from-date(@when)" />17. Juni 100
+                        v.Chr. (Jahr unsicher)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -48,8 +54,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV6/5882b.xml
+++ b/HGV_meta_EpiDoc/HGV6/5882b.xml
@@ -38,7 +38,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5882b.xml
+++ b/HGV_meta_EpiDoc/HGV6/5882b.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -46,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -78,11 +82,14 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Zur Datierung vgl. P.Giss. I, III, S. 113. Duplikat von Z. 20 - 26: SB I  4512 B, 34 - 43. Gehört zu einer Papyrusrolle, von der Teile in P.Giss. I  36, 37 und 108 erhalten sind. Gehört zum Erbstreit - Archiv.</p>
+            <p>Zur Datierung vgl. P.Giss. I, III, S. 113. Duplikat von Z. 20 - 26: SB I 4512 B, 34 -
+               43. Gehört zu einer Papyrusrolle, von der Teile in P.Giss. I 36, 37 und 108 erhalten
+               sind. Gehört zum Erbstreit - Archiv.</p>
          </div>
          <div type="commentary" subtype="mentionedDates">
             <head>Erwähnte Daten</head>
-            <note type="original">Kol. II, Z. 8 - 19: Dokument vom 22. Aug. - 20. Sept. 136 v. Chr.; Kol. II, Z. 20: 29. Sept. 134 v. Chr.</note>
+            <note type="original">Kol. II, Z. 8 - 19: Dokument vom 22. Aug. - 20. Sept. 136 v. Chr.;
+               Kol. II, Z. 20: 29. Sept. 134 v. Chr.</note>
             <note type="source">MentionedDates.fp7</note>
             <list>
                <item>
@@ -91,7 +98,8 @@
                </item>
                <item>
                   <ref>Kol. II Z. 8-19</ref>
-                  <date type="mentioned" notBefore="-0136-08-22" notAfter="-0136-09-20">22. Aug.  - 20. Sept. 136 v.Chr.</date>
+                  <date type="mentioned" notBefore="-0136-08-22" notAfter="-0136-09-20">22. Aug. -
+                     20. Sept. 136 v.Chr.</date>
                </item>
             </list>
          </div>
@@ -123,7 +131,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://digibib.ub.uni-giessen.de/cgi-bin/populo/pap.pl?t_allegro=x&amp;f_SIG=P.+Giss.+37"/>
+                  <graphic
+                     url="http://digibib.ub.uni-giessen.de/cgi-bin/populo/pap.pl?t_allegro=x&amp;f_SIG=P.+Giss.+37" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV6/5882c.xml
+++ b/HGV_meta_EpiDoc/HGV6/5882c.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5882c.xml
+++ b/HGV_meta_EpiDoc/HGV6/5882c.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -93,7 +97,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://digibib.ub.uni-giessen.de/cgi-bin/populo/pap.pl?t_allegro=x&amp;f_SIG=P.+Giss.+38"/>
+                  <graphic
+                     url="http://digibib.ub.uni-giessen.de/cgi-bin/populo/pap.pl?t_allegro=x&amp;f_SIG=P.+Giss.+38" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV6/5882d.xml
+++ b/HGV_meta_EpiDoc/HGV6/5882d.xml
@@ -38,7 +38,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5882d.xml
+++ b/HGV_meta_EpiDoc/HGV6/5882d.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -46,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -76,16 +80,20 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Zur Datierung vgl. P.Giss. I, III, S. 113. Gehört zu einer Papyrusrolle, von der Teile in P.Giss. I 36, 37, 108 erhalten sind (P.Giss. I, III, S. 162). Gehört zum Erbstreit - Archiv.</p>
+            <p>Zur Datierung vgl. P.Giss. I, III, S. 113. Gehört zu einer Papyrusrolle, von der
+               Teile in P.Giss. I 36, 37, 108 erhalten sind (P.Giss. I, III, S. 162). Gehört zum
+               Erbstreit - Archiv.</p>
          </div>
          <div type="commentary" subtype="mentionedDates">
             <head>Erwähnte Daten</head>
-            <note type="original">Z. 12 - 17: Abschrift eines Dokuments vom 26. Okt. - 24. Nov. 134 v. Chr.; Z. 18 - 23: Abschrift eines Dokuments vom 9. Nov. 134 v. Chr.</note>
+            <note type="original">Z. 12 - 17: Abschrift eines Dokuments vom 26. Okt. - 24. Nov. 134
+               v. Chr.; Z. 18 - 23: Abschrift eines Dokuments vom 9. Nov. 134 v. Chr.</note>
             <note type="source">MentionedDates.fp7</note>
             <list>
                <item>
                   <ref>Z. 12-17</ref>
-                  <date type="mentioned" notBefore="-0134-10-26" notAfter="-0134-11-24">26. Okt.  - 24. Nov. 134 v.Chr.</date>
+                  <date type="mentioned" notBefore="-0134-10-26" notAfter="-0134-11-24">26. Okt. -
+                     24. Nov. 134 v.Chr.</date>
                </item>
                <item>
                   <ref>Z. 18-23</ref>
@@ -117,7 +125,8 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://digibib.ub.uni-giessen.de/cgi-bin/populo/pap.pl?t_allegro=x&amp;f_SIG=P.+Giss.+108"/>
+                  <graphic
+                     url="http://digibib.ub.uni-giessen.de/cgi-bin/populo/pap.pl?t_allegro=x&amp;f_SIG=P.+Giss.+108" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV71/70337.xml
+++ b/HGV_meta_EpiDoc/HGV71/70337.xml
@@ -38,7 +38,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV74/73316.xml
+++ b/HGV_meta_EpiDoc/HGV74/73316.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV74/73316.xml
+++ b/HGV_meta_EpiDoc/HGV74/73316.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV74/73317.xml
+++ b/HGV_meta_EpiDoc/HGV74/73317.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV74/73317.xml
+++ b/HGV_meta_EpiDoc/HGV74/73317.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV74/73319.xml
+++ b/HGV_meta_EpiDoc/HGV74/73319.xml
@@ -33,16 +33,20 @@
                   <origin>
                      <origPlace>Pathyris</origPlace>
                      <origDate xml:id="dateAlternativeX"
-                               notBefore="-0170"
-                               notAfter="-0169"
-                               cert="low">170 - 169 v.Chr. (?)</origDate>
+                        notBefore="-0170"
+                        notAfter="-0169"
+                        cert="low">170 - 169 v.Chr. (?)</origDate>
                      <origDate xml:id="dateAlternativeY" when="-0180" cert="low">180 v.Chr. (?)</origDate>
                      <origDate xml:id="dateAlternativeZ" when="-0116" cert="low">116 v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -50,8 +54,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV74/73319.xml
+++ b/HGV_meta_EpiDoc/HGV74/73319.xml
@@ -42,7 +42,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV74/73346.xml
+++ b/HGV_meta_EpiDoc/HGV74/73346.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV74/73346.xml
+++ b/HGV_meta_EpiDoc/HGV74/73346.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV74/73357.xml
+++ b/HGV_meta_EpiDoc/HGV74/73357.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV74/73357.xml
+++ b/HGV_meta_EpiDoc/HGV74/73357.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV74/73361.xml
+++ b/HGV_meta_EpiDoc/HGV74/73361.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV74/73361.xml
+++ b/HGV_meta_EpiDoc/HGV74/73361.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV74/73370.xml
+++ b/HGV_meta_EpiDoc/HGV74/73370.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV74/73370.xml
+++ b/HGV_meta_EpiDoc/HGV74/73370.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV74/73380.xml
+++ b/HGV_meta_EpiDoc/HGV74/73380.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV74/73380.xml
+++ b/HGV_meta_EpiDoc/HGV74/73380.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV74/73384.xml
+++ b/HGV_meta_EpiDoc/HGV74/73384.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV74/73384.xml
+++ b/HGV_meta_EpiDoc/HGV74/73384.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV76/75904.xml
+++ b/HGV_meta_EpiDoc/HGV76/75904.xml
@@ -37,8 +37,12 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           cert="low"
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -46,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -77,7 +81,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Griechisch - demotisch. Zur Datierung vgl. BL V, S. 158; BL XI, S. 300 und ZPE 128, 1999, S. 174. Zu Z. 3 und 5 vgl. APF 46, 2000, S. 232.</p>
+            <p>Griechisch - demotisch. Zur Datierung vgl. BL V, S. 158; BL XI, S. 300 und ZPE 128,
+               1999, S. 174. Zu Z. 3 und 5 vgl. APF 46, 2000, S. 232.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>

--- a/HGV_meta_EpiDoc/HGV76/75904.xml
+++ b/HGV_meta_EpiDoc/HGV76/75904.xml
@@ -38,7 +38,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV78/77947.xml
+++ b/HGV_meta_EpiDoc/HGV78/77947.xml
@@ -44,7 +44,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV78/77947.xml
+++ b/HGV_meta_EpiDoc/HGV78/77947.xml
@@ -33,18 +33,22 @@
                   <origin>
                      <origPlace>Pathyris</origPlace>
                      <origDate xml:id="dateAlternativeX"
-                               notBefore="-0154"
-                               notAfter="-0153"
-                               cert="low">154 - 153 v.Chr. (?)</origDate>
+                        notBefore="-0154"
+                        notAfter="-0153"
+                        cert="low">154 - 153 v.Chr. (?)</origDate>
                      <origDate xml:id="dateAlternativeY"
-                               notBefore="-0143"
-                               notAfter="-0142"
-                               cert="low">143 - 142 v.Chr. (?)</origDate>
+                        notBefore="-0143"
+                        notAfter="-0142"
+                        cert="low">143 - 142 v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -52,8 +56,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -100,7 +104,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350503"/>
+                  <graphic url="http://corsair.themorgan.org/cgi-bin/Pwebrecon.cgi?BBID=350503" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV79/78831.xml
+++ b/HGV_meta_EpiDoc/HGV79/78831.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78831.xml
+++ b/HGV_meta_EpiDoc/HGV79/78831.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -101,10 +105,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.psi-online.it/documents/psi;3;254"/>
+                  <graphic url="http://www.psi-online.it/documents/psi;3;254" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV79/78832.xml
+++ b/HGV_meta_EpiDoc/HGV79/78832.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78832.xml
+++ b/HGV_meta_EpiDoc/HGV79/78832.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -100,10 +104,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.psi-online.it/documents/psi;3;255"/>
+                  <graphic url="http://www.psi-online.it/documents/psi;3;255" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV79/78833.xml
+++ b/HGV_meta_EpiDoc/HGV79/78833.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78833.xml
+++ b/HGV_meta_EpiDoc/HGV79/78833.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -101,10 +105,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.psi-online.it/documents/psi;3;256"/>
+                  <graphic url="http://www.psi-online.it/documents/psi;3;256" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV79/78834.xml
+++ b/HGV_meta_EpiDoc/HGV79/78834.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78834.xml
+++ b/HGV_meta_EpiDoc/HGV79/78834.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -101,10 +105,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.psi-online.it/documents/psi;3;257"/>
+                  <graphic url="http://www.psi-online.it/documents/psi;3;257" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV79/78836.xml
+++ b/HGV_meta_EpiDoc/HGV79/78836.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -75,7 +79,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Zum Ort vgl. BL VIII, S. 530. Zur Datierung vgl. BL V, S. 122 und APF 46, 2000, S. 231 (versehentlich 17. März 110 v.Chr.).</p>
+            <p>Zum Ort vgl. BL VIII, S. 530. Zur Datierung vgl. BL V, S. 122 und APF 46, 2000, S.
+               231 (versehentlich 17. März 110 v.Chr.).</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -105,10 +110,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.psi-online.it/documents/psi;3;260"/>
+                  <graphic url="http://www.psi-online.it/documents/psi;3;260" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV79/78836.xml
+++ b/HGV_meta_EpiDoc/HGV79/78836.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78839.xml
+++ b/HGV_meta_EpiDoc/HGV79/78839.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -88,10 +92,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.psi-online.it/documents/psi;8;984"/>
+                  <graphic url="http://www.psi-online.it/documents/psi;8;984" />
                </figure>
             </p>
-        </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV79/78839.xml
+++ b/HGV_meta_EpiDoc/HGV79/78839.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78905.xml
+++ b/HGV_meta_EpiDoc/HGV79/78905.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78905.xml
+++ b/HGV_meta_EpiDoc/HGV79/78905.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV8/7331.xml
+++ b/HGV_meta_EpiDoc/HGV8/7331.xml
@@ -38,7 +38,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV8/7331.xml
+++ b/HGV_meta_EpiDoc/HGV8/7331.xml
@@ -37,8 +37,12 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           cert="low"
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -46,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -77,7 +81,8 @@
    <text>
       <body>
          <div type="commentary" subtype="general">
-            <p>Zum Ort vgl. BL V, S. 16. Datierung: vor 14. Regierungsjahr. Zu Z. 6-8vgl. APF 50, 2004, S. 42-44.</p>
+            <p>Zum Ort vgl. BL V, S. 16. Datierung: vor 14. Regierungsjahr. Zu Z. 6-8vgl. APF 50,
+               2004, S. 42-44.</p>
          </div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
@@ -94,7 +99,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/02589/"/>
+                  <graphic url="http://berlpap.smb.museum/02589/" />
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV8/7888.xml
+++ b/HGV_meta_EpiDoc/HGV8/7888.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV8/7888.xml
+++ b/HGV_meta_EpiDoc/HGV8/7888.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Aufhebung des Kaufvertrages P.Med. I  2 = P.Adler G 8</title>
+            <title>Aufhebung des Kaufvertrages P.Med. I 2 = P.Adler G 8</title>
          </titleStmt>
          <publicationStmt>
             <idno type="filename">7888</idno>
@@ -32,12 +32,17 @@
                <history>
                   <origin>
                      <origPlace>Pathyris</origPlace>
-                     <origDate notBefore="-0104-07-03" notAfter="-0104-07-08">3. - 8. Juli 104 v.Chr.</origDate>
+                     <origDate notBefore="-0104-07-03" notAfter="-0104-07-08">3. - 8. Juli 104
+                        v.Chr.</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +50,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV80/79050.xml
+++ b/HGV_meta_EpiDoc/HGV80/79050.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79050.xml
+++ b/HGV_meta_EpiDoc/HGV80/79050.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV9/8290.xml
+++ b/HGV_meta_EpiDoc/HGV9/8290.xml
@@ -38,7 +38,7 @@
                      <p>
                         <placeName type="ancient"
                                    cert="low"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/233">Aphroditopolis</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV9/8351.xml
+++ b/HGV_meta_EpiDoc/HGV9/8351.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV9/8351.xml
+++ b/HGV_meta_EpiDoc/HGV9/8351.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV9/8536.xml
+++ b/HGV_meta_EpiDoc/HGV9/8536.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV9/8536.xml
+++ b/HGV_meta_EpiDoc/HGV9/8536.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -45,8 +49,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>

--- a/HGV_meta_EpiDoc/HGV98/97144.xml
+++ b/HGV_meta_EpiDoc/HGV98/97144.xml
@@ -35,7 +35,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628 https://www.trismegistos.org/place/16228">Pathyris</placeName>
+                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV98/97144.xml
+++ b/HGV_meta_EpiDoc/HGV98/97144.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/2849 https://www.trismegistos.org/place/1628">Pathyris</placeName>
+                           n="1"
+                           ref="https://pleiades.stoa.org/places/786084 https://www.trismegistos.org/place/1628">
+                           Pathyris</placeName>
+                        <placeName type="ancient" subtype="nome" n="2"
+                           ref="https://www.trismegistos.org/place/2849">Pathyrites</placeName>
                      </p>
                   </provenance>
                </history>
@@ -43,8 +47,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>
+            http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>


### PR DESCRIPTION
This is a fix for #375. I've removed the erroneous TM Geo for Kareneitai in `@ref`, and have inserted a new line of xml that adds the nome. That new line includes the TM Geo for the Pathyrite nome, which was formerly included in the `@ref` for Pathyris itself. Hiving the nome off into its own line of code makes for clearer EpiDoc.