### PR TITLE
Fixes markup issues

### DIFF
--- a/APD/apd12t.xml
+++ b/APD/apd12t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="12" xml:id="pap(B)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="12" xml:id="pap-B" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd16t.xml
+++ b/APD/apd16t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="16" xml:id="pap(A)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="16" xml:id="pap-A" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd17t.xml
+++ b/APD/apd17t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="17" xml:id="pap(C)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="17" xml:id="pap-C" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd18t.xml
+++ b/APD/apd18t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="18" xml:id="pap(D)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="18" xml:id="pap-D" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd21t.xml
+++ b/APD/apd21t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="21" xml:id="pap(E)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="21" xml:id="pap-E" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd22t.xml
+++ b/APD/apd22t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="22" xml:id="pap(F)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="22" xml:id="pap-F" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd23t.xml
+++ b/APD/apd23t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="23" xml:id="pap(G)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="23" xml:id="pap-G" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd24t.xml
+++ b/APD/apd24t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="24" xml:id="pap(H)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="24" xml:id="pap-H" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd25t.xml
+++ b/APD/apd25t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="25" xml:id="pap(I)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="25" xml:id="pap-I" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd26t.xml
+++ b/APD/apd26t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="26" xml:id="pap(K)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="26" xml:id="pap-K" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd27t.xml
+++ b/APD/apd27t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="27" xml:id="pap(L)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="27" xml:id="pap-L" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd32t.xml
+++ b/APD/apd32t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="32" xml:id="pap(2)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="32" xml:id="pap-2" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd34t.xml
+++ b/APD/apd34t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="34" xml:id="pap(3)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="34" xml:id="pap-3" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd35t.xml
+++ b/APD/apd35t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="35" xml:id="pap(4)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="35" xml:id="pap-4" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd36t.xml
+++ b/APD/apd36t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="36" xml:id="pap(5)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="36" xml:id="pap-5" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd37t.xml
+++ b/APD/apd37t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="37" xml:id="pap(6)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="37" xml:id="pap-6" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd41t.xml
+++ b/APD/apd41t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="41" xml:id="pap(10)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="41" xml:id="pap-10" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd42t.xml
+++ b/APD/apd42t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="42" xml:id="pap(11)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="42" xml:id="pap-11" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd44t.xml
+++ b/APD/apd44t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="44" xml:id="pap(13)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="44" xml:id="pap-13" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd45t.xml
+++ b/APD/apd45t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="45" xml:id="pap(14)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="45" xml:id="pap-14" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd46t.xml
+++ b/APD/apd46t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="46" xml:id="pap(15)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="46" xml:id="pap-15" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd47t.xml
+++ b/APD/apd47t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="47" xml:id="pap(16)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="47" xml:id="pap-16" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd48t.xml
+++ b/APD/apd48t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="48" xml:id="pap(17)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="48" xml:id="pap-17" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd49t.xml
+++ b/APD/apd49t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="49" xml:id="pap(18)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="49" xml:id="pap-18" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd50t.xml
+++ b/APD/apd50t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="50" xml:id="pap(21)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="50" xml:id="pap-21" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd51t.xml
+++ b/APD/apd51t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="51" xml:id="pap(22)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="51" xml:id="pap-22" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd57t.xml
+++ b/APD/apd57t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="57" xml:id="pap(19)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="57" xml:id="pap-19" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd59t.xml
+++ b/APD/apd59t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="59" xml:id="pap(23new)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="59" xml:id="pap-23new" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/APD/apd60t.xml
+++ b/APD/apd60t.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?oxygen RNGSchema="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="xml"?>
 
-<TEI xmlns="http://www.tei-c.org/ns/1.0" n="60" xml:id="pap(24)" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" n="60" xml:id="pap-24" xml:lang="en">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/HGV_meta_EpiDoc/HGV26/25169.xml
+++ b/HGV_meta_EpiDoc/HGV26/25169.xml
@@ -94,7 +94,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://libweb.princeton.edu/libraries/firestone/rbsc/aids/papyri/theano.html&#xA;"/>
+                  <graphic url="http://libweb.princeton.edu/libraries/firestone/rbsc/aids/papyri/theano.html"/>
                </figure>
                <figure>
                   <graphic url="https://dpul.princeton.edu/papyri/catalog/rr172173c"/>


### PR DESCRIPTION
a part of the fixes targets invalid XML where parenthesis are used as xml:id values. that makes it impossible for strict XML processors to load the affected document.

some Windows OS-based editors seem to been used as one URL ended with a LF entitity which is unexpected and depending on the client code / used URL parser might lead to problems.

there are also several occurances of `&#xD` (CR) in change records without any semantical significance, certainly stemming from the Windows editor world, and possibly an annoyance for users. let me know if i should amend an removal of these as well.