### PR TITLE
Corrected empty origPlace elements

### DIFF
--- a/HGV_meta_EpiDoc/HGV119/118283.xml
+++ b/HGV_meta_EpiDoc/HGV119/118283.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Bawit (Hermopolites)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129759.xml
+++ b/HGV_meta_EpiDoc/HGV130/129759.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129760.xml
+++ b/HGV_meta_EpiDoc/HGV130/129760.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129761.xml
+++ b/HGV_meta_EpiDoc/HGV130/129761.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129762.xml
+++ b/HGV_meta_EpiDoc/HGV130/129762.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129763.xml
+++ b/HGV_meta_EpiDoc/HGV130/129763.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129764.xml
+++ b/HGV_meta_EpiDoc/HGV130/129764.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129765.xml
+++ b/HGV_meta_EpiDoc/HGV130/129765.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129766.xml
+++ b/HGV_meta_EpiDoc/HGV130/129766.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129767.xml
+++ b/HGV_meta_EpiDoc/HGV130/129767.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129768.xml
+++ b/HGV_meta_EpiDoc/HGV130/129768.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129769.xml
+++ b/HGV_meta_EpiDoc/HGV130/129769.xml
@@ -29,10 +29,15 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0640" notAfter="0700">
                         <precision match="../@notBefore" degree="0.5"/>ca. 640 - 700</origDate>
                   </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
+                     </p>
+                  </provenance>
                </history>
             </msDesc>
          </sourceDesc>

--- a/HGV_meta_EpiDoc/HGV130/129770.xml
+++ b/HGV_meta_EpiDoc/HGV130/129770.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129771.xml
+++ b/HGV_meta_EpiDoc/HGV130/129771.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129772.xml
+++ b/HGV_meta_EpiDoc/HGV130/129772.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129773.xml
+++ b/HGV_meta_EpiDoc/HGV130/129773.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129775.xml
+++ b/HGV_meta_EpiDoc/HGV130/129775.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129776.xml
+++ b/HGV_meta_EpiDoc/HGV130/129776.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129777.xml
+++ b/HGV_meta_EpiDoc/HGV130/129777.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129778.xml
+++ b/HGV_meta_EpiDoc/HGV130/129778.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0640" notAfter="0700">
                         <precision match="../@notBefore" degree="0.5"/>ca. 640 - 700</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129779.xml
+++ b/HGV_meta_EpiDoc/HGV130/129779.xml
@@ -29,9 +29,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
                   </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
+                     </p>
+                  </provenance>
                </history>
             </msDesc>
          </sourceDesc>

--- a/HGV_meta_EpiDoc/HGV130/129780.xml
+++ b/HGV_meta_EpiDoc/HGV130/129780.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129781.xml
+++ b/HGV_meta_EpiDoc/HGV130/129781.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129782.xml
+++ b/HGV_meta_EpiDoc/HGV130/129782.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129783.xml
+++ b/HGV_meta_EpiDoc/HGV130/129783.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129784.xml
+++ b/HGV_meta_EpiDoc/HGV130/129784.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129785.xml
+++ b/HGV_meta_EpiDoc/HGV130/129785.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129786.xml
+++ b/HGV_meta_EpiDoc/HGV130/129786.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0643" notAfter="0644">
                         <precision match="../@notBefore" degree="0.5"/>ca. 643 - 644</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129788.xml
+++ b/HGV_meta_EpiDoc/HGV130/129788.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Ptolemais Euergetis (Arsinoites)</origPlace>
                      <origDate notBefore="0138" notAfter="0143">138 - 143</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129789.xml
+++ b/HGV_meta_EpiDoc/HGV130/129789.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Antinoopolis?</origPlace>
                      <origDate notBefore="0176" notAfter="0225" precision="low">Ende II - Anfang III</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129790.xml
+++ b/HGV_meta_EpiDoc/HGV130/129790.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Oxyrhynchos</origPlace>
                      <origDate when="0267-10-07">7. Okt. 267</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129791.xml
+++ b/HGV_meta_EpiDoc/HGV130/129791.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermontis?</origPlace>
                      <origDate notBefore="0539" notAfter="0570">
                         <precision match="../@notBefore" degree="0.5"/>ca. 539 - 570</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129792.xml
+++ b/HGV_meta_EpiDoc/HGV130/129792.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0576" notAfter="0625" precision="low">Ende VI - Anfang VII</origDate>
                   </origin>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129793.xml
+++ b/HGV_meta_EpiDoc/HGV130/129793.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Arsinoiton Polis?</origPlace>
                      <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129794.xml
+++ b/HGV_meta_EpiDoc/HGV130/129794.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Maximianopolis</origPlace>
                      <origDate notBefore="0301" notAfter="0350" precision="low">1. Hälfte IV</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129795.xml
+++ b/HGV_meta_EpiDoc/HGV130/129795.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
                   </origin>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129796.xml
+++ b/HGV_meta_EpiDoc/HGV130/129796.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129797.xml
+++ b/HGV_meta_EpiDoc/HGV130/129797.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Oxyrhynchites</origPlace>
                      <origDate notBefore="0335-08-30" notAfter="0335-09-28">30. Aug. - 28. Sept. 335</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129799.xml
+++ b/HGV_meta_EpiDoc/HGV130/129799.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Ordre de forniture de viande</title>
+            <title>Ordre de fourniture de viande</title>
          </titleStmt>
          <publicationStmt>
             <idno type="filename">129799</idno>
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Oxyrhynchos</origPlace>
                      <origDate when="0385-11-14">14. Nov. 385</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129800.xml
+++ b/HGV_meta_EpiDoc/HGV130/129800.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0576" notAfter="0600" precision="low">Ende VI</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129801.xml
+++ b/HGV_meta_EpiDoc/HGV130/129801.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites?</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129802.xml
+++ b/HGV_meta_EpiDoc/HGV130/129802.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129803.xml
+++ b/HGV_meta_EpiDoc/HGV130/129803.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Arsinoites?</origPlace>
                      <origDate notBefore="0601" notAfter="0625" precision="low">Anfang VII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129804.xml
+++ b/HGV_meta_EpiDoc/HGV130/129804.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Oxyrhynchos</origPlace>
                      <origDate notBefore="0468-10-11" notAfter="0468-12-31" cert="low">11. Okt. - 31. Dez. 468 (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129805.xml
+++ b/HGV_meta_EpiDoc/HGV130/129805.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Oxyrhynchos</origPlace>
                      <origDate notBefore="0401" notAfter="0500" precision="low">V</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129806.xml
+++ b/HGV_meta_EpiDoc/HGV130/129806.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Aphrodites Kome? (Antaiopolites)</origPlace>
                      <origDate notBefore="0551" notAfter="0552" cert="low">551 - 552 (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129808.xml
+++ b/HGV_meta_EpiDoc/HGV130/129808.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolis</origPlace>
                      <origDate notBefore="0473" notAfter="0490">473 - 490</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129809.xml
+++ b/HGV_meta_EpiDoc/HGV130/129809.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129811.xml
+++ b/HGV_meta_EpiDoc/HGV130/129811.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Leukogion (Herakleopolites)</origPlace>
                      <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129812.xml
+++ b/HGV_meta_EpiDoc/HGV130/129812.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Sinarchebis (Hermopolites)</origPlace>
                      <origDate xml:id="dateAlternativeX" when="0525-03-28">
                         <certainty locus="value" match="../year-from-date(@when)"/>28. März 525 (Jahr unsicher)</origDate>
                      <origDate xml:id="dateAlternativeY" when="0526-03-28">

--- a/HGV_meta_EpiDoc/HGV130/129813.xml
+++ b/HGV_meta_EpiDoc/HGV130/129813.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Herakleopolites</origPlace>
                      <origDate when="0532-03-30">30. März 532</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129814.xml
+++ b/HGV_meta_EpiDoc/HGV130/129814.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites?</origPlace>
                      <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129815.xml
+++ b/HGV_meta_EpiDoc/HGV130/129815.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0651" notAfter="0700" precision="low">2. Hälfte VII</origDate>
                   </origin>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129816.xml
+++ b/HGV_meta_EpiDoc/HGV130/129816.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0619" notAfter="0629">
                         <precision match="../@notBefore" degree="0.5"/>ca. 619 - 629</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV130/129818.xml
+++ b/HGV_meta_EpiDoc/HGV130/129818.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Arsinoiton Polis</origPlace>
                      <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129820.xml
+++ b/HGV_meta_EpiDoc/HGV130/129820.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Hermopolites</origPlace>
                      <origDate notAfter="0576" precision="low">
                         <offset type="before" n="1">vor (?)</offset>
                         <certainty locus="value" match="../offset[@type='before']"/> Ende VI</origDate>

--- a/HGV_meta_EpiDoc/HGV130/129821.xml
+++ b/HGV_meta_EpiDoc/HGV130/129821.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0576" notAfter="0625" precision="low">Ende VI - Anfang VII</origDate>
                   </origin>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129822.xml
+++ b/HGV_meta_EpiDoc/HGV130/129822.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Arsinoites?</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129823.xml
+++ b/HGV_meta_EpiDoc/HGV130/129823.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Tebtynis (Arsinoites)</origPlace>
                      <origDate when="0195-08-04">4. Aug. 195</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129824.xml
+++ b/HGV_meta_EpiDoc/HGV130/129824.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Tebtynis (Arsinoites)</origPlace>
                      <origDate when="0195-08-04">4. Aug. 195</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129825.xml
+++ b/HGV_meta_EpiDoc/HGV130/129825.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Tebtynis (Arsinoites)</origPlace>
                      <origDate when="0195-08-04">4. Aug. 195</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129826.xml
+++ b/HGV_meta_EpiDoc/HGV130/129826.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Tebtynis (Arsinoites)</origPlace>
                      <origDate when="0195-08-04">4. Aug. 195</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129827.xml
+++ b/HGV_meta_EpiDoc/HGV130/129827.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Tebtynis (Arsinoites)</origPlace>
                      <origDate when="0195-08-04">4. Aug. 195</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129828.xml
+++ b/HGV_meta_EpiDoc/HGV130/129828.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Tebtynis (Arsinoites)</origPlace>
                      <origDate when="0195-08-04">4. Aug. 195</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129829.xml
+++ b/HGV_meta_EpiDoc/HGV130/129829.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Tebtynis (Arsinoites)</origPlace>
                      <origDate when="0195-08-04">4. Aug. 195</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129830.xml
+++ b/HGV_meta_EpiDoc/HGV130/129830.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Toltis (Oxyrhynchites)</origPlace>
                      <origDate notBefore="0101" notAfter="0150" precision="low">1. Hälfte II</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129831.xml
+++ b/HGV_meta_EpiDoc/HGV130/129831.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0151" notAfter="0225" precision="low">2. Hälfte II - Anfang III</origDate>
                   </origin>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129832.xml
+++ b/HGV_meta_EpiDoc/HGV130/129832.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0151" notAfter="0225" precision="low">2. Hälfte II - Anfang III</origDate>
                   </origin>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129833.xml
+++ b/HGV_meta_EpiDoc/HGV130/129833.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Xenarchu epoikion (Oxyrhynchites) bzw. Oxyrhynchos</origPlace>
                      <origDate notBefore="0500-02-26" notAfter="0500-03-27">26. Febr. - 27. März 500</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129834.xml
+++ b/HGV_meta_EpiDoc/HGV130/129834.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Seryphis (Oxyrhynchites) bzw. Oxyrhynchos</origPlace>
                      <origDate when="0532-12-27">27. Dez. 532</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV130/129835.xml
+++ b/HGV_meta_EpiDoc/HGV130/129835.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
                   </origin>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129936.xml
+++ b/HGV_meta_EpiDoc/HGV130/129936.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
                   </origin>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129937.xml
+++ b/HGV_meta_EpiDoc/HGV130/129937.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>unbekannt</origPlace>
                      <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
                   </origin>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47335.xml
+++ b/HGV_meta_EpiDoc/HGV48/47335.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Arsinoiton Polis bzw. Busiris (Arsinoites)</origPlace>
                      <origDate when="0616-06-09">9. Juni 616</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV48/47336.xml
+++ b/HGV_meta_EpiDoc/HGV48/47336.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Soknopaiu Nesos (Arsinoites)</origPlace>
                      <origDate when="0136-01-31">31. Jan. 136</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV48/47344.xml
+++ b/HGV_meta_EpiDoc/HGV48/47344.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Ptolemais Euergetis bzw. Philadelphia (Arsinoites)</origPlace>
                      <origDate when="0326" cert="low">326 (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV76/75206.xml
+++ b/HGV_meta_EpiDoc/HGV76/75206.xml
@@ -27,12 +27,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Theben</origPlace>
+                     <origDate when="0169-06-19">19. Juni 169</origDate>
+                  </origin>
+                  <provenance type="located">
                      <p>
                         <placeName type="ancientFindspot">Theben</placeName>
                      </p>
-                     <origDate when="0169-06-19">19. Juni 169</origDate>
-                  </origin>
+                  </provenance>
                </history>
             </msDesc>
          </sourceDesc>

--- a/HGV_meta_EpiDoc/HGV76/75234.xml
+++ b/HGV_meta_EpiDoc/HGV76/75234.xml
@@ -27,12 +27,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace/>
+                     <origPlace>Theben</origPlace>
+                     <origDate type="textDate" notBefore="0197" notAfter="0211">197 - 211</origDate>
+                  </origin>
+                  <provenance type="located">
                      <p>
                         <placeName type="ancientFindspot">Theben</placeName>
                      </p>
-                     <origDate type="textDate" notBefore="0197" notAfter="0211">197 - 211</origDate>
-                  </origin>
+                  </provenance>
                </history>
             </msDesc>
          </sourceDesc>


### PR DESCRIPTION
I have added the content of the placeName(s) in provenance element into origPlace, following the model I could deduce from the data:
- when available, settlement + (nome), e.g. "Bawit (Hermopolites)"
- otherwise the nome
- question mark included when the @cert is "low"

Some documents did not have a provenance element. For the P.Gen. I could check the online catalogue and they were all of unknown provenance. I have assumed the same for a few others (p.schoyen, p.poethke) and I have added "Ägypten" for 129779 and 129769 because it was the provenance mentioned in the ÖNB catalogue.

I have not corrected 4145 and 5323 because they exist in parallel to identifiers with letters ( 4145a/b/c and 5323a/b), so I am not sure if these two should not be removed altogether...

For 75206 and 75234 in particular I am not sure about the correction. I could not see the @type "ancientFindspot" in the dropdown menus available in the Papyrological Editor, but I let it as it was in the data already.