### PR TITLE
Corrected Theben refs for TM 3617 and 20001

### DIFF
--- a/HGV_meta_EpiDoc/HGV21/20001.xml
+++ b/HGV_meta_EpiDoc/HGV21/20001.xml
@@ -44,7 +44,7 @@
                      <p>
                         <placeName n="1"
                                    type="ancient"
-                                   ref="https://pleiades.stoa.org/places/991398 https://www.trismegistos.org/place/2983 https://www.trismegistos.org/place/1281">Theben</placeName>
+                                   ref="https://www.trismegistos.org/place/576 https://pleiades.stoa.org/places/786017">Theben</placeName>
                         <placeName n="2" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>

--- a/HGV_meta_EpiDoc/HGV4/3617.xml
+++ b/HGV_meta_EpiDoc/HGV4/3617.xml
@@ -37,7 +37,7 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/991398 https://www.trismegistos.org/place/2983 https://www.trismegistos.org/place/1281">Theben</placeName>
+                                   ref="https://www.trismegistos.org/place/576 https://pleiades.stoa.org/places/786017">Theben</placeName>
                         <placeName type="ancient"
                                    subtype="nome"
                                    ref="https://www.trismegistos.org/place/1690">Peri Thebas</placeName>


### PR DESCRIPTION
The two documents have the place "Theben", but the references to TM Places and Pleiades seemed not quite right.

The two references in Trismegistos are in fact to Charax ([TM Geo 1281](https://www.trismegistos.org/place/1281)) and Kerameia ([TM Geo 2983](https://www.trismegistos.org/place/2983)).

The Pleiades link was to [Thebais](https://pleiades.stoa.org/places/991398), but there are several on Pleiades and this one has less precise coordinates that show far off in the desert, compared to [786131](https://pleiades.stoa.org/places/786131)

I have changed the references to those of Diospolis Magna, I hope that it fits better Theben than Charax or Kerameia...