### PR TITLE
Harmonisation to Ägypten

### DIFF
--- a/HGV_meta_EpiDoc/HGV100/99686.xml
+++ b/HGV_meta_EpiDoc/HGV100/99686.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Gurob ? (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Gurob ? (Arsinoites, Ägypten)</origPlace>
                      <origDate n="1"
                                xml:id="dateAlternativeX"
                                notBefore="-0233-09-15"

--- a/HGV_meta_EpiDoc/HGV111/110834.xml
+++ b/HGV_meta_EpiDoc/HGV111/110834.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>erworben: Egypt - 1923; Oxyrhynchites ?, Egypt</origPlace>
+                     <origPlace>erworben: Ägypten - 1923; Oxyrhynchites ?, Ägypten</origPlace>
                      <origDate notBefore="0001" notAfter="0100" precision="low">I</origDate>
                   </origin>
                   <provenance n="1" type="acquired" when="1923">

--- a/HGV_meta_EpiDoc/HGV112/111348.xml
+++ b/HGV_meta_EpiDoc/HGV112/111348.xml
@@ -47,7 +47,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/727070 https://www.trismegistos.org/place/100">Alexandria</placeName>
-                        <placeName n="2" type="modern" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="modern" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV112/111679.xml
+++ b/HGV_meta_EpiDoc/HGV112/111679.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Koba (Herakleopolites, Egypt)</origPlace>
+                     <origPlace>Koba (Herakleopolites, Ägypten)</origPlace>
                      <origDate when="-0136-06-03">3. Juni 136 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV115/114322.xml
+++ b/HGV_meta_EpiDoc/HGV115/114322.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Thosbis ? (Oxyrhynchites, Egypt); Fundort: Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Thosbis ? (Oxyrhynchites, Ägypten); Fundort: Herakleopolites ?, Ägypten</origPlace>
                      <origDate notBefore="-0025" notAfter="-0001" precision="low">Ende I v.Chr.</origDate>
                   </origin>
                   <provenance n="1" type="located">
@@ -42,7 +42,7 @@
                                    type="ancient"
                                    subtype="nome"
                                    ref="www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
-                        <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="3" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="found">
@@ -52,7 +52,7 @@
                                    subtype="nome"
                                    cert="low"
                                    ref="www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV118/117968.xml
+++ b/HGV_meta_EpiDoc/HGV118/117968.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Aegypten</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0719" notAfter="0816">719 - 816</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV119/118264.xml
+++ b/HGV_meta_EpiDoc/HGV119/118264.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoFDE533">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="https://www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="https://www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118265.xml
+++ b/HGV_meta_EpiDoc/HGV119/118265.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoCHBEG">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="https://www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="https://www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118266.xml
+++ b/HGV_meta_EpiDoc/HGV119/118266.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoIEH44J">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118267.xml
+++ b/HGV_meta_EpiDoc/HGV119/118267.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoFICE55">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118268.xml
+++ b/HGV_meta_EpiDoc/HGV119/118268.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoEBJ4DA">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118269.xml
+++ b/HGV_meta_EpiDoc/HGV119/118269.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoBJ9EI1">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118270.xml
+++ b/HGV_meta_EpiDoc/HGV119/118270.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoJH9EI9">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118271.xml
+++ b/HGV_meta_EpiDoc/HGV119/118271.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoBCEFA">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118272.xml
+++ b/HGV_meta_EpiDoc/HGV119/118272.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoHGCBD6">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118273.xml
+++ b/HGV_meta_EpiDoc/HGV119/118273.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoD3EFJ4">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118274.xml
+++ b/HGV_meta_EpiDoc/HGV119/118274.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoJHBIG9">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118275.xml
+++ b/HGV_meta_EpiDoc/HGV119/118275.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoC2IJBD">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV13/12997.xml
+++ b/HGV_meta_EpiDoc/HGV13/12997.xml
@@ -46,7 +46,6 @@
                                    subtype="nome"
                                    ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
                         <placeName type="ancient" subtype="region">Ägypten</placeName>
-                        <placeName n="3" type="ancient"/>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129953.xml
+++ b/HGV_meta_EpiDoc/HGV130/129953.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Koptites, Egypt</origPlace>
+                     <origPlace>Koptites, Ägypten</origPlace>
                      <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV131/130025.xml
+++ b/HGV_meta_EpiDoc/HGV131/130025.xml
@@ -32,12 +32,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Egypt</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0526" notAfter="0575" precision="low">Mitte VI</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoFG5JBD">
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV132/131683.xml
+++ b/HGV_meta_EpiDoc/HGV132/131683.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/785975 https://www.trismegistos.org/place/269">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV132/131720.xml
+++ b/HGV_meta_EpiDoc/HGV132/131720.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Apollonopolis Heptakomias (Egypt)</origPlace>
+                     <origPlace>Apollonopolis Heptakomias (Ägypten)</origPlace>
                      <origDate notBefore="0576" notAfter="0625" precision="low">Ende VI - Anfang VII</origDate>
                   </origin>
                   <provenance type="located">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/268 https://pleiades.stoa.org/places/756534">Apollonopolis Heptakomias</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV132/131721.xml
+++ b/HGV_meta_EpiDoc/HGV132/131721.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Apollonopolis Heptakomias (Egypt)</origPlace>
+                     <origPlace>Apollonopolis Heptakomias (Ägypten)</origPlace>
                      <origDate notBefore="0576" notAfter="0625" precision="low">Ende VI - Anfang VII</origDate>
                   </origin>
                   <provenance type="located">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/268 https://pleiades.stoa.org/places/756534">Apollonopolis Heptakomias</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV132/131855.xml
+++ b/HGV_meta_EpiDoc/HGV132/131855.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate when="-0129" cert="low" precision="medium">ca. 129 v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV132/131856.xml
+++ b/HGV_meta_EpiDoc/HGV132/131856.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate when="-0129-12-12" precision="medium">
                 ca. 12. Dez. 129 v.Chr. (Jahr unsicher)
                 <certainty locus="value" match="../year-from-date(@when)"/>

--- a/HGV_meta_EpiDoc/HGV132/131857.xml
+++ b/HGV_meta_EpiDoc/HGV132/131857.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate when="-0129" cert="low" precision="medium">ca. 129 v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV132/131858.xml
+++ b/HGV_meta_EpiDoc/HGV132/131858.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate when="-0129-08-01">1. Aug. 129 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV132/131859.xml
+++ b/HGV_meta_EpiDoc/HGV132/131859.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate notBefore="-0129-01-23" notAfter="-0129-02-21">23. Jan. - 21. Febr. 129 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV132/131860.xml
+++ b/HGV_meta_EpiDoc/HGV132/131860.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate when="-0129" cert="low" precision="medium">ca. 129 v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV132/131863.xml
+++ b/HGV_meta_EpiDoc/HGV132/131863.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate when="-0129-12-12" precision="medium">
                 ca. 12. Dez. 129 v.Chr. (Jahr unsicher)
                 <certainty locus="value" match="../year-from-date(@when)"/>

--- a/HGV_meta_EpiDoc/HGV132/131893.xml
+++ b/HGV_meta_EpiDoc/HGV132/131893.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate when="-0129" cert="low" precision="medium">ca. 129 v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV132/131894.xml
+++ b/HGV_meta_EpiDoc/HGV132/131894.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate when="-0129-12-29">
                 29. Dez. 129 v.Chr. (Jahr unsicher)
                 <certainty locus="value" match="../year-from-date(@when)"/>

--- a/HGV_meta_EpiDoc/HGV133/132363.xml
+++ b/HGV_meta_EpiDoc/HGV133/132363.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Schreibort: Abba Apollotos Monasterion (= Bawit) (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Schreibort: Abba Apollotos Monasterion (= Bawit) (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="composed">

--- a/HGV_meta_EpiDoc/HGV133/132916.xml
+++ b/HGV_meta_EpiDoc/HGV133/132916.xml
@@ -32,12 +32,12 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Egypt</origPlace>
+              <origPlace>Ägypten</origPlace>
               <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV133/132920.xml
+++ b/HGV_meta_EpiDoc/HGV133/132920.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Abba Apollotos Monasterion (= Bawit) (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Abba Apollotos Monasterion (= Bawit) (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV134/133428.xml
+++ b/HGV_meta_EpiDoc/HGV134/133428.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/621 https://pleiades.stoa.org/places/786021">Elephantine</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV134/133429.xml
+++ b/HGV_meta_EpiDoc/HGV134/133429.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV134/133430.xml
+++ b/HGV_meta_EpiDoc/HGV134/133430.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133431.xml
+++ b/HGV_meta_EpiDoc/HGV134/133431.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133432.xml
+++ b/HGV_meta_EpiDoc/HGV134/133432.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133433.xml
+++ b/HGV_meta_EpiDoc/HGV134/133433.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133434.xml
+++ b/HGV_meta_EpiDoc/HGV134/133434.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133435.xml
+++ b/HGV_meta_EpiDoc/HGV134/133435.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133436.xml
+++ b/HGV_meta_EpiDoc/HGV134/133436.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133437.xml
+++ b/HGV_meta_EpiDoc/HGV134/133437.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133438.xml
+++ b/HGV_meta_EpiDoc/HGV134/133438.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133439.xml
+++ b/HGV_meta_EpiDoc/HGV134/133439.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133440.xml
+++ b/HGV_meta_EpiDoc/HGV134/133440.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133441.xml
+++ b/HGV_meta_EpiDoc/HGV134/133441.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133442.xml
+++ b/HGV_meta_EpiDoc/HGV134/133442.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133443.xml
+++ b/HGV_meta_EpiDoc/HGV134/133443.xml
@@ -38,7 +38,7 @@
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Theben</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV134/133451.xml
+++ b/HGV_meta_EpiDoc/HGV134/133451.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhyncha (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Oxyrhyncha (Arsinoites, Ägypten)</origPlace>
                      <origDate when="-0096-11-27">
                 27. Nov. 96 v.Chr. (Jahr unsicher)
                 <certainty locus="value" match="../year-from-date(@when)"/>

--- a/HGV_meta_EpiDoc/HGV140/139867.xml
+++ b/HGV_meta_EpiDoc/HGV140/139867.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV141/140231.xml
+++ b/HGV_meta_EpiDoc/HGV141/140231.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0351" notAfter="0425" precision="low">2. Hälfte IV - Anfang V</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV141/140354.xml
+++ b/HGV_meta_EpiDoc/HGV141/140354.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Tebtynis (Arsinoites, Aegyptus)</origPlace>
+                     <origPlace>Tebtynis (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="0192-09" notAfter="0192-10">Sept. - Okt. 192</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV141/140535.xml
+++ b/HGV_meta_EpiDoc/HGV141/140535.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV141/140538.xml
+++ b/HGV_meta_EpiDoc/HGV141/140538.xml
@@ -32,12 +32,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Egypt</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="-0100" notAfter="0100" precision="low">I v.Chr. - I</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV141/140724.xml
+++ b/HGV_meta_EpiDoc/HGV141/140724.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Tiktois (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Tiktois (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0566" notAfter="0567">
                 566 - 567 (Jahr unsicher)
                 <certainty locus="value" match="../year-from-date(@notBefore)"/>

--- a/HGV_meta_EpiDoc/HGV171/170046.xml
+++ b/HGV_meta_EpiDoc/HGV171/170046.xml
@@ -29,12 +29,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Egypt</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient">Egypt</placeName>
+                        <placeName type="ancient">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV173/172217.xml
+++ b/HGV_meta_EpiDoc/HGV173/172217.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten</origPlace>
                      <origDate notBefore="-0239" notAfter="-0218">
                 239 - 218 v.Chr.
                 <precision match="../@notAfter" degree="0.5"/>

--- a/HGV_meta_EpiDoc/HGV173/172218.xml
+++ b/HGV_meta_EpiDoc/HGV173/172218.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate n="1" xml:id="dateAlternativeX" when="-0146-05-21">21. Mai 146 v.Chr.</origDate>
                      <origDate n="2" xml:id="dateAlternativeY" when="-0135-05-08">8. Mai 135 v.Chr.</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV173/172219.xml
+++ b/HGV_meta_EpiDoc/HGV173/172219.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate notBefore="-0275" notAfter="-0151" precision="low">Mitte III - 1. Hälfte II v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV176/175293.xml
+++ b/HGV_meta_EpiDoc/HGV176/175293.xml
@@ -32,13 +32,13 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Egypt</origPlace>
+              <origPlace>Ägypten</origPlace>
               <origDate notBefore="-0300" notAfter="-0201" precision="low">III v.Chr.</origDate>
             </origin>
             <provenance type="located">
               <p>
                 <placeName type="ancient"
-                           subtype="region">Egypt</placeName>
+                           subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV19/18862.xml
+++ b/HGV_meta_EpiDoc/HGV19/18862.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Chosis (Oasis Magna, Egypt)</origPlace>
+                     <origPlace>Chosis (Oasis Magna, Ägypten)</origPlace>
                      <origDate notBefore="0290" notAfter="0292">
                 ca. 290 - 292
                 <precision match="../@notBefore" degree="0.5"/>

--- a/HGV_meta_EpiDoc/HGV19/18863.xml
+++ b/HGV_meta_EpiDoc/HGV19/18863.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oasis Magna, Egypt</origPlace>
+                     <origPlace>Oasis Magna, Ägypten</origPlace>
                      <origDate when="0284-03-07">7. März 284</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV21/20683.xml
+++ b/HGV_meta_EpiDoc/HGV21/20683.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate when="0126-11-07">7. Nov. 126</origDate>
                   </origin>
                   <provenance type="located">
@@ -45,7 +45,7 @@
                                    type="ancient"
                                    subtype="nome"
                                    ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
-                        <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="3" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV219/218352.xml
+++ b/HGV_meta_EpiDoc/HGV219/218352.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites, Egypt</origPlace>
+                     <origPlace>Arsinoites, Ägypten</origPlace>
                      <origDate notBefore="-0232" notAfter="-0202">
                 ca. 232 - 202 v.Chr.
                 <precision match="../@notBefore" degree="0.5"/>

--- a/HGV_meta_EpiDoc/HGV221/220516.xml
+++ b/HGV_meta_EpiDoc/HGV221/220516.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Theadelphia (Arsinoites, Aegypten)</origPlace>
+                     <origPlace>Theadelphia (Arsinoites, Ägypten)</origPlace>
                      <origDate when="0258-11-10">10. Nov. 258</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV23/22579.xml
+++ b/HGV_meta_EpiDoc/HGV23/22579.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (= Dush) (Oasis Magna, Egypt); Schreibort: Hibis (= El-Hiba) (Oasis Magna, Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (= Dush) (Oasis Magna, Ägypten); Schreibort: Hibis (= El-Hiba) (Oasis Magna, Ägypten)</origPlace>
                      <origDate when="0300" precision="medium">ca. 300</origDate>
                   </origin>
                   <provenance n="1" type="found">

--- a/HGV_meta_EpiDoc/HGV23/22605.xml
+++ b/HGV_meta_EpiDoc/HGV23/22605.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Oasis Magna, Egypt); Schreibort: Egypt</origPlace>
+                     <origPlace>Fundort: Kysis (Oasis Magna, Ägypten); Schreibort: Ägypten</origPlace>
                      <origDate when="0311-07">Juli 311</origDate>
                   </origin>
                   <provenance n="1" type="found">

--- a/HGV_meta_EpiDoc/HGV23/22606.xml
+++ b/HGV_meta_EpiDoc/HGV23/22606.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oasis Magna ?, Egypt; Schreibort: Kysis (Oasis Magna, Egypt)</origPlace>
+                     <origPlace>Oasis Magna ?, Ägypten; Schreibort: Kysis (Oasis Magna, Ägypten)</origPlace>
                      <origDate when="0308-11-04">
                 4. Nov. 308 (Jahr und Monat unsicher)
                 <certainty locus="value" n="1" match="../month-from-date(@when)"/>

--- a/HGV_meta_EpiDoc/HGV23/22627.xml
+++ b/HGV_meta_EpiDoc/HGV23/22627.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Kysis (Oasis Magna, Egypt)</origPlace>
+                     <origPlace>Kysis (Oasis Magna, Ägypten)</origPlace>
                      <origDate when="0287-08-16">16. Aug. 287</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV23/22629.xml
+++ b/HGV_meta_EpiDoc/HGV23/22629.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Oasis Magna, Egypt); Schreibort: Dios Polis (Hiou)</origPlace>
+                     <origPlace>Fundort: Kysis (Oasis Magna, Ägypten); Schreibort: Dios Polis (Hiou)</origPlace>
                      <origDate when="0308-02-18">18. Febr. 308</origDate>
                   </origin>
                   <provenance n="1" type="found">

--- a/HGV_meta_EpiDoc/HGV23/22630.xml
+++ b/HGV_meta_EpiDoc/HGV23/22630.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Oasis Magna, Egypt); Schreibort: Tentyris (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Oasis Magna, Ägypten); Schreibort: Tentyris (Ägypten)</origPlace>
                      <origDate when="0302-04-25">25. Apr. 302</origDate>
                   </origin>
                   <provenance n="1" type="found">

--- a/HGV_meta_EpiDoc/HGV23/22631.xml
+++ b/HGV_meta_EpiDoc/HGV23/22631.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Mothis (Oasis Magna, Egypt)</origPlace>
+                     <origPlace>Mothis (Oasis Magna, Ägypten)</origPlace>
                      <origDate when="0308-01-06">6. Jan. 308</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV23/22632.xml
+++ b/HGV_meta_EpiDoc/HGV23/22632.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Kysis (Egypt, Oasis Magna); Schreibort: Hibis ? (Oasis Magna, Egypt) oder Kysis ? (Oasis Magna, Egypt)</origPlace>
+                     <origPlace>Kysis (Ägypten, Oasis Magna); Schreibort: Hibis ? (Oasis Magna, Ägypten) oder Kysis ? (Oasis Magna, Ägypten)</origPlace>
                      <origDate notBefore="0305" notAfter="0306">305 - 306</origDate>
                   </origin>
                   <provenance n="1" type="located">

--- a/HGV_meta_EpiDoc/HGV23/22633.xml
+++ b/HGV_meta_EpiDoc/HGV23/22633.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oasis Magna ?, Egypt</origPlace>
+                     <origPlace>Oasis Magna ?, Ägypten</origPlace>
                      <origDate notBefore="0260" notAfter="0275">
                 ca. 260 - 275
                 <precision match="../@notBefore" degree="0.5"/>

--- a/HGV_meta_EpiDoc/HGV23/22634.xml
+++ b/HGV_meta_EpiDoc/HGV23/22634.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Oasis Magna, Egypt) oder ; Schreibort: Hibis ? (Oasis Magna) oder</origPlace>
+                     <origPlace>Fundort: Kysis (Oasis Magna, Ägypten) oder ; Schreibort: Hibis ? (Oasis Magna) oder</origPlace>
                      <origDate notBefore="0307-02-25" notAfter="0307-03-26">25. Febr. - 26. März 307</origDate>
                   </origin>
                   <provenance n="1" type="found">

--- a/HGV_meta_EpiDoc/HGV24/23142.xml
+++ b/HGV_meta_EpiDoc/HGV24/23142.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Oasis Magna, Egypt); Schreibort: Hibis ? (Oasis Magna, Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Oasis Magna, Ägypten); Schreibort: Hibis ? (Oasis Magna, Ägypten)</origPlace>
                      <origDate when="0304-02-15">15. Febr. 304</origDate>
                   </origin>
                   <provenance n="1" type="found">

--- a/HGV_meta_EpiDoc/HGV24/23259.xml
+++ b/HGV_meta_EpiDoc/HGV24/23259.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Hibis (Oasis Magna, Egypt) oder Kysis (Oasis Magna, Egypt)</origPlace>
+                     <origPlace>Hibis (Oasis Magna, Ägypten) oder Kysis (Oasis Magna, Ägypten)</origPlace>
                      <origDate notBefore="0307-02" notAfter="0307-03">Febr. - März 307</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV245/244050.xml
+++ b/HGV_meta_EpiDoc/HGV245/244050.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites, Egypt</origPlace>
+                     <origPlace>Arsinoites, Ägypten</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV245/244059.xml
+++ b/HGV_meta_EpiDoc/HGV245/244059.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten</origPlace>
                      <origDate notBefore="0256" notAfter="0257" cert="low">256 - 257 (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV245/244060.xml
+++ b/HGV_meta_EpiDoc/HGV245/244060.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten</origPlace>
                      <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV245/244062.xml
+++ b/HGV_meta_EpiDoc/HGV245/244062.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Aphrodito (Antaiopolites, Egypt)</origPlace>
+                     <origPlace>Aphrodito (Antaiopolites, Ägypten)</origPlace>
                      <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV245/244111.xml
+++ b/HGV_meta_EpiDoc/HGV245/244111.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Theadelpheia (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Fundort: Theadelpheia (Arsinoites, Ägypten)</origPlace>
                      <origDate when="0058-08-20">20. Aug. 58</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV29/28347.xml
+++ b/HGV_meta_EpiDoc/HGV29/28347.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchites, Egypt</origPlace>
+                     <origPlace>Oxyrhynchites, Ägypten</origPlace>
                      <origDate notBefore="0176" notAfter="0300" precision="low">Ende II - III</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV3/2229.xml
+++ b/HGV_meta_EpiDoc/HGV3/2229.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos ? (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos ? (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="-0186-10-09">
                         <offset n="1" type="after">nach</offset>
                 9. Okt. 186 v.Chr.

--- a/HGV_meta_EpiDoc/HGV3/2526.xml
+++ b/HGV_meta_EpiDoc/HGV3/2526.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites, Egypt</origPlace>
+                     <origPlace>Arsinoites, Ägypten</origPlace>
                      <origDate notBefore="-0232" notAfter="-0226">232 - 226 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV31/30394.xml
+++ b/HGV_meta_EpiDoc/HGV31/30394.xml
@@ -31,7 +31,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0376" notAfter="0400" precision="low">Ende IV</origDate>
                   </origin>
                   <provenance type="located">
@@ -43,7 +43,7 @@
                                    type="ancient"
                                    subtype="nome"
                                    ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
-                        <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="3" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV317/316329.xml
+++ b/HGV_meta_EpiDoc/HGV317/316329.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites, Egypt</origPlace>
+                     <origPlace>Herakleopolites, Ägypten</origPlace>
                      <origDate when="0439">439</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV317/316742.xml
+++ b/HGV_meta_EpiDoc/HGV317/316742.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten</origPlace>
                      <origDate notBefore="-0225" notAfter="-0201" precision="low">Ende III v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV317/316743.xml
+++ b/HGV_meta_EpiDoc/HGV317/316743.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten</origPlace>
                      <origDate notBefore="-0200" notAfter="-0101" cert="low" precision="low">II v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV317/316749.xml
+++ b/HGV_meta_EpiDoc/HGV317/316749.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten</origPlace>
                      <origDate notBefore="-0200" notAfter="-0101" precision="low">II v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV317/316751.xml
+++ b/HGV_meta_EpiDoc/HGV317/316751.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten</origPlace>
                      <origDate notBefore="-0225" notAfter="-0176" precision="low">Ende III - Anfang II v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV317/316753.xml
+++ b/HGV_meta_EpiDoc/HGV317/316753.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten</origPlace>
                      <origDate notBefore="-0225" notAfter="-0201" cert="low" precision="low">Ende III v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV317/316754.xml
+++ b/HGV_meta_EpiDoc/HGV317/316754.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten</origPlace>
                      <origDate notBefore="-0225" notAfter="-0201" cert="low" precision="low">Ende III v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV317/316756.xml
+++ b/HGV_meta_EpiDoc/HGV317/316756.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten</origPlace>
                      <origDate notBefore="-0200" notAfter="-0101" cert="low" precision="low">II v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV317/316757.xml
+++ b/HGV_meta_EpiDoc/HGV317/316757.xml
@@ -32,7 +32,7 @@
                     </physDesc>
                     <history>
                         <origin>
-                            <origPlace>Arsinoites ?, Egypt</origPlace>
+                            <origPlace>Arsinoites ?, Ägypten</origPlace>
                             <origDate notBefore="-0200" notAfter="-0101" cert="low" precision="low">II v.Chr. (?)</origDate>
                         </origin>
                         <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV317/316758.xml
+++ b/HGV_meta_EpiDoc/HGV317/316758.xml
@@ -32,7 +32,7 @@
                     </physDesc>
                     <history>
                         <origin>
-                            <origPlace>Arsinoites ?, Egypt</origPlace>
+                            <origPlace>Arsinoites ?, Ägypten</origPlace>
                             <origDate notBefore="-0200" notAfter="-0101" cert="low" precision="low">II v.Chr. (?)</origDate>
                         </origin>
                         <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV318/317014.xml
+++ b/HGV_meta_EpiDoc/HGV318/317014.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Ta Memnoneia (Theben) (Egypt)</origPlace>
+                     <origPlace>Ta Memnoneia (Theben) (Ägypten)</origPlace>
                      <origDate when="0724-06-26">26. Juni 724</origDate>
                   </origin>
                   <provenance type="located">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/1341 https://pleiades.stoa.org/places/786067">Ta Memnoneia (Theben)</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV318/317029.xml
+++ b/HGV_meta_EpiDoc/HGV318/317029.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Ta Memnoneia (Theben) (Egypt)</origPlace>
+                     <origPlace>Ta Memnoneia (Theben) (Ägypten)</origPlace>
                      <origDate notBefore="0721" notAfter="0722">721 - 722</origDate>
                   </origin>
                   <provenance type="located">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/1341 https://pleiades.stoa.org/places/786067">Ta Memnoneia (Theben)</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV318/317311.xml
+++ b/HGV_meta_EpiDoc/HGV318/317311.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0590" notAfter="0621">ca. 590 - 621
                 <precision match="../@notBefore" degree="0.5"/>
               </origDate>
@@ -40,7 +40,7 @@
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV32/31940.xml
+++ b/HGV_meta_EpiDoc/HGV32/31940.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Oasis magna, Egypt oder ; Schreibort: Toeto (Egypt, Panopolites)</origPlace>
+                     <origPlace>Fundort: Oasis magna, Ägypten oder ; Schreibort: Toeto (Ägypten, Panopolites)</origPlace>
                      <origDate notBefore="0276" notAfter="0300" precision="low">Ende III</origDate>
                   </origin>
                   <provenance n="1" type="found">

--- a/HGV_meta_EpiDoc/HGV320/319805.xml
+++ b/HGV_meta_EpiDoc/HGV320/319805.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0590" notAfter="0621">ca. 590 - 621
                 <precision match="../@notBefore" degree="0.5"/>
               </origDate>
@@ -40,7 +40,7 @@
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV320/319882.xml
+++ b/HGV_meta_EpiDoc/HGV320/319882.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0590" notAfter="0621">ca. 590 - 621
                 <precision match="../@notBefore" degree="0.5"/>
               </origDate>
@@ -40,7 +40,7 @@
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV320/319985.xml
+++ b/HGV_meta_EpiDoc/HGV320/319985.xml
@@ -32,13 +32,13 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0610" notAfter="0619">610 - 619</origDate>
             </origin>
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV321/320034.xml
+++ b/HGV_meta_EpiDoc/HGV321/320034.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0590" notAfter="0621">ca. 590 - 621
                 <precision match="../@notBefore" degree="0.5"/>
               </origDate>
@@ -40,7 +40,7 @@
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV321/320043.xml
+++ b/HGV_meta_EpiDoc/HGV321/320043.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0590" notAfter="0621">ca. 590 - 621
                 <precision match="../@notBefore" degree="0.5"/>
               </origDate>
@@ -40,7 +40,7 @@
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV321/320155.xml
+++ b/HGV_meta_EpiDoc/HGV321/320155.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0590" notAfter="0621">ca. 590 - 621
                 <precision match="../@notBefore" degree="0.5"/>
               </origDate>
@@ -40,7 +40,7 @@
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV321/320160.xml
+++ b/HGV_meta_EpiDoc/HGV321/320160.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0590" notAfter="0621">ca. 590 - 621
                 <precision match="../@notBefore" degree="0.5"/>
               </origDate>
@@ -40,7 +40,7 @@
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV321/320212.xml
+++ b/HGV_meta_EpiDoc/HGV321/320212.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0590" notAfter="0621">ca. 590 - 621
                 <precision match="../@notBefore" degree="0.5"/>
               </origDate>
@@ -40,7 +40,7 @@
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV321/320266.xml
+++ b/HGV_meta_EpiDoc/HGV321/320266.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Ta Memnoneia (Theben) (Egypt)</origPlace>
+                     <origPlace>Ta Memnoneia (Theben) (Ägypten)</origPlace>
                      <origDate when="0721-04-21">21. Apr. 721</origDate>
                   </origin>
                   <provenance type="located">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/1341 https://pleiades.stoa.org/places/786067">Ta Memnoneia (Theben)</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV321/320419.xml
+++ b/HGV_meta_EpiDoc/HGV321/320419.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0590" notAfter="0621">ca. 590 - 621
                 <precision match="../@notBefore" degree="0.5"/>
               </origDate>
@@ -40,7 +40,7 @@
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV321/320435.xml
+++ b/HGV_meta_EpiDoc/HGV321/320435.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0590" notAfter="0621">ca. 590 - 621
                 <precision match="../@notBefore" degree="0.5"/>
               </origDate>
@@ -40,7 +40,7 @@
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV321/320438.xml
+++ b/HGV_meta_EpiDoc/HGV321/320438.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Ta Memnoneia (Theben) (Egypt)</origPlace>
+                     <origPlace>Ta Memnoneia (Theben) (Ägypten)</origPlace>
                      <origDate when="0717-10-07">7. Okt. 717</origDate>
                   </origin>
                   <provenance type="located">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/1341 https://pleiades.stoa.org/places/786067">Ta Memnoneia (Theben)</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV321/320455.xml
+++ b/HGV_meta_EpiDoc/HGV321/320455.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Deir el-Bahari (Egypt)</origPlace>
+              <origPlace>Fundort: Deir el-Bahari (Ägypten)</origPlace>
               <origDate notBefore="0590" notAfter="0621">ca. 590 - 621
                 <precision match="../@notBefore" degree="0.5"/>
               </origDate>
@@ -40,7 +40,7 @@
             <provenance type="found">
               <p>
                 <placeName n="1" type="ancient" ref="https://pleiades.stoa.org/places/785970">Deir el-Bahari</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV34/33125.xml
+++ b/HGV_meta_EpiDoc/HGV34/33125.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate when="0330" precision="medium">ca. 330</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV38/37942.xml
+++ b/HGV_meta_EpiDoc/HGV38/37942.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0576" notAfter="0625" precision="low">Ende VI - Anfang VII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV381/380607.xml
+++ b/HGV_meta_EpiDoc/HGV381/380607.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites, Egypt</origPlace>
+                     <origPlace>Arsinoites, Ägypten</origPlace>
                      <origDate when="-0202-08-27">27. Aug. 202 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV383/382530.xml
+++ b/HGV_meta_EpiDoc/HGV383/382530.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Karanis (Arsinoites), Egypt</origPlace>
+                     <origPlace>Karanis (Arsinoites), Ägypten</origPlace>
                      <origDate notBefore="0119-10-29" notAfter="0119-11-27" cert="low">29. Okt. 119 - 27. Nov. 119 (?)</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV389/388511.xml
+++ b/HGV_meta_EpiDoc/HGV389/388511.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Hermopolis (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Hermopolis (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0501" notAfter="0600">VI</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV390/389951.xml
+++ b/HGV_meta_EpiDoc/HGV390/389951.xml
@@ -32,12 +32,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Egypt ?</origPlace>
+                     <origPlace>Fundort: Ägypten ?</origPlace>
                      <origDate notBefore="0001" notAfter="0100" precision="low">I</origDate>
                   </origin>
                   <provenance type="found">
                      <p xml:id="geoBDH7G7">
-                        <placeName type="ancient" subtype="region" cert="low">Egypt</placeName>
+                        <placeName type="ancient" subtype="region" cert="low">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV43/42852.xml
+++ b/HGV_meta_EpiDoc/HGV43/42852.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Schreibort: Narmouthis (= Medinet Madi) (Arsinoites, Egypt); Fundort: Arsinoites, Egypt</origPlace>
+                     <origPlace>Schreibort: Narmouthis (= Medinet Madi) (Arsinoites, Ägypten); Fundort: Arsinoites, Ägypten</origPlace>
                      <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
                   </origin>
                   <provenance n="1" type="composed">

--- a/HGV_meta_EpiDoc/HGV464/463696.xml
+++ b/HGV_meta_EpiDoc/HGV464/463696.xml
@@ -29,7 +29,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Aegypten</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0786" notAfter="0845">786 - 845</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV465/464098.xml
+++ b/HGV_meta_EpiDoc/HGV465/464098.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Arsinoites (Egypt)</origPlace>
+              <origPlace>Arsinoites (Ägypten)</origPlace>
               <origDate notBefore="0787" notAfter="0788">787 - 788</origDate>
             </origin>
             <provenance type="located">
@@ -40,7 +40,7 @@
                 <placeName n="1"
                   type="ancient"
                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
-                  <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                  <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                 </p>
               </provenance>
             </history>

--- a/HGV_meta_EpiDoc/HGV48/47288.xml
+++ b/HGV_meta_EpiDoc/HGV48/47288.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Muchis (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Fundort: Muchis (Arsinoites, Ägypten)</origPlace>
                      <origDate when="-0223-08-16">16. Aug. 223 v.Chr.</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV567/566331.xml
+++ b/HGV_meta_EpiDoc/HGV567/566331.xml
@@ -31,7 +31,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Philadelpheia (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Philadelpheia (Arsinoites, Ägypten)</origPlace>
                      <origDate when="-0250" precision="medium">ca. 250 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV567/566332.xml
+++ b/HGV_meta_EpiDoc/HGV567/566332.xml
@@ -31,7 +31,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Philadelpheia (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Philadelpheia (Arsinoites, Ägypten)</origPlace>
                      <origDate when="-0254-06-23">23. Juni 254 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV59/58466.xml
+++ b/HGV_meta_EpiDoc/HGV59/58466.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhyncha (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Oxyrhyncha (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="-0300" notAfter="-0201" precision="low">III v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV59/58467.xml
+++ b/HGV_meta_EpiDoc/HGV59/58467.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites, Egypt</origPlace>
+                     <origPlace>Arsinoites, Ägypten</origPlace>
                      <origDate notBefore="-0196" notAfter="-0195" cert="low">196 - 195 v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV59/58468.xml
+++ b/HGV_meta_EpiDoc/HGV59/58468.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate notBefore="-0200" notAfter="-0101" cert="low" precision="low">II v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV642/641986.xml
+++ b/HGV_meta_EpiDoc/HGV642/641986.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate when="-0013-12-19">19. Dez. 13 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV642/641988.xml
+++ b/HGV_meta_EpiDoc/HGV642/641988.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV642/641989.xml
+++ b/HGV_meta_EpiDoc/HGV642/641989.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Hermopolites, Egypt</origPlace>
+                     <origPlace>Hermopolites, Ägypten</origPlace>
                      <origDate when="0102-09-22">22. Sept. 102</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV642/641990.xml
+++ b/HGV_meta_EpiDoc/HGV642/641990.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoiton Polis (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Arsinoiton Polis (Arsinoites, Ägypten)</origPlace>
                      <origDate when="0192-10-05">5. Okt. 192</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV642/641991.xml
+++ b/HGV_meta_EpiDoc/HGV642/641991.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoiton Polis (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Arsinoiton Polis (Arsinoites, Ägypten)</origPlace>
                      <origDate when="0193-06-05">5. Juni 193</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV642/641992.xml
+++ b/HGV_meta_EpiDoc/HGV642/641992.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV642/641993.xml
+++ b/HGV_meta_EpiDoc/HGV642/641993.xml
@@ -32,13 +32,13 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Oxyrhynchites, Egypt</origPlace>
+              <origPlace>Oxyrhynchites, Ägypten</origPlace>
               <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
             </origin>
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV642/641994.xml
+++ b/HGV_meta_EpiDoc/HGV642/641994.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Hermopolites, Egypt</origPlace>
+                     <origPlace>Hermopolites, Ägypten</origPlace>
                      <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV642/641995.xml
+++ b/HGV_meta_EpiDoc/HGV642/641995.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos ? (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos ? (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0301" notAfter="0400" precision="low">IV</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV642/641996.xml
+++ b/HGV_meta_EpiDoc/HGV642/641996.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV642/641997.xml
+++ b/HGV_meta_EpiDoc/HGV642/641997.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos ? (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos ? (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0301" notAfter="0500" precision="low">IV-V</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV642/641998.xml
+++ b/HGV_meta_EpiDoc/HGV642/641998.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate when="0484-12-21">21. Dez. 484</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV642/641999.xml
+++ b/HGV_meta_EpiDoc/HGV642/641999.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV642/642000.xml
+++ b/HGV_meta_EpiDoc/HGV642/642000.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0527" notAfter="0528">527 - 528</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV643/642001.xml
+++ b/HGV_meta_EpiDoc/HGV643/642001.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV643/642002.xml
+++ b/HGV_meta_EpiDoc/HGV643/642002.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV643/642003.xml
+++ b/HGV_meta_EpiDoc/HGV643/642003.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoiton Polis (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Arsinoiton Polis (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV643/642464.xml
+++ b/HGV_meta_EpiDoc/HGV643/642464.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites ?, Egypt</origPlace>
+                     <origPlace>Herakleopolites ?, Ägypten</origPlace>
                      <origDate notBefore="0301" notAfter="0500" precision="low">IV - V</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV654/653712.xml
+++ b/HGV_meta_EpiDoc/HGV654/653712.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Philadelphia (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Philadelphia (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="-0275" notAfter="-0226">
                 Mitte (?) III v.Chr.
                 <precision n="1" match="../@notBefore" degree="0.1"/>

--- a/HGV_meta_EpiDoc/HGV698/697599.xml
+++ b/HGV_meta_EpiDoc/HGV698/697599.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bakchias (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Bakchias (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="0126" notAfter="0200" precision="low">Mitte - Ende II</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV698/697600.xml
+++ b/HGV_meta_EpiDoc/HGV698/697600.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bakchias (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Bakchias (Arsinoites, Ägypten)</origPlace>
                      <origDate when="0174-02-19">19. Febr. 174</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV698/697602.xml
+++ b/HGV_meta_EpiDoc/HGV698/697602.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bakchias (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Bakchias (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="0217" notAfter="0218">217 - 218</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV70/69890.xml
+++ b/HGV_meta_EpiDoc/HGV70/69890.xml
@@ -33,7 +33,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Schreibort: Aelia Capitolina; Fundort: Egypt</origPlace>
+                     <origPlace>Schreibort: Aelia Capitolina; Fundort: Ägypten</origPlace>
                      <origDate when="0141">141</origDate>
                   </origin>
                   <provenance n="1" type="composed">
@@ -44,7 +44,7 @@
                   </provenance>
                   <provenance n="2" type="found">
                      <p xml:id="geoCHB7F1">
-                        <placeName type="ancient">Egypt</placeName>
+                        <placeName type="ancient">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV700/699704.xml
+++ b/HGV_meta_EpiDoc/HGV700/699704.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhyncha ? (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Oxyrhyncha ? (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="-0175" notAfter="-0126" precision="low">Mitte II v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV700/699707.xml
+++ b/HGV_meta_EpiDoc/HGV700/699707.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV700/699708.xml
+++ b/HGV_meta_EpiDoc/HGV700/699708.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV701/700731.xml
+++ b/HGV_meta_EpiDoc/HGV701/700731.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchus (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchus (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0351" notAfter="0400" precision="low">2. Hälfte IV</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV701/700732.xml
+++ b/HGV_meta_EpiDoc/HGV701/700732.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Naqlun (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Fundort: Naqlun (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV701/700733.xml
+++ b/HGV_meta_EpiDoc/HGV701/700733.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Naqlun (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Fundort: Naqlun (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="0501" notAfter="0600" cert="low" precision="low">VI (?)</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV701/700734.xml
+++ b/HGV_meta_EpiDoc/HGV701/700734.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Naqlun (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Fundort: Naqlun (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="0501" notAfter="0600" cert="low" precision="low">VI (?)</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV701/700735.xml
+++ b/HGV_meta_EpiDoc/HGV701/700735.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Naqlun (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Fundort: Naqlun (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="0501" notAfter="0600" cert="low" precision="low">VI (?)</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV701/700795.xml
+++ b/HGV_meta_EpiDoc/HGV701/700795.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV701/700796.xml
+++ b/HGV_meta_EpiDoc/HGV701/700796.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV703/702253.xml
+++ b/HGV_meta_EpiDoc/HGV703/702253.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702254.xml
+++ b/HGV_meta_EpiDoc/HGV703/702254.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702255.xml
+++ b/HGV_meta_EpiDoc/HGV703/702255.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702256.xml
+++ b/HGV_meta_EpiDoc/HGV703/702256.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702257.xml
+++ b/HGV_meta_EpiDoc/HGV703/702257.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702258.xml
+++ b/HGV_meta_EpiDoc/HGV703/702258.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702259.xml
+++ b/HGV_meta_EpiDoc/HGV703/702259.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702260.xml
+++ b/HGV_meta_EpiDoc/HGV703/702260.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702261.xml
+++ b/HGV_meta_EpiDoc/HGV703/702261.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702262.xml
+++ b/HGV_meta_EpiDoc/HGV703/702262.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702263.xml
+++ b/HGV_meta_EpiDoc/HGV703/702263.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702264.xml
+++ b/HGV_meta_EpiDoc/HGV703/702264.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702265.xml
+++ b/HGV_meta_EpiDoc/HGV703/702265.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702266.xml
+++ b/HGV_meta_EpiDoc/HGV703/702266.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702267.xml
+++ b/HGV_meta_EpiDoc/HGV703/702267.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702268.xml
+++ b/HGV_meta_EpiDoc/HGV703/702268.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/270 https://pleiades.stoa.org/places/785975">Apollonopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV703/702269.xml
+++ b/HGV_meta_EpiDoc/HGV703/702269.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Fundort: Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0301" notAfter="0325" precision="low">Anfang IV</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV703/702270.xml
+++ b/HGV_meta_EpiDoc/HGV703/702270.xml
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://www.trismegistos.org/place/1341  https://pleiades.stoa.org/places/786067">Memnoneia</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV704/703072.xml
+++ b/HGV_meta_EpiDoc/HGV704/703072.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Aueris (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Fundort: Aueris (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV704/703158.xml
+++ b/HGV_meta_EpiDoc/HGV704/703158.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Bakhias (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Fundort: Bakhias (Arsinoites, Ägypten)</origPlace>
                      <origDate when="-0011-11-11" cert="low">11. Nov. 11 v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV704/703159.xml
+++ b/HGV_meta_EpiDoc/HGV704/703159.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Bakhias (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Fundort: Bakhias (Arsinoites, Ägypten)</origPlace>
                      <origDate when="-0011-11-11" cert="low">11. Nov. 11 v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV704/703160.xml
+++ b/HGV_meta_EpiDoc/HGV704/703160.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Bakhias (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Fundort: Bakhias (Arsinoites, Ägypten)</origPlace>
                      <origDate when="-0011-11-12" cert="low">12. Nov. 11 v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV704/703254.xml
+++ b/HGV_meta_EpiDoc/HGV704/703254.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Peri Tekmi (Herakleopolites, Egypt)</origPlace>
+                     <origPlace>Peri Tekmi (Herakleopolites, Ägypten)</origPlace>
                      <origDate notBefore="-0192-12-09">
                         <offset n="1" type="after">nach</offset>
                 9. Dez. 192 v.Chr.

--- a/HGV_meta_EpiDoc/HGV704/703255.xml
+++ b/HGV_meta_EpiDoc/HGV704/703255.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Machor (Herakleopolites, Egypt)</origPlace>
+                     <origPlace>Machor (Herakleopolites, Ägypten)</origPlace>
                      <origDate when="-0190-02-03">3. Febr. 190 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV704/703259.xml
+++ b/HGV_meta_EpiDoc/HGV704/703259.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Schreibort: Sohag (Panopolites, Egypt)</origPlace>
+                     <origPlace>Schreibort: Sohag (Panopolites, Ägypten)</origPlace>
                      <origDate notBefore="0101" notAfter="0400" precision="low">II - IV</origDate>
                   </origin>
                   <provenance type="composed">

--- a/HGV_meta_EpiDoc/HGV704/703260.xml
+++ b/HGV_meta_EpiDoc/HGV704/703260.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV704/703261.xml
+++ b/HGV_meta_EpiDoc/HGV704/703261.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos ? (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos ? (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="-0100" notAfter="-0001" precision="low">I v.Chr.</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV704/703262.xml
+++ b/HGV_meta_EpiDoc/HGV704/703262.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV704/703263.xml
+++ b/HGV_meta_EpiDoc/HGV704/703263.xml
@@ -32,12 +32,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Egypt</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0301" notAfter="0400" precision="low">IV</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV704/703264.xml
+++ b/HGV_meta_EpiDoc/HGV704/703264.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0131" notAfter="0146">131 - 146</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV704/703265.xml
+++ b/HGV_meta_EpiDoc/HGV704/703265.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV704/703267.xml
+++ b/HGV_meta_EpiDoc/HGV704/703267.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites (Egypt)</origPlace>
+                     <origPlace>Arsinoites (Ägypten)</origPlace>
                      <origDate notBefore="0001" notAfter="0300">I - III</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV704/703268.xml
+++ b/HGV_meta_EpiDoc/HGV704/703268.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="https://www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="https://www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV704/703269.xml
+++ b/HGV_meta_EpiDoc/HGV704/703269.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV704/703279.xml
+++ b/HGV_meta_EpiDoc/HGV704/703279.xml
@@ -32,12 +32,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Egypt</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0276" notAfter="0325" precision="low">Ende III - Anfang IV</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV704/703280.xml
+++ b/HGV_meta_EpiDoc/HGV704/703280.xml
@@ -32,12 +32,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Egypt</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0276" notAfter="0325" precision="low">Ende III - Anfang IV</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV704/703281.xml
+++ b/HGV_meta_EpiDoc/HGV704/703281.xml
@@ -32,12 +32,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Egypt</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0601" notAfter="0650" precision="low">1. Hälfte VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV704/703282.xml
+++ b/HGV_meta_EpiDoc/HGV704/703282.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Chalothis (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Chalothis (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0700" cert="low" precision="low">VII (?)</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV704/703283.xml
+++ b/HGV_meta_EpiDoc/HGV704/703283.xml
@@ -32,12 +32,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Egypt</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0626" notAfter="0700" precision="low">Mitte VII - 2. Hälfte VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV704/703285.xml
+++ b/HGV_meta_EpiDoc/HGV704/703285.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites, Egypt</origPlace>
+                     <origPlace>Arsinoites, Ägypten</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV704/703286.xml
+++ b/HGV_meta_EpiDoc/HGV704/703286.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites, Egypt</origPlace>
+                     <origPlace>Arsinoites, Ägypten</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV704/703289.xml
+++ b/HGV_meta_EpiDoc/HGV704/703289.xml
@@ -32,12 +32,12 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Egypt</origPlace>
+              <origPlace>Ägypten</origPlace>
               <origDate notBefore="0801" notAfter="0900" precision="low">IX</origDate>
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV704/703290.xml
+++ b/HGV_meta_EpiDoc/HGV704/703290.xml
@@ -32,12 +32,12 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Egypt</origPlace>
+              <origPlace>Ägypten</origPlace>
               <origDate when="0875">875</origDate>
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV705/704416.xml
+++ b/HGV_meta_EpiDoc/HGV705/704416.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (= Dush) (Oasis Magna, Egypt); Schreibort: Hibis ? (= El-Hiba) (Oasis Magna ?, Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (= Dush) (Oasis Magna, Ägypten); Schreibort: Hibis ? (= El-Hiba) (Oasis Magna ?, Ägypten)</origPlace>
                      <origDate when="0241-07-27">27. Juli 241</origDate>
                   </origin>
                   <provenance n="1" type="found">

--- a/HGV_meta_EpiDoc/HGV705/704417.xml
+++ b/HGV_meta_EpiDoc/HGV705/704417.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (= Dush) (Oasis Magna, Egypt); Schreibort: Hibis (= El-Hiba) (Oasis Magna, Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (= Dush) (Oasis Magna, Ägypten); Schreibort: Hibis (= El-Hiba) (Oasis Magna, Ägypten)</origPlace>
                      <origDate notBefore="0245-02-21" notAfter="0247-02-22">21. 245 - 22. Febr. 247</origDate>
                   </origin>
                   <provenance n="1" type="found">

--- a/HGV_meta_EpiDoc/HGV705/704419.xml
+++ b/HGV_meta_EpiDoc/HGV705/704419.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Schreibort: Egypt oder Hibis ?; Fundort: Egypt oder Kysis</origPlace>
+                     <origPlace>Schreibort: Ägypten oder Hibis ?; Fundort: Ägypten oder Kysis</origPlace>
                      <origDate notBefore="0284-06-25" notAfter="0284-07-24">
                 25. Juni - 24. Juli 284 (Monat und Tag unsicher)
                 <certainty locus="value" n="1" match="../day-from-date(@notBefore)"/>
@@ -41,7 +41,7 @@
                   </origin>
                   <provenance n="1" type="composed">
                      <p n="1" xml:id="geoHDAC3F" exclude="#geoJGAFD9">
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                      <p n="2" xml:id="geoJGAFD9" exclude="#geoHDAC3F">
                         <placeName type="ancient"
@@ -51,7 +51,7 @@
                   </provenance>
                   <provenance n="2" type="found">
                      <p n="1" xml:id="geoFB11AH" exclude="#geoJAD90C">
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                      <p n="2" xml:id="geoJAD90C" exclude="#geoFB11AH">
                         <placeName type="ancient"

--- a/HGV_meta_EpiDoc/HGV705/704420.xml
+++ b/HGV_meta_EpiDoc/HGV705/704420.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Schreibort: Hibis ? (Egypt); Fundort: Kysis (Egypt)</origPlace>
+                     <origPlace>Schreibort: Hibis ? (Ägypten); Fundort: Kysis (Ägypten)</origPlace>
                      <origDate notBefore="0298" notAfter="0314">
                 ca. 298 - 314
                 <precision match="../@notBefore" degree="0.5"/>
@@ -40,7 +40,7 @@
                   </origin>
                   <provenance n="1" type="composed">
                      <p xml:id="geoGBD66F">
-                        <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
                         <placeName n="2"
                                    type="ancient"
                                    cert="low"
@@ -49,7 +49,7 @@
                   </provenance>
                   <provenance n="2" type="found">
                      <p xml:id="geoB1CAEI">
-                        <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
                         <placeName n="2"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>

--- a/HGV_meta_EpiDoc/HGV705/704421.xml
+++ b/HGV_meta_EpiDoc/HGV705/704421.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Oasis Magna (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Oasis Magna (Ägypten)</origPlace>
                      <origDate notBefore="0201" notAfter="0400" precision="low">III - IV</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -48,7 +48,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776210 https://www.trismegistos.org/place/619">Oasis Magna</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704422.xml
+++ b/HGV_meta_EpiDoc/HGV705/704422.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Oasis Magna, Egypt); Schreibort: Oasis Magna, Egypt</origPlace>
+                     <origPlace>Fundort: Kysis (Oasis Magna, Ägypten); Schreibort: Oasis Magna, Ägypten</origPlace>
                      <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
                   </origin>
                   <provenance n="1" type="found">

--- a/HGV_meta_EpiDoc/HGV705/704423.xml
+++ b/HGV_meta_EpiDoc/HGV705/704423.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Oasis Magna (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Oasis Magna (Ägypten)</origPlace>
                      <origDate notBefore="0201" notAfter="0400" precision="low">III - IV</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -48,7 +48,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776210 https://www.trismegistos.org/place/619">Oasis Magna</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704424.xml
+++ b/HGV_meta_EpiDoc/HGV705/704424.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Oasis Magna (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Oasis Magna (Ägypten)</origPlace>
                      <origDate notBefore="0201" notAfter="0400" precision="low">III - IV</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -48,7 +48,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776210 https://www.trismegistos.org/place/619">Oasis Magna</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704425.xml
+++ b/HGV_meta_EpiDoc/HGV705/704425.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Schreibort: Hibis ? (Egypt); Fundort: Kysis</origPlace>
+                     <origPlace>Schreibort: Hibis ? (Ägypten); Fundort: Kysis</origPlace>
                      <origDate notBefore="0287" notAfter="0288">287 - 288</origDate>
                   </origin>
                   <provenance n="1" type="composed">
@@ -58,7 +58,7 @@
                                    subtype="nome"
                                    ref="https://www.trismegistos.org/place/619 https://pleiades.stoa.org/places/776210">Oasis Magna</placeName>
                         <placeName type="ancient" subtype="region">Ägypten</placeName>
-                        <placeName n="3" type="ancient">Egypt</placeName>
+                        <placeName n="3" type="ancient">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704426.xml
+++ b/HGV_meta_EpiDoc/HGV705/704426.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Hibis ? (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Hibis ? (Ägypten)</origPlace>
                      <origDate when="0307-02-16">16. Febr. 307</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -49,7 +49,7 @@
                                    type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/776181 https://www.trismegistos.org/place/2786">Hibis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704427.xml
+++ b/HGV_meta_EpiDoc/HGV705/704427.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Hibis ? (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Hibis ? (Ägypten)</origPlace>
                      <origDate when="0307-07-16">16. Juli 307</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -49,7 +49,7 @@
                                    type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/776181 https://www.trismegistos.org/place/2786">Hibis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704428.xml
+++ b/HGV_meta_EpiDoc/HGV705/704428.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Hibis ? (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Hibis ? (Ägypten)</origPlace>
                      <origDate when="0309">309</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -49,7 +49,7 @@
                                    type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/776181 https://www.trismegistos.org/place/2786">Hibis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704429.xml
+++ b/HGV_meta_EpiDoc/HGV705/704429.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Hibis ? (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Hibis ? (Ägypten)</origPlace>
                      <origDate when="0310-06-30">30. Juni 310</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -49,7 +49,7 @@
                                    type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/776181 https://www.trismegistos.org/place/2786">Hibis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704430.xml
+++ b/HGV_meta_EpiDoc/HGV705/704430.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Hibis ? (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Hibis ? (Ägypten)</origPlace>
                      <origDate when="0310">310</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -49,7 +49,7 @@
                                    type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/776181 https://www.trismegistos.org/place/2786">Hibis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704431.xml
+++ b/HGV_meta_EpiDoc/HGV705/704431.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Hibis ? (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Hibis ? (Ägypten)</origPlace>
                      <origDate notBefore="0313" notAfter="0314">313 - 314</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -49,7 +49,7 @@
                                    type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/776181 https://www.trismegistos.org/place/2786">Hibis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704432.xml
+++ b/HGV_meta_EpiDoc/HGV705/704432.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Hibis ? (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Hibis ? (Ägypten)</origPlace>
                      <origDate notBefore="0301" notAfter="0325" precision="low">Anfang IV</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -49,7 +49,7 @@
                                    type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/776181 https://www.trismegistos.org/place/2786">Hibis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704433.xml
+++ b/HGV_meta_EpiDoc/HGV705/704433.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Hibis ? (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Hibis ? (Ägypten)</origPlace>
                      <origDate notBefore="0307" notAfter="0314">ca. 307 - 314
                 <precision match="../@notBefore" degree="0.5"/>
                      </origDate>
@@ -42,7 +42,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -51,7 +51,7 @@
                                    type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/776181 https://www.trismegistos.org/place/2786">Hibis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704625.xml
+++ b/HGV_meta_EpiDoc/HGV705/704625.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Hibis ? (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Hibis ? (Ägypten)</origPlace>
                      <origDate when="0240" precision="medium">ca. 240</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -49,7 +49,7 @@
                                    type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/776181 https://www.trismegistos.org/place/2786">Hibis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704626.xml
+++ b/HGV_meta_EpiDoc/HGV705/704626.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Kysis (Egypt); Schreibort: Hibis ? (Egypt)</origPlace>
+                     <origPlace>Fundort: Kysis (Ägypten); Schreibort: Hibis ? (Ägypten)</origPlace>
                      <origDate notBefore="0245" notAfter="0247">245 - 247</origDate>
                   </origin>
                   <provenance n="1" type="found">
@@ -40,7 +40,7 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/776191 https://www.trismegistos.org/place/2761">Kysis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">
@@ -49,7 +49,7 @@
                                    type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/776181 https://www.trismegistos.org/place/2786">Hibis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV705/704792.xml
+++ b/HGV_meta_EpiDoc/HGV705/704792.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt; erworben: - 1920</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten; erworben: - 1920</origPlace>
                      <origDate notBefore="0101" notAfter="0300" precision="low">II - III</origDate>
                   </origin>
                   <provenance n="1" type="located">

--- a/HGV_meta_EpiDoc/HGV705/704793.xml
+++ b/HGV_meta_EpiDoc/HGV705/704793.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt; erworben: Cairo - 1920</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten; erworben: Cairo - 1920</origPlace>
                      <origDate notBefore="0101" notAfter="0300" precision="low">II - III</origDate>
                   </origin>
                   <provenance n="1" type="located">

--- a/HGV_meta_EpiDoc/HGV705/704794.xml
+++ b/HGV_meta_EpiDoc/HGV705/704794.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt; erworben: - 1920</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten; erworben: - 1920</origPlace>
                      <origDate notBefore="0201" notAfter="0400" precision="low">III - IV</origDate>
                   </origin>
                   <provenance n="1" type="located">

--- a/HGV_meta_EpiDoc/HGV705/704795.xml
+++ b/HGV_meta_EpiDoc/HGV705/704795.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchites ?, Egypt; erworben: - 1920</origPlace>
+                     <origPlace>Oxyrhynchites ?, Ägypten; erworben: - 1920</origPlace>
                      <origDate notBefore="0301" notAfter="0400" precision="low">IV</origDate>
                   </origin>
                   <provenance n="1" type="located">

--- a/HGV_meta_EpiDoc/HGV705/704893.xml
+++ b/HGV_meta_EpiDoc/HGV705/704893.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Hermopolis (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Fundort: Hermopolis (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0103" notAfter="0199">103 - 199</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV705/704970.xml
+++ b/HGV_meta_EpiDoc/HGV705/704970.xml
@@ -31,7 +31,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Schreibort: Alexandria (Egypt); Fundort: Krokodilopolis (= Medinet el-Fayum) (Egypt)</origPlace>
+                     <origPlace>Schreibort: Alexandria (Ägypten); Fundort: Krokodilopolis (= Medinet el-Fayum) (Ägypten)</origPlace>
                      <origDate notBefore="0255" notAfter="0259" precision="medium">
                 ca. 255 - 259
                 <precision match="../@notAfter" degree="0.5"/>
@@ -39,7 +39,7 @@
                   </origin>
                   <provenance n="1" type="composed">
                      <p>
-                        <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
                         <placeName n="2"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/727070 https://www.trismegistos.org/place/100">Alexandria</placeName>
@@ -47,7 +47,7 @@
                   </provenance>
                   <provenance n="2" type="found">
                      <p>
-                        <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
                         <placeName n="2"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/736948 https://www.trismegistos.org/place/327">Krokodilopolis</placeName>

--- a/HGV_meta_EpiDoc/HGV705/704973.xml
+++ b/HGV_meta_EpiDoc/HGV705/704973.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites, Egypt</origPlace>
+                     <origPlace>Arsinoites, Ägypten</origPlace>
                      <origDate when="0616-02-20">20. Febr. 616</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV705/704979.xml
+++ b/HGV_meta_EpiDoc/HGV705/704979.xml
@@ -32,12 +32,12 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Egypt</origPlace>
+              <origPlace>Ägypten</origPlace>
               <origDate notBefore="0901" notAfter="1000" precision="low">X</origDate>
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV705/704980.xml
+++ b/HGV_meta_EpiDoc/HGV705/704980.xml
@@ -32,12 +32,12 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Egypt</origPlace>
+              <origPlace>Ägypten</origPlace>
               <origDate notBefore="0901" notAfter="1000" precision="low">X</origDate>
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV705/704981.xml
+++ b/HGV_meta_EpiDoc/HGV705/704981.xml
@@ -32,12 +32,12 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Egypt</origPlace>
+              <origPlace>Ägypten</origPlace>
               <origDate notBefore="0908" notAfter="0909">908 - 909</origDate>
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV705/704982.xml
+++ b/HGV_meta_EpiDoc/HGV705/704982.xml
@@ -32,12 +32,12 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Egypt</origPlace>
+              <origPlace>Ägypten</origPlace>
               <origDate notBefore="0908" notAfter="0909">908 - 909</origDate>
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV74/73880.xml
+++ b/HGV_meta_EpiDoc/HGV74/73880.xml
@@ -33,12 +33,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Egypt</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoHBFAI5">
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV750/749345.xml
+++ b/HGV_meta_EpiDoc/HGV750/749345.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Schreibort: Oxyrhynchos ? (Oxyrhynchites, Egypt); erworben: Egypt - 1932</origPlace>
+                     <origPlace>Schreibort: Oxyrhynchos ? (Oxyrhynchites, Ägypten); erworben: Ägypten - 1932</origPlace>
                      <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
                   </origin>
                   <provenance n="1" type="composed">

--- a/HGV_meta_EpiDoc/HGV750/749346.xml
+++ b/HGV_meta_EpiDoc/HGV750/749346.xml
@@ -32,12 +32,12 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Fundort: Bakchias (Arsinoites, Egypt)</origPlace>
+              <origPlace>Fundort: Bakchias (Arsinoites, Ägypten)</origPlace>
               <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
             </origin>
             <provenance type="found">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
                 <placeName n="2" type="ancient" subtype="nome">Arsinoites</placeName>
                 <placeName n="3"
                            type="ancient"

--- a/HGV_meta_EpiDoc/HGV755/754197.xml
+++ b/HGV_meta_EpiDoc/HGV755/754197.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Oxyrhynchus ? (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Fundort: Oxyrhynchus ? (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0151" notAfter="0200" precision="low">2. Hälfte II</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV755/754941.xml
+++ b/HGV_meta_EpiDoc/HGV755/754941.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-               <origPlace>Herakleopolites, Egypt</origPlace>
+               <origPlace>Herakleopolites, Ägypten</origPlace>
                <origDate notBefore="-0185" notAfter="-0125">ca. 185 - 125 v.Chr.
                 <precision match="../@notBefore" degree="0.5"/>
                </origDate>
@@ -43,7 +43,7 @@
                              type="ancient"
                              subtype="nome"
                              ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
-                  <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                  <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                </p>
             </provenance>
          </history>

--- a/HGV_meta_EpiDoc/HGV755/754942.xml
+++ b/HGV_meta_EpiDoc/HGV755/754942.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-                <origPlace>Herakleopolites, Egypt</origPlace>
+                <origPlace>Herakleopolites, Ägypten</origPlace>
                 <origDate notBefore="-0225" notAfter="-0176" precision="low">Ende III - Anfang II v.Chr.</origDate>
             </origin>
             <provenance type="located">
@@ -41,7 +41,7 @@
                               type="ancient"
                               subtype="nome"
                               ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
-                   <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                   <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                 </p>
              </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV755/754943.xml
+++ b/HGV_meta_EpiDoc/HGV755/754943.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV755/754944.xml
+++ b/HGV_meta_EpiDoc/HGV755/754944.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV755/754945.xml
+++ b/HGV_meta_EpiDoc/HGV755/754945.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-               <origPlace>Ankyropolis ? (Herakleopolites, Egypt)</origPlace>
+               <origPlace>Ankyropolis ? (Herakleopolites, Ägypten)</origPlace>
                <origDate notBefore="-0225" notAfter="-0176" precision="low">Ende III - Anfang II v.Chr.</origDate>
             </origin>
             <provenance type="located">
@@ -45,7 +45,7 @@
                              type="ancient"
                              subtype="nome"
                              ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
-                  <placeName n="3" type="ancient" subtype="region">Egypt</placeName>
+                  <placeName n="3" type="ancient" subtype="region">Ägypten</placeName>
                </p>
             </provenance>
          </history>

--- a/HGV_meta_EpiDoc/HGV755/754946.xml
+++ b/HGV_meta_EpiDoc/HGV755/754946.xml
@@ -32,7 +32,7 @@
           </physDesc>
           <history>
             <origin>
-               <origPlace>Arsinoites, Egypt</origPlace>
+               <origPlace>Arsinoites, Ägypten</origPlace>
                <origDate n="1" xml:id="dateAlternativeX" when="-0209">209 v.Chr.</origDate>
                <origDate n="2" xml:id="dateAlternativeY" when="-0192">192 v.Chr.</origDate>
             </origin>
@@ -42,7 +42,7 @@
                              type="ancient"
                              subtype="nome"
                              ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
-                  <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                  <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                </p>
             </provenance>
          </history>

--- a/HGV_meta_EpiDoc/HGV765/764352.xml
+++ b/HGV_meta_EpiDoc/HGV765/764352.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites ?, Egypt</origPlace>
+                     <origPlace>Arsinoites ?, Ägypten</origPlace>
                      <origDate notBefore="-0200" notAfter="-0151">
                 1. Hälfte (?) II v.Chr.
                 <precision n="1" match="../@notBefore" degree="0.1"/>

--- a/HGV_meta_EpiDoc/HGV765/764353.xml
+++ b/HGV_meta_EpiDoc/HGV765/764353.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Oxyrhynchus (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Fundort: Oxyrhynchus (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0041" notAfter="0068">41 - 68</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV765/764354.xml
+++ b/HGV_meta_EpiDoc/HGV765/764354.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Karanis (Arsinoites, Egypt) - 2010</origPlace>
+                     <origPlace>Fundort: Karanis (Arsinoites, Ägypten) - 2010</origPlace>
                      <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
                   </origin>
                   <provenance type="found" when="2010">

--- a/HGV_meta_EpiDoc/HGV765/764355.xml
+++ b/HGV_meta_EpiDoc/HGV765/764355.xml
@@ -32,12 +32,12 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Egypt</origPlace>
+              <origPlace>Ägypten</origPlace>
               <origDate notBefore="0676" notAfter="0725" precision="low">Ende VII - Anfang VIII</origDate>
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient">Egypt</placeName>
+                <placeName n="1" type="ancient">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV765/764356.xml
+++ b/HGV_meta_EpiDoc/HGV765/764356.xml
@@ -32,12 +32,12 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Egypt</origPlace>
+              <origPlace>Ägypten</origPlace>
               <origDate notBefore="0676" notAfter="0725" precision="low">Ende VII - Anfang VIII</origDate>
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient">Egypt</placeName>
+                <placeName n="1" type="ancient">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV765/764729.xml
+++ b/HGV_meta_EpiDoc/HGV765/764729.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0161">
                         <offset n="1" type="after">nach</offset>
                 161

--- a/HGV_meta_EpiDoc/HGV765/764730.xml
+++ b/HGV_meta_EpiDoc/HGV765/764730.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchos (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate n="1" xml:id="dateAlternativeX" notBefore="0169-04-01">
                         <offset n="1" type="after">nach</offset>
                 1. Apr. 169

--- a/HGV_meta_EpiDoc/HGV769/768440.xml
+++ b/HGV_meta_EpiDoc/HGV769/768440.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchus (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchus (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate when="0309-08-17">17. Aug. 309</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV784/783404.xml
+++ b/HGV_meta_EpiDoc/HGV784/783404.xml
@@ -32,13 +32,13 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Oberägypten ? (Egypt)</origPlace>
+              <origPlace>Oberägypten ? (Ägypten)</origPlace>
               <origDate notBefore="0601" notAfter="0625" precision="low">Anfang VII</origDate>
             </origin>
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2766">Oberägypten</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV784/783405.xml
+++ b/HGV_meta_EpiDoc/HGV784/783405.xml
@@ -32,13 +32,13 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Oberägypten ? (Egypt)</origPlace>
+              <origPlace>Oberägypten ? (Ägypten)</origPlace>
               <origDate notBefore="0601" notAfter="0625" precision="low">Anfang VII</origDate>
             </origin>
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2766">Oberägypten</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV784/783406.xml
+++ b/HGV_meta_EpiDoc/HGV784/783406.xml
@@ -32,13 +32,13 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Oberägypten ? (Egypt)</origPlace>
+              <origPlace>Oberägypten ? (Ägypten)</origPlace>
               <origDate notBefore="0501" notAfter="0800" precision="low">VI - VIII</origDate>
             </origin>
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" ref="https://www.trismegistos.org/place/2766">Oberägypten</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV787/786027.xml
+++ b/HGV_meta_EpiDoc/HGV787/786027.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV828/827801.xml
+++ b/HGV_meta_EpiDoc/HGV828/827801.xml
@@ -32,12 +32,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate>unbekannt</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoB1JI1">
-                        <placeName type="ancient">Middle Egypt</placeName>
+                        <placeName type="ancient">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV829/828778.xml
+++ b/HGV_meta_EpiDoc/HGV829/828778.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Taie (Memphites, Egypt)</origPlace>
+                     <origPlace>Taie (Memphites, Ägypten)</origPlace>
                      <origDate notBefore="0201" notAfter="0300" precision="low">III</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV833/832104.xml
+++ b/HGV_meta_EpiDoc/HGV833/832104.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Hermopolis (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Hermopolis (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0650" precision="low">1. Hälfte VII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV833/832106.xml
+++ b/HGV_meta_EpiDoc/HGV833/832106.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites, Egypt</origPlace>
+                     <origPlace>Herakleopolites, Ägypten</origPlace>
                      <origDate notBefore="0551" notAfter="0600" precision="low">2. Hälfte VI</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV833/832107.xml
+++ b/HGV_meta_EpiDoc/HGV833/832107.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites, Egypt</origPlace>
+                     <origPlace>Herakleopolites, Ägypten</origPlace>
                      <origDate notBefore="0551" notAfter="0600" precision="low">2. Hälfte VI</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV833/832108.xml
+++ b/HGV_meta_EpiDoc/HGV833/832108.xml
@@ -32,13 +32,13 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Herakleopolis ? (Egypt)</origPlace>
+              <origPlace>Herakleopolis ? (Ägypten)</origPlace>
               <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
             </origin>
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" cert="low" ref="https://www.trismegistos.org/place/801 https://pleiades.stoa.org/places/736920">Herakleopolis</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV833/832109.xml
+++ b/HGV_meta_EpiDoc/HGV833/832109.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites, Egypt</origPlace>
+                     <origPlace>Herakleopolites, Ägypten</origPlace>
                      <origDate notBefore="0640" notAfter="0725">640 - 725</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV833/832314.xml
+++ b/HGV_meta_EpiDoc/HGV833/832314.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Philadelphia (Arsinoites, Egypt); erworben: - 1924</origPlace>
+                     <origPlace>Philadelphia (Arsinoites, Ägypten); erworben: - 1924</origPlace>
                      <origDate notBefore="-0075" notAfter="-0001" precision="low">Mitte - Ende I v.Chr.</origDate>
                   </origin>
                   <provenance n="1" type="located">

--- a/HGV_meta_EpiDoc/HGV833/832315.xml
+++ b/HGV_meta_EpiDoc/HGV833/832315.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Theadelphia (Arsinoites, Egypt); erworben: - 1925</origPlace>
+                     <origPlace>Theadelphia (Arsinoites, Ägypten); erworben: - 1925</origPlace>
                      <origDate notBefore="-0025" notAfter="0025" precision="low">Ende I v.Chr. - Anfang I</origDate>
                   </origin>
                   <provenance n="1" type="located">

--- a/HGV_meta_EpiDoc/HGV833/832342.xml
+++ b/HGV_meta_EpiDoc/HGV833/832342.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Oxyrhynchus (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Oxyrhynchus (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate when="0495-05-27">27. Mai 495</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV873/872950.xml
+++ b/HGV_meta_EpiDoc/HGV873/872950.xml
@@ -32,13 +32,13 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Thebes ? (Egypt)</origPlace>
+              <origPlace>Thebes ? (Ägypten)</origPlace>
               <origDate notBefore="0376" notAfter="0700" precision="low">Ende IV - VII</origDate>
             </origin>
             <provenance type="located">
               <p>
                 <placeName n="1" type="ancient" cert="low" ref="https://www.trismegistos.org/place/2355 https://pleiades.stoa.org/places/786017">Thebes</placeName>
-                <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV875/874358.xml
+++ b/HGV_meta_EpiDoc/HGV875/874358.xml
@@ -32,13 +32,13 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Herakleopolites, Aegypten</origPlace>
+                     <origPlace>Herakleopolites, Ägypten</origPlace>
                      <origDate notBefore="-0159" notAfter="-0151" cert="low">159 - 151 v.Chr. (?)</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoF5HGD">
                         <placeName n="1" type="ancient" subtype="nome">Herakleopolites</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Aegypten</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV875/874403.xml
+++ b/HGV_meta_EpiDoc/HGV875/874403.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Oxyrhynchus (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Fundort: Oxyrhynchus (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate when="0345">345</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV875/874404.xml
+++ b/HGV_meta_EpiDoc/HGV875/874404.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Oxyrhynchus (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Fundort: Oxyrhynchus (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate n="1" xml:id="dateAlternativeX" when="0390">390</origDate>
                      <origDate n="2" xml:id="dateAlternativeY" when="0391">391</origDate>
                   </origin>

--- a/HGV_meta_EpiDoc/HGV875/874412.xml
+++ b/HGV_meta_EpiDoc/HGV875/874412.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV875/874414.xml
+++ b/HGV_meta_EpiDoc/HGV875/874414.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bakhias (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Bakhias (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV88/87349.xml
+++ b/HGV_meta_EpiDoc/HGV88/87349.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Hermopolis (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Hermopolis (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0787" notAfter="0788">787 - 788</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV88/87895.xml
+++ b/HGV_meta_EpiDoc/HGV88/87895.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoEAGBF1">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV88/87896.xml
+++ b/HGV_meta_EpiDoc/HGV88/87896.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoDJGB1">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV88/87912.xml
+++ b/HGV_meta_EpiDoc/HGV88/87912.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoBAGCF0">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV88/87930.xml
+++ b/HGV_meta_EpiDoc/HGV88/87930.xml
@@ -32,14 +32,14 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Middle Egypt</origPlace>
+                     <origPlace>Mittelägypten</origPlace>
                      <origDate notBefore="0501" notAfter="0700" precision="low">VI - VII</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoBJGCE">
                         <placeName type="ancient"
                                    subtype="region"
-                                   ref="www.trismegistos.org/place/2800">Middle Egypt</placeName>
+                                   ref="www.trismegistos.org/place/2800">Mittelägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV89/88165.xml
+++ b/HGV_meta_EpiDoc/HGV89/88165.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Aphrodites Kome (Antaiopolites, Egypt)</origPlace>
+                     <origPlace>Fundort: Aphrodites Kome (Antaiopolites, Ägypten)</origPlace>
                      <origDate notBefore="0665-08-30" notAfter="0666-08-28">30. 665 - 28. Aug. 666</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV901/900989.xml
+++ b/HGV_meta_EpiDoc/HGV901/900989.xml
@@ -32,12 +32,12 @@
           </physDesc>
           <history>
             <origin>
-              <origPlace>Egypt</origPlace>
+              <origPlace>Ägypten</origPlace>
               <origDate notBefore="0801" notAfter="0900" precision="low">IX</origDate>
             </origin>
             <provenance type="located">
               <p>
-                <placeName type="ancient" subtype="region">Egypt</placeName>
+                <placeName type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV901/900996.xml
+++ b/HGV_meta_EpiDoc/HGV901/900996.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Fundort: Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0676" notAfter="0800" precision="low">Ende VII - VIII</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV901/901000.xml
+++ b/HGV_meta_EpiDoc/HGV901/901000.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Oxyrhynchus (Oxyrhynchites, Egypt)</origPlace>
+                     <origPlace>Fundort: Oxyrhynchus (Oxyrhynchites, Ägypten)</origPlace>
                      <origDate notBefore="0401" notAfter="0600" precision="low">V - VI</origDate>
                   </origin>
                   <provenance type="found">

--- a/HGV_meta_EpiDoc/HGV943/942761.xml
+++ b/HGV_meta_EpiDoc/HGV943/942761.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942762.xml
+++ b/HGV_meta_EpiDoc/HGV943/942762.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942763.xml
+++ b/HGV_meta_EpiDoc/HGV943/942763.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942764.xml
+++ b/HGV_meta_EpiDoc/HGV943/942764.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942765.xml
+++ b/HGV_meta_EpiDoc/HGV943/942765.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942766.xml
+++ b/HGV_meta_EpiDoc/HGV943/942766.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942767.xml
+++ b/HGV_meta_EpiDoc/HGV943/942767.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942768.xml
+++ b/HGV_meta_EpiDoc/HGV943/942768.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942769.xml
+++ b/HGV_meta_EpiDoc/HGV943/942769.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942770.xml
+++ b/HGV_meta_EpiDoc/HGV943/942770.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942771.xml
+++ b/HGV_meta_EpiDoc/HGV943/942771.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942772.xml
+++ b/HGV_meta_EpiDoc/HGV943/942772.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942773.xml
+++ b/HGV_meta_EpiDoc/HGV943/942773.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942774.xml
+++ b/HGV_meta_EpiDoc/HGV943/942774.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942775.xml
+++ b/HGV_meta_EpiDoc/HGV943/942775.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942776.xml
+++ b/HGV_meta_EpiDoc/HGV943/942776.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942777.xml
+++ b/HGV_meta_EpiDoc/HGV943/942777.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942778.xml
+++ b/HGV_meta_EpiDoc/HGV943/942778.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942779.xml
+++ b/HGV_meta_EpiDoc/HGV943/942779.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942780.xml
+++ b/HGV_meta_EpiDoc/HGV943/942780.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942781.xml
+++ b/HGV_meta_EpiDoc/HGV943/942781.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942782.xml
+++ b/HGV_meta_EpiDoc/HGV943/942782.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942783.xml
+++ b/HGV_meta_EpiDoc/HGV943/942783.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942784.xml
+++ b/HGV_meta_EpiDoc/HGV943/942784.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942785.xml
+++ b/HGV_meta_EpiDoc/HGV943/942785.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942786.xml
+++ b/HGV_meta_EpiDoc/HGV943/942786.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942787.xml
+++ b/HGV_meta_EpiDoc/HGV943/942787.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942788.xml
+++ b/HGV_meta_EpiDoc/HGV943/942788.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942789.xml
+++ b/HGV_meta_EpiDoc/HGV943/942789.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942790.xml
+++ b/HGV_meta_EpiDoc/HGV943/942790.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942791.xml
+++ b/HGV_meta_EpiDoc/HGV943/942791.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit ? (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit ? (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942792.xml
+++ b/HGV_meta_EpiDoc/HGV943/942792.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Hermupolis ? (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Hermupolis ? (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942793.xml
+++ b/HGV_meta_EpiDoc/HGV943/942793.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942794.xml
+++ b/HGV_meta_EpiDoc/HGV943/942794.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942795.xml
+++ b/HGV_meta_EpiDoc/HGV943/942795.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942796.xml
+++ b/HGV_meta_EpiDoc/HGV943/942796.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942797.xml
+++ b/HGV_meta_EpiDoc/HGV943/942797.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942798.xml
+++ b/HGV_meta_EpiDoc/HGV943/942798.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942800.xml
+++ b/HGV_meta_EpiDoc/HGV943/942800.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942801.xml
+++ b/HGV_meta_EpiDoc/HGV943/942801.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942802.xml
+++ b/HGV_meta_EpiDoc/HGV943/942802.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942803.xml
+++ b/HGV_meta_EpiDoc/HGV943/942803.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942804.xml
+++ b/HGV_meta_EpiDoc/HGV943/942804.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Teschlot ? (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Teschlot ? (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="1001" notAfter="1100" precision="low">XI</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942805.xml
+++ b/HGV_meta_EpiDoc/HGV943/942805.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0601" notAfter="0800" precision="low">VII - VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942806.xml
+++ b/HGV_meta_EpiDoc/HGV943/942806.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Bawit (Hermopolites, Egypt)</origPlace>
+                     <origPlace>Bawit (Hermopolites, Ägypten)</origPlace>
                      <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
                   </origin>
                   <provenance type="located">

--- a/HGV_meta_EpiDoc/HGV943/942807.xml
+++ b/HGV_meta_EpiDoc/HGV943/942807.xml
@@ -37,7 +37,7 @@
             </origin>
             <provenance type="located">
               <p>
-                <placeName n="1" type="ancient" subtype="region">Egypt</placeName>
+                <placeName n="1" type="ancient" subtype="region">Ägypten</placeName>
               </p>
             </provenance>
           </history>

--- a/HGV_meta_EpiDoc/HGV943/942887.xml
+++ b/HGV_meta_EpiDoc/HGV943/942887.xml
@@ -32,12 +32,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Egypt</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0001" notAfter="0100" precision="low">I</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV943/942888.xml
+++ b/HGV_meta_EpiDoc/HGV943/942888.xml
@@ -32,12 +32,12 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Egypt</origPlace>
+                     <origPlace>Ägypten</origPlace>
                      <origDate notBefore="0001" notAfter="0200" precision="low">I - II</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV943/942901.xml
+++ b/HGV_meta_EpiDoc/HGV943/942901.xml
@@ -32,13 +32,13 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites, Aegypten</origPlace>
+                     <origPlace>Arsinoites, Ägypten</origPlace>
                      <origDate when="-0226-08">Aug. 226 v.Chr.</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoF5HGD">
                         <placeName n="1" type="ancient" subtype="nome">Arsinoites</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Aegypten</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV958/957914.xml
+++ b/HGV_meta_EpiDoc/HGV958/957914.xml
@@ -32,13 +32,13 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Hermopolis, Aegypten</origPlace>
+                     <origPlace>Hermopolis, Ägypten</origPlace>
                      <origDate when="0195-08-06">6. Aug. 195</origDate>
                   </origin>
                   <provenance type="located">
                      <p xml:id="geoF5HGD">
                         <placeName n="1" type="ancient">Hermopolis</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Aegypten</placeName>
+                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV99/98008.xml
+++ b/HGV_meta_EpiDoc/HGV99/98008.xml
@@ -32,7 +32,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Tebtunis (Arsinoites, Egypt)</origPlace>
+                     <origPlace>Fundort: Tebtunis (Arsinoites, Ägypten)</origPlace>
                      <origDate notBefore="-0125" notAfter="-0101" precision="low">Ende II v.Chr.</origDate>
                   </origin>
                   <provenance type="found">


### PR DESCRIPTION
Corrected 
- Egypt/Aegyptus/Aegypten to Ägypten
- Middle Egypt to Mittelägypten

Cf issue #401 , point 1.

Also removed the empty placename in TM 12997.