### PR TITLE
Update 87930.xml

### DIFF
--- a/HGV_meta_EpiDoc/HGV88/87930.xml
+++ b/HGV_meta_EpiDoc/HGV88/87930.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Epypt</origPlace>
+                     <origPlace>Middle Egypt</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoBJGCE">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Epypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
                      </p>
                   </provenance>
                </history>


### PR DESCRIPTION
Corrected typing mistake (Epypt>Egypt). One should consider whether to convert the five instances of "Middle Egypt" to "Mittelägypten" for the sake of internal consistency