### PR TITLE
Update princeton.apis.p312.xml

### DIFF
--- a/APIS/princeton/xml/princeton.apis.p312.xml
+++ b/APIS/princeton/xml/princeton.apis.p312.xml
@@ -35,7 +35,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origDate notBefore="-0400" notAfter="-1499">400 BCE – 1499 BCE</origDate>
+                     <origDate notBefore="0400" notAfter="1499">400 CE – 1499 CE</origDate>
                   </origin>
                   <provenance>
                      <p>Garrett Deposit 1926, no. II 186 in H. I. Bell's inventory</p>


### PR DESCRIPTION
There seems to be a mistake in the chronological information for this entry. The papyrus is Byzantine, not Mycenean... Maybe some conversion issues from the original APIS data?