### PR TITLE
Corrections to placename Alexandria - removed region Ägypten

### DIFF
--- a/HGV_meta_EpiDoc/HGV1/694.xml
+++ b/HGV_meta_EpiDoc/HGV1/694.xml
@@ -45,7 +45,6 @@
                                    type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/727070 https://www.trismegistos.org/place/100">Alexandria</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="sent">

--- a/HGV_meta_EpiDoc/HGV19/18497.xml
+++ b/HGV_meta_EpiDoc/HGV19/18497.xml
@@ -41,7 +41,6 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="https://pleiades.stoa.org/places/727070 https://www.trismegistos.org/place/100">Alexandria</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18504.xml
+++ b/HGV_meta_EpiDoc/HGV19/18504.xml
@@ -45,7 +45,6 @@
                         <placeName n="1"
                                    type="ancient"
                                    ref="http://pleiades.stoa.org/places/727070 http://www.trismegistos.org/place/100">Alexandria</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>


### PR DESCRIPTION
Given the special status of Alexandria (not part of Egypt, adjacent to the province), it seems that it would be more precise to remove the region "Ägypten".

I've checked the whole corpus and found ~600 documents with Alexandria as the only placename, compared to ten with the region, so it seems that the standard for Alexandria is not to include the region. 
