### PR TITLE
BASP 60 XWalk to HGV

### DIFF
--- a/APIS/berkeley/xml/berkeley.apis.4935.xml
+++ b/APIS/berkeley/xml/berkeley.apis.4935.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">berkeley.apis.4935</idno>
             <idno type="controlNo">(CU)4935</idno>
+            <idno type="HGV">989137</idno>
+            <idno type="TM">989137</idno>
+            <idno type="ddb-hybrid">basp;60;48_4</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/michigan/xml/michigan.apis.4012.xml
+++ b/APIS/michigan/xml/michigan.apis.4012.xml
@@ -11,6 +11,9 @@
             <authority>APIS</authority>
             <idno type="apisid">michigan.apis.4012</idno>
             <idno type="controlNo">(MiU)4012</idno>
+            <idno type="HGV">989142</idno>
+            <idno type="TM">989142</idno>
+            <idno type="ddb-hybrid">basp;60;104</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/michigan/xml/michigan.apis.4114.xml
+++ b/APIS/michigan/xml/michigan.apis.4114.xml
@@ -11,6 +11,9 @@
             <authority>APIS</authority>
             <idno type="apisid">michigan.apis.4114</idno>
             <idno type="controlNo">(MiU)4114</idno>
+            <idno type="HGV">989140</idno>
+            <idno type="TM">989140</idno>
+            <idno type="ddb-hybrid">basp;60;94</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/michigan/xml/michigan.apis.6164.xml
+++ b/APIS/michigan/xml/michigan.apis.6164.xml
@@ -11,6 +11,9 @@
             <authority>APIS</authority>
             <idno type="apisid">michigan.apis.6164</idno>
             <idno type="controlNo">(MiU)6164</idno>
+            <idno type="HGV">989138</idno>
+            <idno type="TM">989138</idno>
+            <idno type="ddb-hybrid">basp;60;76</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/michigan/xml/michigan.apis.6175.xml
+++ b/APIS/michigan/xml/michigan.apis.6175.xml
@@ -11,6 +11,9 @@
             <authority>APIS</authority>
             <idno type="apisid">michigan.apis.6175</idno>
             <idno type="controlNo">(MiU)6175</idno>
+            <idno type="HGV">989139</idno>
+            <idno type="TM">989139</idno>
+            <idno type="ddb-hybrid">basp;60;84</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/michigan/xml/michigan.apis.6326.xml
+++ b/APIS/michigan/xml/michigan.apis.6326.xml
@@ -11,6 +11,9 @@
             <authority>APIS</authority>
             <idno type="apisid">michigan.apis.6326</idno>
             <idno type="controlNo">(MiU)6326</idno>
+            <idno type="HGV">989141</idno>
+            <idno type="TM">989141</idno>
+            <idno type="ddb-hybrid">basp;60;100</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/princeton/xml/princeton.apis.p490.xml
+++ b/APIS/princeton/xml/princeton.apis.p490.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">princeton.apis.p490</idno>
             <idno type="controlNo">(NjP)apis.p0490</idno>
+            <idno type="TM">566128</idno>
+            <idno type="HGV">566128</idno>
+            <idno type="ddb-hybrid">basp;60;175</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/APIS/princeton/xml/princeton.apis.p505.xml
+++ b/APIS/princeton/xml/princeton.apis.p505.xml
@@ -10,6 +10,9 @@
             <authority>APIS</authority>
             <idno type="apisid">princeton.apis.p505</idno>
             <idno type="controlNo">(NjP)apis.p0505</idno>
+            <idno type="HGV">566135</idno>
+            <idno type="TM">566135</idno>
+            <idno type="ddb-hybrid">basp;60;159</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/HGV_meta_EpiDoc/HGV567/566128.xml
+++ b/HGV_meta_EpiDoc/HGV567/566128.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Byzantine Letter to an Exceptor (P.Princ. GD 7634)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">566128</idno>
+                <idno type="TM">566128</idno>
+                <idno type="ddb-filename">basp.60.175</idno>
+                <idno type="ddb-hybrid">basp;60;175</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Princeton</settlement>
+                        </placeName>
+                        <collection>University Library</collection>
+                        <idno type="invNo">P.Princ. GD 7634</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>unbekannt</origPlace>
+                            <origDate notBefore="0576" notAfter="0600" precision="low">Ende VI</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient" subtype="region">Ägypten</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96553" />
+                        <biblScope type="pp">175</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Brief</term>
+                    <term n="2">Exceptor</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 175</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 177</bibl>
+                </p>
+            </div>
+            <div type="figure">
+                <p>
+                    <figure n="1">
+                        <graphic url="https://dpul.princeton.edu/papyri/catalog/gh93h3018" />
+                    </figure>
+                </p>
+            </div>
+
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV567/566135.xml
+++ b/HGV_meta_EpiDoc/HGV567/566135.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Letter to a Magister from the Oxyrhynchite Nome (P.Princ. GD 7618; Sixth Century)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">566135</idno>
+                <idno type="TM">566135</idno>
+                <idno type="ddb-filename">basp.60.159</idno>
+                <idno type="ddb-hybrid">basp;60;159</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Princeton</settlement>
+                        </placeName>
+                        <collection>University Library</collection>
+                        <idno type="invNo">P.Princ. GD 7618</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Oxyrhynchites</origPlace>
+                            <origDate notBefore="0501" notAfter="0600">VI</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient" subtype="nome"
+                                    ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">
+                                    Oxyrhynchites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96552" />
+                        <biblScope type="pp">159</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Brief</term>
+                    <term n="2">Magister</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 159</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 150, 151</bibl>
+                </p>
+            </div>
+            <div type="figure">
+                <p>
+                    <figure n="1">
+                        <graphic url="https://dpul.princeton.edu/papyri/catalog/br86b7083" />
+                    </figure>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV987/986846.xml
+++ b/HGV_meta_EpiDoc/HGV987/986846.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Proposal to Become the Lesonis of Harsaphes (P.Tebt. Frag. 12190; 179 BCE)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">986846</idno>
+                <idno type="TM">986846</idno>
+                <idno type="ddb-filename">basp.60.16</idno>
+                <idno type="ddb-hybrid">basp;60;16</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Berkeley</settlement>
+                        </placeName>
+                        <collection>Bancroft Library</collection>
+                        <idno type="invNo">P.Tebt. Frag. 12190</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Oxyrhyncha ? (Arsinoites)</origPlace>
+                            <origDate when="0179">179</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName n="1"
+                                    type="ancient"
+                                    cert="low"
+                                    ref="https://www.trismegistos.org/place/1523 https://pleiades.stoa.org/places/741540">
+                                    Oxyrhyncha</placeName>
+                                <placeName n="2" type="ancient" subtype="nome">Arsinoites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Vorschlag</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV
+                entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 16</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 19</bibl>
+                </p>
+            </div>
+            <div type="commentary" subtype="general">
+                <p>Demotisch.</p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV989/988032.xml
+++ b/HGV_meta_EpiDoc/HGV989/988032.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Copy of Judicial Proceedings (P.Tebt. UC 1589-1591; Late Second Century BCE)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">988032</idno>
+                <idno type="TM">988032</idno>
+                <idno type="ddb-filename">basp.60.62</idno>
+                <idno type="ddb-hybrid">basp;60;62</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Berkeley</settlement>
+                        </placeName>
+                        <collection>Bancroft Library</collection>
+                        <idno type="invNo">P.Tebt. UC 1589-1591</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Tebtunis (Arsinoites)</origPlace>
+                            <origDate notBefore="-0125" notAfter="-0101" precision="low">Ende II v.Chr.</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName n="1" type="ancient"
+                                    ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">
+                                    Tebtynis</placeName>
+                                <placeName n="2" type="ancient" subtype="nome">Arsinoites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96561" />
+                        <biblScope type="pp">62</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Akten</term>
+                    <term n="2">Prozeß</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 62</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 63</bibl>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989134.xml
+++ b/HGV_meta_EpiDoc/HGV990/989134.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Marriage Contract</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989134</idno>
+                <idno type="TM">989134</idno>
+                <idno type="ddb-filename">basp.60.35_1</idno>
+                <idno type="ddb-hybrid">basp;60;35_1</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Berkeley</settlement>
+                        </placeName>
+                        <collection>Bancroft Library</collection>
+                        <idno type="invNo">P.Tebt. Frag. 15161</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Tebtunis (Arsinoites)</origPlace>
+                            <origDate n="1" xml:id="dateAlternativeX" when="-0158">158 v.Chr.</origDate>
+                            <origDate n="2" xml:id="dateAlternativeY" when="-0157">157 v.Chr.</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient"
+                                    ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">Tebtynis</placeName>
+                                <placeName type="ancient" subtype="nome">Arsinoites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Vertrag</term>
+                    <term n="2">Heirat</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 35</biblScope>
+                        <biblScope type="number">Nr. 1</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 35, 36</bibl>
+                </p>
+            </div>
+            <div type="commentary" subtype="general">
+                <p>Demotisch.</p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989135.xml
+++ b/HGV_meta_EpiDoc/HGV990/989135.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Marriage Contract</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989135</idno>
+                <idno type="TM">989135</idno>
+                <idno type="ddb-filename">basp.60.40_2</idno>
+                <idno type="ddb-hybrid">basp;60;40_2</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Berkeley</settlement>
+                        </placeName>
+                        <collection>Bancroft Library</collection>
+                        <idno type="invNo">P.Tebt. Frag. 15162</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Tebtunis (Arsinoites)</origPlace>
+                            <origDate n="1" xml:id="dateAlternativeX" when="-0158">158 v.Chr.</origDate>
+                            <origDate n="2" xml:id="dateAlternativeY" when="-0157">157 v.Chr.</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient"
+                                    ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">Tebtynis</placeName>
+                                <placeName type="ancient" subtype="nome">Arsinoites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Vertrag</term>
+                    <term n="2">Heirat</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 40</biblScope>
+                        <biblScope type="number">Nr. 2</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 41</bibl>
+                </p>
+            </div>
+            <div type="commentary" subtype="general">
+                <p>Demotisch.</p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989136.xml
+++ b/HGV_meta_EpiDoc/HGV990/989136.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Marriage Contract</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989136</idno>
+                <idno type="TM">989136</idno>
+                <idno type="ddb-filename">basp.60.43_3</idno>
+                <idno type="ddb-hybrid">basp;60;43_3</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Berkeley</settlement>
+                        </placeName>
+                        <collection>Bancroft Library</collection>
+                        <idno type="invNo">P.Tebt. Frag. 402</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Tebtunis (Arsinoites)</origPlace>
+                            <origDate notBefore="-0149" notAfter="-0140">149 - 140 v.Chr.</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient"
+                                    ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">
+                                    Tebtynis</placeName>
+                                <placeName type="ancient" subtype="nome">Arsinoites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Vertrag</term>
+                    <term n="2">Heirat</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 43</biblScope>
+                        <biblScope type="number">Nr. 3</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 44</bibl>
+                </p>
+            </div>
+            <div type="commentary" subtype="general">
+                <p>Demotisch.</p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989137.xml
+++ b/HGV_meta_EpiDoc/HGV990/989137.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Marriage Contract</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989137</idno>
+                <idno type="TM">989137</idno>
+                <idno type="ddb-filename">basp.60.48_4</idno>
+                <idno type="ddb-hybrid">basp;60;48_4</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Berkeley</settlement>
+                        </placeName>
+                        <collection>Bancroft Library</collection>
+                        <idno type="invNo">P.Tebt. Frag. 411+412</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Tebtunis (Arsinoites)</origPlace>
+                            <origDate notBefore="-0275" notAfter="-0226" precision="low">Mitte III
+                                v.Chr.</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient"
+                                    ref="https://www.trismegistos.org/place/2287 https://pleiades.stoa.org/places/737072">
+                                    Tebtynis</placeName>
+                                <placeName type="ancient" subtype="nome">Arsinoites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Vertrag</term>
+                    <term n="2">Heirat</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 48</biblScope>
+                        <biblScope type="number">Nr. 4</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 49, 50</bibl>
+                </p>
+            </div>
+            <div type="commentary" subtype="general">
+                <p>Demotisch.</p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989138.xml
+++ b/HGV_meta_EpiDoc/HGV990/989138.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Petition to the Archiphylakites Asklepiades (P.Mich. inv. 1322; Peran, 182 BCE?)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989138</idno>
+                <idno type="TM">989138</idno>
+                <idno type="ddb-filename">basp.60.76</idno>
+                <idno type="ddb-hybrid">basp;60;76</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Ann Arbor</settlement>
+                        </placeName>
+                        <collection>Michigan University Library</collection>
+                        <idno type="invNo">P.Mich. inv. 1322</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Peran (Herakleopolites)</origPlace>
+                            <origDate when="-0182-12-13" cert="low">13. Dez. 182 v.Chr. (?)</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient"
+                                    ref="https://www.trismegistos.org/place/6491">Peran</placeName>
+                                <placeName type="ancient" subtype="nome">Herakleopolites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96562" />
+                        <biblScope type="pp">76</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Eingabe an den Archiphylakites Asklepiades</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 76</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 79</bibl>
+                </p>
+            </div>
+            <div type="figure">
+                <p>
+                    <figure n="1">
+                        <graphic url="https://quod.lib.umich.edu/a/apis/x-6164" />
+                    </figure>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989139.xml
+++ b/HGV_meta_EpiDoc/HGV990/989139.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Poll Tax Receipt from Arsinoe (P.Mich. inv. 1336; 133 CE)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989139</idno>
+                <idno type="TM">989139</idno>
+                <idno type="ddb-filename">basp.60.84</idno>
+                <idno type="ddb-hybrid">basp;60;84</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Ann Arbor</settlement>
+                        </placeName>
+                        <collection>Michigan University Library</collection>
+                        <idno type="invNo">P.Mich. inv. 1336</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Arsinoe (Arsinoites)</origPlace>
+                            <origDate when="0133-09-04">4. Sept. 133</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient"
+                                    ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">
+                                    Arsinoe</placeName>
+                                <placeName type="ancient" subtype="nome">Arsinoites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96563" />
+                        <biblScope type="pp">84</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Quittung</term>
+                    <term n="2">Kopfsteuer</term>
+                    <term n="3">Geld</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 84</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 85</bibl>
+                </p>
+            </div>
+            <div type="figure">
+                <p>
+                    <figure n="1">
+                        <graphic url="https://quod.lib.umich.edu/a/apis/x-6175" />
+                    </figure>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989140.xml
+++ b/HGV_meta_EpiDoc/HGV990/989140.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Nomination of Four Village Elders of Psinteo (P.Mich. inv. 214; 167 CE)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989140</idno>
+                <idno type="TM">989140</idno>
+                <idno type="ddb-filename">basp.60.94</idno>
+                <idno type="ddb-hybrid">basp;60;94</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Ann Arbor</settlement>
+                        </placeName>
+                        <collection>Michigan University Library</collection>
+                        <idno type="invNo">P.Mich. inv. 214</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Psinteo (Arsinoites)</origPlace>
+                            <origDate notBefore="0167-02-25" notAfter="0167-03-26">25. Febr. - 26. März 167</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient"
+                                    ref="https://www.trismegistos.org/place/1991 https://pleiades.stoa.org/places/741580">
+                                    Psinteo</placeName>
+                                <placeName type="ancient" subtype="nome">Arsinoites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96564" />
+                        <biblScope type="pp">94</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Nominierung</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 94</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 95</bibl>
+                </p>
+            </div>
+            <div type="figure">
+                <p>
+                    <figure n="1">
+                        <graphic url="https://quod.lib.umich.edu/a/apis/x-4114" />
+                    </figure>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989142.xml
+++ b/HGV_meta_EpiDoc/HGV990/989142.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Rent Receipt for a Warehouse from Oxyrhynchus (P.Mich. inv. 1049; 478 CE)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989142</idno>
+                <idno type="TM">989142</idno>
+                <idno type="ddb-filename">basp.60.104</idno>
+                <idno type="ddb-hybrid">basp;60;104</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Ann Arbor</settlement>
+                        </placeName>
+                        <collection>Michigan University Library</collection>
+                        <idno type="invNo">P.Mich. inv. 1049</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Oxyrhynchus (Oxyrhynchites)</origPlace>
+                            <origDate notBefore="0478-07-25" notAfter="0478-08-23">25. Juli - 23. Aug. 478</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName n="1"
+                                    type="ancient"
+                                    ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">
+                                    Oxyrhynchus</placeName>
+                                <placeName n="2" type="ancient" subtype="nome">Oxyrhynchites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96544" />
+                        <biblScope type="pp">104</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Quittung</term>
+                    <term n="2">Pacht</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 104</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 105</bibl>
+                </p>
+            </div>
+            <div type="figure">
+                <p>
+                    <figure n="1">
+                        <graphic url="https://quod.lib.umich.edu/a/apis/x-4012" />
+                    </figure>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989162.xml
+++ b/HGV_meta_EpiDoc/HGV990/989162.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Order for Payment to a Stonecutter from Oxyrhynchus (P.Wash.Univ. inv. 272; 480 CE)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989162</idno>
+                <idno type="TM">989162</idno>
+                <idno type="ddb-filename">basp.60.110</idno>
+                <idno type="ddb-hybrid">basp;60;110</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>St. Louis</settlement>
+                        </placeName>
+                        <collection>Washington University</collection>
+                        <idno type="invNo">P.Wash.Univ. inv. 272</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Oxyrhynchus (Oxyrhynchites)</origPlace>
+                            <origDate when="0480-01-10">10. Jan. 480</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName n="1"
+                                    type="ancient"
+                                    ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">
+                                    Oxyrhynchus</placeName>
+                                <placeName n="2" type="ancient" subtype="nome">Oxyrhynchites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96545" />
+                        <biblScope type="pp">110</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Anweisung</term>
+                    <term n="2">Zahlung</term>
+                    <term n="3">Steinmetz</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 110</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 111</bibl>
+                </p>
+            </div>
+
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989163.xml
+++ b/HGV_meta_EpiDoc/HGV990/989163.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Slave Sale from Hermopolis (P.Vindob. G 13290 Ro; Sixth/Seventh Century)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989163</idno>
+                <idno type="TM">989163</idno>
+                <idno type="ddb-filename">basp.60.118</idno>
+                <idno type="ddb-hybrid">basp;60;118</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Vienna</settlement>
+                        </placeName>
+                        <collection>Nationalbibliothek</collection>
+                        <idno type="invNo">P.Vindob. G 13290 Ro</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Hermopolis (Hermopolites)</origPlace>
+                            <origDate notBefore="0501" notAfter="0700">VI - VII</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient"
+                                    ref="https://www.trismegistos.org/place/816 https://pleiades.stoa.org/places/756574">
+                                    Hermopolis</placeName>
+                                <placeName type="ancient" subtype="nome">Hermopolites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96547" />
+                        <biblScope type="pp">118</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Vertrag</term>
+                    <term n="2">Verkauf</term>
+                    <term n="3">Sklave</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 118</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 118</bibl>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989164.xml
+++ b/HGV_meta_EpiDoc/HGV990/989164.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Early Roman Letter of Recommendation for a Skipper (O.Sydney NMR 107)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989164</idno>
+                <idno type="TM">989164</idno>
+                <idno type="ddb-filename">basp.60.128</idno>
+                <idno type="ddb-hybrid">basp;60;128</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Sydney</settlement>
+                        </placeName>
+                        <collection>Nicholson Museum</collection>
+                        <idno type="invNo">O.Sydney NMR 107</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Ostrakon</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Oberägypten</origPlace>
+                            <origDate notBefore="-0025" notAfter="0025" precision="low">Ende I v.Chr. - Anfang I</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient"
+                                    ref="https://www.trismegistos.org/place/2766">Oberägypten</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96548" />
+                        <biblScope type="pp">128</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Brief (amtlich)</term>
+                    <term n="2">Empfehlungsschreiben</term>
+                    <term n="3">Schiffer</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 128</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 128</bibl>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989165.xml
+++ b/HGV_meta_EpiDoc/HGV990/989165.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Wage Receipt from Herakleopolis (?) (P.Vindob. G 26628; Fifth/Sixth Century)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989165</idno>
+                <idno type="TM">989165</idno>
+                <idno type="ddb-filename">basp.60.134</idno>
+                <idno type="ddb-hybrid">basp;60;134</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Vienna</settlement>
+                        </placeName>
+                        <collection>Nationalbibliothek</collection>
+                        <idno type="invNo">P.Vindob. G 26628</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Herakleopolis ? (Herakleopolites)</origPlace>
+                            <origDate notBefore="0451" notAfter="0600" precision="low">2. Hälfte V - VI</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName n="1"
+                                    type="ancient"
+                                    cert="low"
+                                    ref="https://www.trismegistos.org/place/801 https://pleiades.stoa.org/places/736920">
+                                    Herakleopolis</placeName>
+                                <placeName n="2" type="ancient" subtype="nome">Herakleopolites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96549" />
+                        <biblScope type="pp">134</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Quittung</term>
+                    <term n="2">Geld</term>
+                    <term n="3">Lohn</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 134</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 134</bibl>
+                </p>
+            </div>
+            <div type="figure">
+                <p>
+                    <figure n="1">
+                        <graphic url="http://data.onb.ac.at/rec/RZ00010809" />
+                    </figure>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989168.xml
+++ b/HGV_meta_EpiDoc/HGV990/989168.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Sharecropping Lease from the Arsinoite Nome (P.Vindob. G 26584; Sixth/Early
+                    Seventh Century)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989168</idno>
+                <idno type="TM">989168</idno>
+                <idno type="ddb-filename">basp.60.141</idno>
+                <idno type="ddb-hybrid">basp;60;141</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Vienna</settlement>
+                        </placeName>
+                        <collection>Nationalbibliothek</collection>
+                        <idno type="invNo">P.Vindob. G 26584</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Tetrathyron (Arsinoites)</origPlace>
+                            <origDate notBefore="0501" notAfter="0625" precision="low">VI - Anfang VII</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient"
+                                    ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">
+                                    Tetrathyron</placeName>
+                                <placeName type="ancient" subtype="nome">Arsinoites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96550" />
+                        <biblScope type="pp">141</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Vertrag</term>
+                    <term n="2">Pacht</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 141</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 143</bibl>
+                </p>
+            </div>
+            <div type="figure">
+                <p>
+                    <figure n="1">
+                        <graphic url="http://data.onb.ac.at/rec/RZ00010808" />
+                    </figure>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989169.xml
+++ b/HGV_meta_EpiDoc/HGV990/989169.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Bilateral Contract from the Hermopolite Nome (?) (P.Vindob. G 27527; First Half Seventh Century)</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989169</idno>
+                <idno type="TM">989169</idno>
+                <idno type="ddb-filename">basp.60.153</idno>
+                <idno type="ddb-hybrid">basp;60;153</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Vienna</settlement>
+                        </placeName>
+                        <collection>Nationalbibliothek</collection>
+                        <idno type="invNo">P.Vindob. G 27527</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Hermopolites (?)</origPlace>
+                            <origDate notBefore="0601" notAfter="0650" precision="low">1. Hälfte VII</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient" subtype="nome" cert="low"
+                                    ref="https://www.trismegistos.org/place/2720 https://pleiades.stoa.org/places/756575">
+                                    Hermopolites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96551" />
+                        <biblScope type="pp">153</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Vertrag</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 153</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 153</bibl>
+                </p>
+            </div>
+            <div type="figure">
+                <p>
+                    <figure n="1">
+                        <graphic url="http://data.onb.ac.at/rec/RZ00020168" />
+                    </figure>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989170.xml
+++ b/HGV_meta_EpiDoc/HGV990/989170.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Loan of Two Solidi from John the Salter</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989170</idno>
+                <idno type="TM">989170</idno>
+                <idno type="ddb-filename">basp.60.188_1</idno>
+                <idno type="ddb-hybrid">basp;60;188_1</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>London</settlement>
+                        </placeName>
+                        <collection>British Library</collection>
+                        <idno type="invNo">Papyrus 2422</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Arsinoe (Arsinoites)</origPlace>
+                            <origDate notBefore="0574-03" notAfter="0574-06">März - Juni 574</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName type="ancient"
+                                    ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">
+                                    Arsinoe</placeName>
+                                <placeName type="ancient" subtype="nome">Arsinoites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96554" />
+                        <biblScope type="pp">188</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Vertrag</term>
+                    <term n="2">Darlehen</term>
+                    <term n="3">Geld</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 188</biblScope>
+                        <biblScope type="number">Nr. 1</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 189</bibl>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV990/989177.xml
+++ b/HGV_meta_EpiDoc/HGV990/989177.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Land Survey</title>
+            </titleStmt>
+            <publicationStmt>
+                <idno type="filename">989177</idno>
+                <idno type="TM">989177</idno>
+                <idno type="ddb-filename">basp.60.28</idno>
+                <idno type="ddb-hybrid">basp;60;28</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <placeName>
+                            <settlement>Berkeley</settlement>
+                        </placeName>
+                        <collection>Bancroft Library</collection>
+                        <idno type="invNo">P.Tebt. Frag. 12190 verso</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>
+                                    <material>Papyrus</material>
+                                </support>
+                            </supportDesc>
+                        </objectDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Oxyrhyncha ? (Arsinoites)</origPlace>
+                            <origDate n="1" xml:id="dateAlternativeX" when="-0178">178 v.Chr.</origDate>
+                            <origDate n="2" xml:id="dateAlternativeY" when="-0167">167 v.Chr.</origDate>
+                        </origin>
+                        <provenance type="located">
+                            <p>
+                                <placeName n="1"
+                                    type="ancient"
+                                    cert="low"
+                                    ref="https://www.trismegistos.org/place/1523 https://pleiades.stoa.org/places/741540">
+                                    Oxyrhyncha</placeName>
+                                <placeName n="2" type="ancient" subtype="nome">Arsinoites</placeName>
+                            </p>
+                        </provenance>
+                    </history>
+                </msDesc>
+                <listBibl>
+                    <bibl type="SB">
+                        <ptr target="https://papyri.info/biblio/96546" />
+                        <biblScope type="pp">28</biblScope>
+                    </bibl>
+                </listBibl>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="fr">Französisch</language>
+                <language ident="en">Englisch</language>
+                <language ident="de">Deutsch</language>
+                <language ident="it">Italienisch</language>
+                <language ident="es">Spanisch</language>
+                <language ident="la">Latein</language>
+                <language ident="el">Griechisch</language>
+            </langUsage>
+            <textClass>
+                <keywords scheme="hgv">
+                    <term n="1">Register (Land)</term>
+                </keywords>
+            </textClass>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2023-12-19" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography" subtype="principalEdition">
+                <listBibl>
+                    <bibl type="publication" subtype="principal">
+                        <title level="s" type="abbreviated">BASP</title>
+                        <biblScope type="volume">60</biblScope>
+                        <biblScope type="fascicle">(2023)</biblScope>
+                        <biblScope type="pages">S. 28</biblScope>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="bibliography" subtype="illustrations">
+                <p>
+                    <bibl type="illustration">S. 29</bibl>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
Here are new files for HGV from BASP 60. I went easy on the keywords, but SB XML has been added where appropriate. The APIS entries for Princeton, Michigan, and Berkeley have also been updated with the appropriate idnos.