### PR TITLE
Corrections placename Hermopolis

### DIFF
--- a/HGV_meta_EpiDoc/HGV1/725.xml
+++ b/HGV_meta_EpiDoc/HGV1/725.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV100/99922.xml
+++ b/HGV_meta_EpiDoc/HGV100/99922.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV100/99984.xml
+++ b/HGV_meta_EpiDoc/HGV100/99984.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV115/114348.xml
+++ b/HGV_meta_EpiDoc/HGV115/114348.xml
@@ -44,7 +44,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV116/115559.xml
+++ b/HGV_meta_EpiDoc/HGV116/115559.xml
@@ -36,7 +36,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV116/115560.xml
+++ b/HGV_meta_EpiDoc/HGV116/115560.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV116/115561.xml
+++ b/HGV_meta_EpiDoc/HGV116/115561.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV116/115562.xml
+++ b/HGV_meta_EpiDoc/HGV116/115562.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV119/118641.xml
+++ b/HGV_meta_EpiDoc/HGV119/118641.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV129/128345.xml
+++ b/HGV_meta_EpiDoc/HGV129/128345.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV129/128346.xml
+++ b/HGV_meta_EpiDoc/HGV129/128346.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV129/128347.xml
+++ b/HGV_meta_EpiDoc/HGV129/128347.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV129/128485.xml
+++ b/HGV_meta_EpiDoc/HGV129/128485.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV129/128654.xml
+++ b/HGV_meta_EpiDoc/HGV129/128654.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV129/128697.xml
+++ b/HGV_meta_EpiDoc/HGV129/128697.xml
@@ -36,7 +36,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV129/128698.xml
+++ b/HGV_meta_EpiDoc/HGV129/128698.xml
@@ -36,7 +36,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV130/129808.xml
+++ b/HGV_meta_EpiDoc/HGV130/129808.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV141/140532.xml
+++ b/HGV_meta_EpiDoc/HGV141/140532.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV141/140867.xml
+++ b/HGV_meta_EpiDoc/HGV141/140867.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV141/140873.xml
+++ b/HGV_meta_EpiDoc/HGV141/140873.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV141/140876.xml
+++ b/HGV_meta_EpiDoc/HGV141/140876.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV144/143375.xml
+++ b/HGV_meta_EpiDoc/HGV144/143375.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15365.xml
+++ b/HGV_meta_EpiDoc/HGV16/15365.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15421.xml
+++ b/HGV_meta_EpiDoc/HGV16/15421.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15437.xml
+++ b/HGV_meta_EpiDoc/HGV16/15437.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15439.xml
+++ b/HGV_meta_EpiDoc/HGV16/15439.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15462.xml
+++ b/HGV_meta_EpiDoc/HGV16/15462.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15470.xml
+++ b/HGV_meta_EpiDoc/HGV16/15470.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15527.xml
+++ b/HGV_meta_EpiDoc/HGV16/15527.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15528.xml
+++ b/HGV_meta_EpiDoc/HGV16/15528.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15529.xml
+++ b/HGV_meta_EpiDoc/HGV16/15529.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15549.xml
+++ b/HGV_meta_EpiDoc/HGV16/15549.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15557.xml
+++ b/HGV_meta_EpiDoc/HGV16/15557.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15558.xml
+++ b/HGV_meta_EpiDoc/HGV16/15558.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15559.xml
+++ b/HGV_meta_EpiDoc/HGV16/15559.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15560.xml
+++ b/HGV_meta_EpiDoc/HGV16/15560.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15561.xml
+++ b/HGV_meta_EpiDoc/HGV16/15561.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15562.xml
+++ b/HGV_meta_EpiDoc/HGV16/15562.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15563.xml
+++ b/HGV_meta_EpiDoc/HGV16/15563.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15564.xml
+++ b/HGV_meta_EpiDoc/HGV16/15564.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15601.xml
+++ b/HGV_meta_EpiDoc/HGV16/15601.xml
@@ -48,7 +48,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15611.xml
+++ b/HGV_meta_EpiDoc/HGV16/15611.xml
@@ -46,7 +46,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15613.xml
+++ b/HGV_meta_EpiDoc/HGV16/15613.xml
@@ -44,7 +44,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15616.xml
+++ b/HGV_meta_EpiDoc/HGV16/15616.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15617.xml
+++ b/HGV_meta_EpiDoc/HGV16/15617.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15774.xml
+++ b/HGV_meta_EpiDoc/HGV16/15774.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15798.xml
+++ b/HGV_meta_EpiDoc/HGV16/15798.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15824.xml
+++ b/HGV_meta_EpiDoc/HGV16/15824.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15827.xml
+++ b/HGV_meta_EpiDoc/HGV16/15827.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15828.xml
+++ b/HGV_meta_EpiDoc/HGV16/15828.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15831.xml
+++ b/HGV_meta_EpiDoc/HGV16/15831.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15834.xml
+++ b/HGV_meta_EpiDoc/HGV16/15834.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15835.xml
+++ b/HGV_meta_EpiDoc/HGV16/15835.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15838.xml
+++ b/HGV_meta_EpiDoc/HGV16/15838.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15839.xml
+++ b/HGV_meta_EpiDoc/HGV16/15839.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV16/15843.xml
+++ b/HGV_meta_EpiDoc/HGV16/15843.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16028.xml
+++ b/HGV_meta_EpiDoc/HGV17/16028.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16031.xml
+++ b/HGV_meta_EpiDoc/HGV17/16031.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16090.xml
+++ b/HGV_meta_EpiDoc/HGV17/16090.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16091.xml
+++ b/HGV_meta_EpiDoc/HGV17/16091.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16092.xml
+++ b/HGV_meta_EpiDoc/HGV17/16092.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16093.xml
+++ b/HGV_meta_EpiDoc/HGV17/16093.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16094.xml
+++ b/HGV_meta_EpiDoc/HGV17/16094.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16095.xml
+++ b/HGV_meta_EpiDoc/HGV17/16095.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16096.xml
+++ b/HGV_meta_EpiDoc/HGV17/16096.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16097.xml
+++ b/HGV_meta_EpiDoc/HGV17/16097.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16098.xml
+++ b/HGV_meta_EpiDoc/HGV17/16098.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16099.xml
+++ b/HGV_meta_EpiDoc/HGV17/16099.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16101.xml
+++ b/HGV_meta_EpiDoc/HGV17/16101.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16103.xml
+++ b/HGV_meta_EpiDoc/HGV17/16103.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16104.xml
+++ b/HGV_meta_EpiDoc/HGV17/16104.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16105.xml
+++ b/HGV_meta_EpiDoc/HGV17/16105.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16106.xml
+++ b/HGV_meta_EpiDoc/HGV17/16106.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16107.xml
+++ b/HGV_meta_EpiDoc/HGV17/16107.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16108.xml
+++ b/HGV_meta_EpiDoc/HGV17/16108.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16109.xml
+++ b/HGV_meta_EpiDoc/HGV17/16109.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16110.xml
+++ b/HGV_meta_EpiDoc/HGV17/16110.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16111.xml
+++ b/HGV_meta_EpiDoc/HGV17/16111.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16112.xml
+++ b/HGV_meta_EpiDoc/HGV17/16112.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16113.xml
+++ b/HGV_meta_EpiDoc/HGV17/16113.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16114.xml
+++ b/HGV_meta_EpiDoc/HGV17/16114.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16115.xml
+++ b/HGV_meta_EpiDoc/HGV17/16115.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16116.xml
+++ b/HGV_meta_EpiDoc/HGV17/16116.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16117.xml
+++ b/HGV_meta_EpiDoc/HGV17/16117.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16118.xml
+++ b/HGV_meta_EpiDoc/HGV17/16118.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16124.xml
+++ b/HGV_meta_EpiDoc/HGV17/16124.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16125.xml
+++ b/HGV_meta_EpiDoc/HGV17/16125.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16126.xml
+++ b/HGV_meta_EpiDoc/HGV17/16126.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16127.xml
+++ b/HGV_meta_EpiDoc/HGV17/16127.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16128.xml
+++ b/HGV_meta_EpiDoc/HGV17/16128.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16129.xml
+++ b/HGV_meta_EpiDoc/HGV17/16129.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16130.xml
+++ b/HGV_meta_EpiDoc/HGV17/16130.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16131.xml
+++ b/HGV_meta_EpiDoc/HGV17/16131.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16132.xml
+++ b/HGV_meta_EpiDoc/HGV17/16132.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16133.xml
+++ b/HGV_meta_EpiDoc/HGV17/16133.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16134.xml
+++ b/HGV_meta_EpiDoc/HGV17/16134.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16136.xml
+++ b/HGV_meta_EpiDoc/HGV17/16136.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16137.xml
+++ b/HGV_meta_EpiDoc/HGV17/16137.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16138.xml
+++ b/HGV_meta_EpiDoc/HGV17/16138.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16139.xml
+++ b/HGV_meta_EpiDoc/HGV17/16139.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16140.xml
+++ b/HGV_meta_EpiDoc/HGV17/16140.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16141.xml
+++ b/HGV_meta_EpiDoc/HGV17/16141.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16142.xml
+++ b/HGV_meta_EpiDoc/HGV17/16142.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16143.xml
+++ b/HGV_meta_EpiDoc/HGV17/16143.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16144.xml
+++ b/HGV_meta_EpiDoc/HGV17/16144.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16145.xml
+++ b/HGV_meta_EpiDoc/HGV17/16145.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16146.xml
+++ b/HGV_meta_EpiDoc/HGV17/16146.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16217.xml
+++ b/HGV_meta_EpiDoc/HGV17/16217.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16218.xml
+++ b/HGV_meta_EpiDoc/HGV17/16218.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16271.xml
+++ b/HGV_meta_EpiDoc/HGV17/16271.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16309.xml
+++ b/HGV_meta_EpiDoc/HGV17/16309.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16310.xml
+++ b/HGV_meta_EpiDoc/HGV17/16310.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16311.xml
+++ b/HGV_meta_EpiDoc/HGV17/16311.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16312.xml
+++ b/HGV_meta_EpiDoc/HGV17/16312.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16313.xml
+++ b/HGV_meta_EpiDoc/HGV17/16313.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16461.xml
+++ b/HGV_meta_EpiDoc/HGV17/16461.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16464.xml
+++ b/HGV_meta_EpiDoc/HGV17/16464.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16466.xml
+++ b/HGV_meta_EpiDoc/HGV17/16466.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16488.xml
+++ b/HGV_meta_EpiDoc/HGV17/16488.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16489.xml
+++ b/HGV_meta_EpiDoc/HGV17/16489.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16502.xml
+++ b/HGV_meta_EpiDoc/HGV17/16502.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16504.xml
+++ b/HGV_meta_EpiDoc/HGV17/16504.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16509.xml
+++ b/HGV_meta_EpiDoc/HGV17/16509.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16510.xml
+++ b/HGV_meta_EpiDoc/HGV17/16510.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16783.xml
+++ b/HGV_meta_EpiDoc/HGV17/16783.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16788.xml
+++ b/HGV_meta_EpiDoc/HGV17/16788.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16789.xml
+++ b/HGV_meta_EpiDoc/HGV17/16789.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16790.xml
+++ b/HGV_meta_EpiDoc/HGV17/16790.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16798.xml
+++ b/HGV_meta_EpiDoc/HGV17/16798.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16800.xml
+++ b/HGV_meta_EpiDoc/HGV17/16800.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16802.xml
+++ b/HGV_meta_EpiDoc/HGV17/16802.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16804.xml
+++ b/HGV_meta_EpiDoc/HGV17/16804.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16806.xml
+++ b/HGV_meta_EpiDoc/HGV17/16806.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16807.xml
+++ b/HGV_meta_EpiDoc/HGV17/16807.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16811.xml
+++ b/HGV_meta_EpiDoc/HGV17/16811.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16833.xml
+++ b/HGV_meta_EpiDoc/HGV17/16833.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16918.xml
+++ b/HGV_meta_EpiDoc/HGV17/16918.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16944.xml
+++ b/HGV_meta_EpiDoc/HGV17/16944.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16949.xml
+++ b/HGV_meta_EpiDoc/HGV17/16949.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16954.xml
+++ b/HGV_meta_EpiDoc/HGV17/16954.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16978.xml
+++ b/HGV_meta_EpiDoc/HGV17/16978.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16979.xml
+++ b/HGV_meta_EpiDoc/HGV17/16979.xml
@@ -48,7 +48,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16980.xml
+++ b/HGV_meta_EpiDoc/HGV17/16980.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16992.xml
+++ b/HGV_meta_EpiDoc/HGV17/16992.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16995.xml
+++ b/HGV_meta_EpiDoc/HGV17/16995.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV17/16999.xml
+++ b/HGV_meta_EpiDoc/HGV17/16999.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV171/170018.xml
+++ b/HGV_meta_EpiDoc/HGV171/170018.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17005.xml
+++ b/HGV_meta_EpiDoc/HGV18/17005.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17016.xml
+++ b/HGV_meta_EpiDoc/HGV18/17016.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17017.xml
+++ b/HGV_meta_EpiDoc/HGV18/17017.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17018.xml
+++ b/HGV_meta_EpiDoc/HGV18/17018.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17019.xml
+++ b/HGV_meta_EpiDoc/HGV18/17019.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17021.xml
+++ b/HGV_meta_EpiDoc/HGV18/17021.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17025.xml
+++ b/HGV_meta_EpiDoc/HGV18/17025.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17036.xml
+++ b/HGV_meta_EpiDoc/HGV18/17036.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17068.xml
+++ b/HGV_meta_EpiDoc/HGV18/17068.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17101.xml
+++ b/HGV_meta_EpiDoc/HGV18/17101.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17129.xml
+++ b/HGV_meta_EpiDoc/HGV18/17129.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17133.xml
+++ b/HGV_meta_EpiDoc/HGV18/17133.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17150.xml
+++ b/HGV_meta_EpiDoc/HGV18/17150.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17166.xml
+++ b/HGV_meta_EpiDoc/HGV18/17166.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17167.xml
+++ b/HGV_meta_EpiDoc/HGV18/17167.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17171.xml
+++ b/HGV_meta_EpiDoc/HGV18/17171.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17197.xml
+++ b/HGV_meta_EpiDoc/HGV18/17197.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17272.xml
+++ b/HGV_meta_EpiDoc/HGV18/17272.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17284.xml
+++ b/HGV_meta_EpiDoc/HGV18/17284.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17292.xml
+++ b/HGV_meta_EpiDoc/HGV18/17292.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17293.xml
+++ b/HGV_meta_EpiDoc/HGV18/17293.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17294.xml
+++ b/HGV_meta_EpiDoc/HGV18/17294.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17297.xml
+++ b/HGV_meta_EpiDoc/HGV18/17297.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17298.xml
+++ b/HGV_meta_EpiDoc/HGV18/17298.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17299.xml
+++ b/HGV_meta_EpiDoc/HGV18/17299.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17302.xml
+++ b/HGV_meta_EpiDoc/HGV18/17302.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17303a.xml
+++ b/HGV_meta_EpiDoc/HGV18/17303a.xml
@@ -36,7 +36,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17303b.xml
+++ b/HGV_meta_EpiDoc/HGV18/17303b.xml
@@ -36,7 +36,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17310.xml
+++ b/HGV_meta_EpiDoc/HGV18/17310.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17315.xml
+++ b/HGV_meta_EpiDoc/HGV18/17315.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17316.xml
+++ b/HGV_meta_EpiDoc/HGV18/17316.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17317.xml
+++ b/HGV_meta_EpiDoc/HGV18/17317.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17318.xml
+++ b/HGV_meta_EpiDoc/HGV18/17318.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17357.xml
+++ b/HGV_meta_EpiDoc/HGV18/17357.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17361.xml
+++ b/HGV_meta_EpiDoc/HGV18/17361.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17366.xml
+++ b/HGV_meta_EpiDoc/HGV18/17366.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17456.xml
+++ b/HGV_meta_EpiDoc/HGV18/17456.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17457.xml
+++ b/HGV_meta_EpiDoc/HGV18/17457.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17647.xml
+++ b/HGV_meta_EpiDoc/HGV18/17647.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17652.xml
+++ b/HGV_meta_EpiDoc/HGV18/17652.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17665.xml
+++ b/HGV_meta_EpiDoc/HGV18/17665.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17681.xml
+++ b/HGV_meta_EpiDoc/HGV18/17681.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17694.xml
+++ b/HGV_meta_EpiDoc/HGV18/17694.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17695.xml
+++ b/HGV_meta_EpiDoc/HGV18/17695.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17696.xml
+++ b/HGV_meta_EpiDoc/HGV18/17696.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17697.xml
+++ b/HGV_meta_EpiDoc/HGV18/17697.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17698.xml
+++ b/HGV_meta_EpiDoc/HGV18/17698.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17699.xml
+++ b/HGV_meta_EpiDoc/HGV18/17699.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17700.xml
+++ b/HGV_meta_EpiDoc/HGV18/17700.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17701a.xml
+++ b/HGV_meta_EpiDoc/HGV18/17701a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17701b.xml
+++ b/HGV_meta_EpiDoc/HGV18/17701b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17703.xml
+++ b/HGV_meta_EpiDoc/HGV18/17703.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17705.xml
+++ b/HGV_meta_EpiDoc/HGV18/17705.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17707.xml
+++ b/HGV_meta_EpiDoc/HGV18/17707.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17708.xml
+++ b/HGV_meta_EpiDoc/HGV18/17708.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17709.xml
+++ b/HGV_meta_EpiDoc/HGV18/17709.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17710.xml
+++ b/HGV_meta_EpiDoc/HGV18/17710.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17711.xml
+++ b/HGV_meta_EpiDoc/HGV18/17711.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17712.xml
+++ b/HGV_meta_EpiDoc/HGV18/17712.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17713.xml
+++ b/HGV_meta_EpiDoc/HGV18/17713.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17714.xml
+++ b/HGV_meta_EpiDoc/HGV18/17714.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17715.xml
+++ b/HGV_meta_EpiDoc/HGV18/17715.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17716.xml
+++ b/HGV_meta_EpiDoc/HGV18/17716.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17717.xml
+++ b/HGV_meta_EpiDoc/HGV18/17717.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17718.xml
+++ b/HGV_meta_EpiDoc/HGV18/17718.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17719.xml
+++ b/HGV_meta_EpiDoc/HGV18/17719.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17720.xml
+++ b/HGV_meta_EpiDoc/HGV18/17720.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17721.xml
+++ b/HGV_meta_EpiDoc/HGV18/17721.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17722.xml
+++ b/HGV_meta_EpiDoc/HGV18/17722.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17723.xml
+++ b/HGV_meta_EpiDoc/HGV18/17723.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17724.xml
+++ b/HGV_meta_EpiDoc/HGV18/17724.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17725.xml
+++ b/HGV_meta_EpiDoc/HGV18/17725.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17726.xml
+++ b/HGV_meta_EpiDoc/HGV18/17726.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17727.xml
+++ b/HGV_meta_EpiDoc/HGV18/17727.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17728.xml
+++ b/HGV_meta_EpiDoc/HGV18/17728.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17729.xml
+++ b/HGV_meta_EpiDoc/HGV18/17729.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17730.xml
+++ b/HGV_meta_EpiDoc/HGV18/17730.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17731.xml
+++ b/HGV_meta_EpiDoc/HGV18/17731.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17732.xml
+++ b/HGV_meta_EpiDoc/HGV18/17732.xml
@@ -48,7 +48,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17738a.xml
+++ b/HGV_meta_EpiDoc/HGV18/17738a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17738b.xml
+++ b/HGV_meta_EpiDoc/HGV18/17738b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17844.xml
+++ b/HGV_meta_EpiDoc/HGV18/17844.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17845.xml
+++ b/HGV_meta_EpiDoc/HGV18/17845.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17846.xml
+++ b/HGV_meta_EpiDoc/HGV18/17846.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17847.xml
+++ b/HGV_meta_EpiDoc/HGV18/17847.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17872.xml
+++ b/HGV_meta_EpiDoc/HGV18/17872.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17874.xml
+++ b/HGV_meta_EpiDoc/HGV18/17874.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17885.xml
+++ b/HGV_meta_EpiDoc/HGV18/17885.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17957.xml
+++ b/HGV_meta_EpiDoc/HGV18/17957.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV18/17958.xml
+++ b/HGV_meta_EpiDoc/HGV18/17958.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18036.xml
+++ b/HGV_meta_EpiDoc/HGV19/18036.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18049.xml
+++ b/HGV_meta_EpiDoc/HGV19/18049.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18050.xml
+++ b/HGV_meta_EpiDoc/HGV19/18050.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18122.xml
+++ b/HGV_meta_EpiDoc/HGV19/18122.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18123.xml
+++ b/HGV_meta_EpiDoc/HGV19/18123.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18173.xml
+++ b/HGV_meta_EpiDoc/HGV19/18173.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18174.xml
+++ b/HGV_meta_EpiDoc/HGV19/18174.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18176.xml
+++ b/HGV_meta_EpiDoc/HGV19/18176.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18182.xml
+++ b/HGV_meta_EpiDoc/HGV19/18182.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18183.xml
+++ b/HGV_meta_EpiDoc/HGV19/18183.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18191.xml
+++ b/HGV_meta_EpiDoc/HGV19/18191.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18202.xml
+++ b/HGV_meta_EpiDoc/HGV19/18202.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18221.xml
+++ b/HGV_meta_EpiDoc/HGV19/18221.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18345.xml
+++ b/HGV_meta_EpiDoc/HGV19/18345.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18367.xml
+++ b/HGV_meta_EpiDoc/HGV19/18367.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18371.xml
+++ b/HGV_meta_EpiDoc/HGV19/18371.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18376.xml
+++ b/HGV_meta_EpiDoc/HGV19/18376.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18383.xml
+++ b/HGV_meta_EpiDoc/HGV19/18383.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18392.xml
+++ b/HGV_meta_EpiDoc/HGV19/18392.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18395.xml
+++ b/HGV_meta_EpiDoc/HGV19/18395.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18404.xml
+++ b/HGV_meta_EpiDoc/HGV19/18404.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18530.xml
+++ b/HGV_meta_EpiDoc/HGV19/18530.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18532.xml
+++ b/HGV_meta_EpiDoc/HGV19/18532.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18660.xml
+++ b/HGV_meta_EpiDoc/HGV19/18660.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18661.xml
+++ b/HGV_meta_EpiDoc/HGV19/18661.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18662.xml
+++ b/HGV_meta_EpiDoc/HGV19/18662.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18663.xml
+++ b/HGV_meta_EpiDoc/HGV19/18663.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18664.xml
+++ b/HGV_meta_EpiDoc/HGV19/18664.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18666a.xml
+++ b/HGV_meta_EpiDoc/HGV19/18666a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18666b.xml
+++ b/HGV_meta_EpiDoc/HGV19/18666b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18668a.xml
+++ b/HGV_meta_EpiDoc/HGV19/18668a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18668b.xml
+++ b/HGV_meta_EpiDoc/HGV19/18668b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18669.xml
+++ b/HGV_meta_EpiDoc/HGV19/18669.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18671.xml
+++ b/HGV_meta_EpiDoc/HGV19/18671.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18681.xml
+++ b/HGV_meta_EpiDoc/HGV19/18681.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18715.xml
+++ b/HGV_meta_EpiDoc/HGV19/18715.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18720.xml
+++ b/HGV_meta_EpiDoc/HGV19/18720.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18722.xml
+++ b/HGV_meta_EpiDoc/HGV19/18722.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18728.xml
+++ b/HGV_meta_EpiDoc/HGV19/18728.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18737.xml
+++ b/HGV_meta_EpiDoc/HGV19/18737.xml
@@ -44,7 +44,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18742.xml
+++ b/HGV_meta_EpiDoc/HGV19/18742.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18751.xml
+++ b/HGV_meta_EpiDoc/HGV19/18751.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18770.xml
+++ b/HGV_meta_EpiDoc/HGV19/18770.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18775.xml
+++ b/HGV_meta_EpiDoc/HGV19/18775.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18781.xml
+++ b/HGV_meta_EpiDoc/HGV19/18781.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18796.xml
+++ b/HGV_meta_EpiDoc/HGV19/18796.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18797.xml
+++ b/HGV_meta_EpiDoc/HGV19/18797.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18801.xml
+++ b/HGV_meta_EpiDoc/HGV19/18801.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18802.xml
+++ b/HGV_meta_EpiDoc/HGV19/18802.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18803.xml
+++ b/HGV_meta_EpiDoc/HGV19/18803.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18804.xml
+++ b/HGV_meta_EpiDoc/HGV19/18804.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18805.xml
+++ b/HGV_meta_EpiDoc/HGV19/18805.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18806.xml
+++ b/HGV_meta_EpiDoc/HGV19/18806.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18807.xml
+++ b/HGV_meta_EpiDoc/HGV19/18807.xml
@@ -44,7 +44,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18857.xml
+++ b/HGV_meta_EpiDoc/HGV19/18857.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV19/18960.xml
+++ b/HGV_meta_EpiDoc/HGV19/18960.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19100.xml
+++ b/HGV_meta_EpiDoc/HGV20/19100.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19106.xml
+++ b/HGV_meta_EpiDoc/HGV20/19106.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19283.xml
+++ b/HGV_meta_EpiDoc/HGV20/19283.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19304.xml
+++ b/HGV_meta_EpiDoc/HGV20/19304.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19310.xml
+++ b/HGV_meta_EpiDoc/HGV20/19310.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19328.xml
+++ b/HGV_meta_EpiDoc/HGV20/19328.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19329.xml
+++ b/HGV_meta_EpiDoc/HGV20/19329.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19331.xml
+++ b/HGV_meta_EpiDoc/HGV20/19331.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19338.xml
+++ b/HGV_meta_EpiDoc/HGV20/19338.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19353.xml
+++ b/HGV_meta_EpiDoc/HGV20/19353.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19355.xml
+++ b/HGV_meta_EpiDoc/HGV20/19355.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19365.xml
+++ b/HGV_meta_EpiDoc/HGV20/19365.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19382.xml
+++ b/HGV_meta_EpiDoc/HGV20/19382.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19384.xml
+++ b/HGV_meta_EpiDoc/HGV20/19384.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19387.xml
+++ b/HGV_meta_EpiDoc/HGV20/19387.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19393.xml
+++ b/HGV_meta_EpiDoc/HGV20/19393.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19402.xml
+++ b/HGV_meta_EpiDoc/HGV20/19402.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19423.xml
+++ b/HGV_meta_EpiDoc/HGV20/19423.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19430.xml
+++ b/HGV_meta_EpiDoc/HGV20/19430.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19432.xml
+++ b/HGV_meta_EpiDoc/HGV20/19432.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19433.xml
+++ b/HGV_meta_EpiDoc/HGV20/19433.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19445.xml
+++ b/HGV_meta_EpiDoc/HGV20/19445.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19472.xml
+++ b/HGV_meta_EpiDoc/HGV20/19472.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19482.xml
+++ b/HGV_meta_EpiDoc/HGV20/19482.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19483.xml
+++ b/HGV_meta_EpiDoc/HGV20/19483.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19486.xml
+++ b/HGV_meta_EpiDoc/HGV20/19486.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19492.xml
+++ b/HGV_meta_EpiDoc/HGV20/19492.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19497.xml
+++ b/HGV_meta_EpiDoc/HGV20/19497.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19498.xml
+++ b/HGV_meta_EpiDoc/HGV20/19498.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19499.xml
+++ b/HGV_meta_EpiDoc/HGV20/19499.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19500.xml
+++ b/HGV_meta_EpiDoc/HGV20/19500.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19501.xml
+++ b/HGV_meta_EpiDoc/HGV20/19501.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19504.xml
+++ b/HGV_meta_EpiDoc/HGV20/19504.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19505.xml
+++ b/HGV_meta_EpiDoc/HGV20/19505.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19506.xml
+++ b/HGV_meta_EpiDoc/HGV20/19506.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19507.xml
+++ b/HGV_meta_EpiDoc/HGV20/19507.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19510.xml
+++ b/HGV_meta_EpiDoc/HGV20/19510.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19520.xml
+++ b/HGV_meta_EpiDoc/HGV20/19520.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19521.xml
+++ b/HGV_meta_EpiDoc/HGV20/19521.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19522.xml
+++ b/HGV_meta_EpiDoc/HGV20/19522.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19523.xml
+++ b/HGV_meta_EpiDoc/HGV20/19523.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19525.xml
+++ b/HGV_meta_EpiDoc/HGV20/19525.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19535.xml
+++ b/HGV_meta_EpiDoc/HGV20/19535.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19671.xml
+++ b/HGV_meta_EpiDoc/HGV20/19671.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19675.xml
+++ b/HGV_meta_EpiDoc/HGV20/19675.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19753.xml
+++ b/HGV_meta_EpiDoc/HGV20/19753.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19754.xml
+++ b/HGV_meta_EpiDoc/HGV20/19754.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19755.xml
+++ b/HGV_meta_EpiDoc/HGV20/19755.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19756.xml
+++ b/HGV_meta_EpiDoc/HGV20/19756.xml
@@ -44,7 +44,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19762.xml
+++ b/HGV_meta_EpiDoc/HGV20/19762.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19763.xml
+++ b/HGV_meta_EpiDoc/HGV20/19763.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19767.xml
+++ b/HGV_meta_EpiDoc/HGV20/19767.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19774.xml
+++ b/HGV_meta_EpiDoc/HGV20/19774.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19775.xml
+++ b/HGV_meta_EpiDoc/HGV20/19775.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19781.xml
+++ b/HGV_meta_EpiDoc/HGV20/19781.xml
@@ -36,7 +36,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV20/19786.xml
+++ b/HGV_meta_EpiDoc/HGV20/19786.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20033.xml
+++ b/HGV_meta_EpiDoc/HGV21/20033.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20051.xml
+++ b/HGV_meta_EpiDoc/HGV21/20051.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20107.xml
+++ b/HGV_meta_EpiDoc/HGV21/20107.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20108.xml
+++ b/HGV_meta_EpiDoc/HGV21/20108.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20110.xml
+++ b/HGV_meta_EpiDoc/HGV21/20110.xml
@@ -45,7 +45,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20123.xml
+++ b/HGV_meta_EpiDoc/HGV21/20123.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20125.xml
+++ b/HGV_meta_EpiDoc/HGV21/20125.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20126.xml
+++ b/HGV_meta_EpiDoc/HGV21/20126.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20127.xml
+++ b/HGV_meta_EpiDoc/HGV21/20127.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20132.xml
+++ b/HGV_meta_EpiDoc/HGV21/20132.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20173.xml
+++ b/HGV_meta_EpiDoc/HGV21/20173.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20174.xml
+++ b/HGV_meta_EpiDoc/HGV21/20174.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20175.xml
+++ b/HGV_meta_EpiDoc/HGV21/20175.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20209.xml
+++ b/HGV_meta_EpiDoc/HGV21/20209.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20210.xml
+++ b/HGV_meta_EpiDoc/HGV21/20210.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20313.xml
+++ b/HGV_meta_EpiDoc/HGV21/20313.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20813.xml
+++ b/HGV_meta_EpiDoc/HGV21/20813.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20874.xml
+++ b/HGV_meta_EpiDoc/HGV21/20874.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20900.xml
+++ b/HGV_meta_EpiDoc/HGV21/20900.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV21/20911.xml
+++ b/HGV_meta_EpiDoc/HGV21/20911.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21016.xml
+++ b/HGV_meta_EpiDoc/HGV22/21016.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21047.xml
+++ b/HGV_meta_EpiDoc/HGV22/21047.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21116.xml
+++ b/HGV_meta_EpiDoc/HGV22/21116.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21117.xml
+++ b/HGV_meta_EpiDoc/HGV22/21117.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21118.xml
+++ b/HGV_meta_EpiDoc/HGV22/21118.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21119.xml
+++ b/HGV_meta_EpiDoc/HGV22/21119.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21120.xml
+++ b/HGV_meta_EpiDoc/HGV22/21120.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21130.xml
+++ b/HGV_meta_EpiDoc/HGV22/21130.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21132.xml
+++ b/HGV_meta_EpiDoc/HGV22/21132.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21134.xml
+++ b/HGV_meta_EpiDoc/HGV22/21134.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21135.xml
+++ b/HGV_meta_EpiDoc/HGV22/21135.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21140.xml
+++ b/HGV_meta_EpiDoc/HGV22/21140.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21141.xml
+++ b/HGV_meta_EpiDoc/HGV22/21141.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21239.xml
+++ b/HGV_meta_EpiDoc/HGV22/21239.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21250.xml
+++ b/HGV_meta_EpiDoc/HGV22/21250.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21254.xml
+++ b/HGV_meta_EpiDoc/HGV22/21254.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21275.xml
+++ b/HGV_meta_EpiDoc/HGV22/21275.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21279.xml
+++ b/HGV_meta_EpiDoc/HGV22/21279.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21405.xml
+++ b/HGV_meta_EpiDoc/HGV22/21405.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21442.xml
+++ b/HGV_meta_EpiDoc/HGV22/21442.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21445.xml
+++ b/HGV_meta_EpiDoc/HGV22/21445.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21662.xml
+++ b/HGV_meta_EpiDoc/HGV22/21662.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21663.xml
+++ b/HGV_meta_EpiDoc/HGV22/21663.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21670.xml
+++ b/HGV_meta_EpiDoc/HGV22/21670.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21671.xml
+++ b/HGV_meta_EpiDoc/HGV22/21671.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21672.xml
+++ b/HGV_meta_EpiDoc/HGV22/21672.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21673.xml
+++ b/HGV_meta_EpiDoc/HGV22/21673.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21674.xml
+++ b/HGV_meta_EpiDoc/HGV22/21674.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21675.xml
+++ b/HGV_meta_EpiDoc/HGV22/21675.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21676.xml
+++ b/HGV_meta_EpiDoc/HGV22/21676.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21677.xml
+++ b/HGV_meta_EpiDoc/HGV22/21677.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21678.xml
+++ b/HGV_meta_EpiDoc/HGV22/21678.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21680.xml
+++ b/HGV_meta_EpiDoc/HGV22/21680.xml
@@ -45,7 +45,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21683.xml
+++ b/HGV_meta_EpiDoc/HGV22/21683.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21684.xml
+++ b/HGV_meta_EpiDoc/HGV22/21684.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21685.xml
+++ b/HGV_meta_EpiDoc/HGV22/21685.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21686.xml
+++ b/HGV_meta_EpiDoc/HGV22/21686.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21687.xml
+++ b/HGV_meta_EpiDoc/HGV22/21687.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21688.xml
+++ b/HGV_meta_EpiDoc/HGV22/21688.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21689.xml
+++ b/HGV_meta_EpiDoc/HGV22/21689.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21691.xml
+++ b/HGV_meta_EpiDoc/HGV22/21691.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21692.xml
+++ b/HGV_meta_EpiDoc/HGV22/21692.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21694.xml
+++ b/HGV_meta_EpiDoc/HGV22/21694.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21695.xml
+++ b/HGV_meta_EpiDoc/HGV22/21695.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21696.xml
+++ b/HGV_meta_EpiDoc/HGV22/21696.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21698.xml
+++ b/HGV_meta_EpiDoc/HGV22/21698.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21699.xml
+++ b/HGV_meta_EpiDoc/HGV22/21699.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21700.xml
+++ b/HGV_meta_EpiDoc/HGV22/21700.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21702.xml
+++ b/HGV_meta_EpiDoc/HGV22/21702.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21709.xml
+++ b/HGV_meta_EpiDoc/HGV22/21709.xml
@@ -44,7 +44,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21713.xml
+++ b/HGV_meta_EpiDoc/HGV22/21713.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21714.xml
+++ b/HGV_meta_EpiDoc/HGV22/21714.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21715.xml
+++ b/HGV_meta_EpiDoc/HGV22/21715.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21716.xml
+++ b/HGV_meta_EpiDoc/HGV22/21716.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21717.xml
+++ b/HGV_meta_EpiDoc/HGV22/21717.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21718.xml
+++ b/HGV_meta_EpiDoc/HGV22/21718.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV22/21723.xml
+++ b/HGV_meta_EpiDoc/HGV22/21723.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV220/219275.xml
+++ b/HGV_meta_EpiDoc/HGV220/219275.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV220/219276.xml
+++ b/HGV_meta_EpiDoc/HGV220/219276.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV220/219277.xml
+++ b/HGV_meta_EpiDoc/HGV220/219277.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV220/219278.xml
+++ b/HGV_meta_EpiDoc/HGV220/219278.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV220/219279.xml
+++ b/HGV_meta_EpiDoc/HGV220/219279.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV220/219280.xml
+++ b/HGV_meta_EpiDoc/HGV220/219280.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV220/219281.xml
+++ b/HGV_meta_EpiDoc/HGV220/219281.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV220/219282.xml
+++ b/HGV_meta_EpiDoc/HGV220/219282.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV220/219283.xml
+++ b/HGV_meta_EpiDoc/HGV220/219283.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV220/219304.xml
+++ b/HGV_meta_EpiDoc/HGV220/219304.xml
@@ -36,7 +36,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22322.xml
+++ b/HGV_meta_EpiDoc/HGV23/22322.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22324.xml
+++ b/HGV_meta_EpiDoc/HGV23/22324.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22325.xml
+++ b/HGV_meta_EpiDoc/HGV23/22325.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22326.xml
+++ b/HGV_meta_EpiDoc/HGV23/22326.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22327.xml
+++ b/HGV_meta_EpiDoc/HGV23/22327.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22328.xml
+++ b/HGV_meta_EpiDoc/HGV23/22328.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22329.xml
+++ b/HGV_meta_EpiDoc/HGV23/22329.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22330.xml
+++ b/HGV_meta_EpiDoc/HGV23/22330.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22332.xml
+++ b/HGV_meta_EpiDoc/HGV23/22332.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22333.xml
+++ b/HGV_meta_EpiDoc/HGV23/22333.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22334.xml
+++ b/HGV_meta_EpiDoc/HGV23/22334.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22335.xml
+++ b/HGV_meta_EpiDoc/HGV23/22335.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22336.xml
+++ b/HGV_meta_EpiDoc/HGV23/22336.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22337.xml
+++ b/HGV_meta_EpiDoc/HGV23/22337.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22338.xml
+++ b/HGV_meta_EpiDoc/HGV23/22338.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22339.xml
+++ b/HGV_meta_EpiDoc/HGV23/22339.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22340.xml
+++ b/HGV_meta_EpiDoc/HGV23/22340.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22341.xml
+++ b/HGV_meta_EpiDoc/HGV23/22341.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22342.xml
+++ b/HGV_meta_EpiDoc/HGV23/22342.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22344.xml
+++ b/HGV_meta_EpiDoc/HGV23/22344.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22345.xml
+++ b/HGV_meta_EpiDoc/HGV23/22345.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22346.xml
+++ b/HGV_meta_EpiDoc/HGV23/22346.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22349.xml
+++ b/HGV_meta_EpiDoc/HGV23/22349.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22350.xml
+++ b/HGV_meta_EpiDoc/HGV23/22350.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22351.xml
+++ b/HGV_meta_EpiDoc/HGV23/22351.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22352.xml
+++ b/HGV_meta_EpiDoc/HGV23/22352.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22365.xml
+++ b/HGV_meta_EpiDoc/HGV23/22365.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22366.xml
+++ b/HGV_meta_EpiDoc/HGV23/22366.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22372.xml
+++ b/HGV_meta_EpiDoc/HGV23/22372.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22375.xml
+++ b/HGV_meta_EpiDoc/HGV23/22375.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22422.xml
+++ b/HGV_meta_EpiDoc/HGV23/22422.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22428.xml
+++ b/HGV_meta_EpiDoc/HGV23/22428.xml
@@ -44,7 +44,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22430.xml
+++ b/HGV_meta_EpiDoc/HGV23/22430.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22581.xml
+++ b/HGV_meta_EpiDoc/HGV23/22581.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22590.xml
+++ b/HGV_meta_EpiDoc/HGV23/22590.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22594.xml
+++ b/HGV_meta_EpiDoc/HGV23/22594.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22620.xml
+++ b/HGV_meta_EpiDoc/HGV23/22620.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22621.xml
+++ b/HGV_meta_EpiDoc/HGV23/22621.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22622.xml
+++ b/HGV_meta_EpiDoc/HGV23/22622.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22639.xml
+++ b/HGV_meta_EpiDoc/HGV23/22639.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22640.xml
+++ b/HGV_meta_EpiDoc/HGV23/22640.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22646.xml
+++ b/HGV_meta_EpiDoc/HGV23/22646.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22647.xml
+++ b/HGV_meta_EpiDoc/HGV23/22647.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22648.xml
+++ b/HGV_meta_EpiDoc/HGV23/22648.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22705.xml
+++ b/HGV_meta_EpiDoc/HGV23/22705.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22717.xml
+++ b/HGV_meta_EpiDoc/HGV23/22717.xml
@@ -44,7 +44,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22718.xml
+++ b/HGV_meta_EpiDoc/HGV23/22718.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22719.xml
+++ b/HGV_meta_EpiDoc/HGV23/22719.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22720.xml
+++ b/HGV_meta_EpiDoc/HGV23/22720.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22721.xml
+++ b/HGV_meta_EpiDoc/HGV23/22721.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22722.xml
+++ b/HGV_meta_EpiDoc/HGV23/22722.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22723.xml
+++ b/HGV_meta_EpiDoc/HGV23/22723.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22724.xml
+++ b/HGV_meta_EpiDoc/HGV23/22724.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22725.xml
+++ b/HGV_meta_EpiDoc/HGV23/22725.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22726.xml
+++ b/HGV_meta_EpiDoc/HGV23/22726.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22727.xml
+++ b/HGV_meta_EpiDoc/HGV23/22727.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22728a.xml
+++ b/HGV_meta_EpiDoc/HGV23/22728a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22728b.xml
+++ b/HGV_meta_EpiDoc/HGV23/22728b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22730.xml
+++ b/HGV_meta_EpiDoc/HGV23/22730.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22731.xml
+++ b/HGV_meta_EpiDoc/HGV23/22731.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22732.xml
+++ b/HGV_meta_EpiDoc/HGV23/22732.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22733.xml
+++ b/HGV_meta_EpiDoc/HGV23/22733.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22734.xml
+++ b/HGV_meta_EpiDoc/HGV23/22734.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22735.xml
+++ b/HGV_meta_EpiDoc/HGV23/22735.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22736.xml
+++ b/HGV_meta_EpiDoc/HGV23/22736.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22737.xml
+++ b/HGV_meta_EpiDoc/HGV23/22737.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22738.xml
+++ b/HGV_meta_EpiDoc/HGV23/22738.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22739.xml
+++ b/HGV_meta_EpiDoc/HGV23/22739.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22740.xml
+++ b/HGV_meta_EpiDoc/HGV23/22740.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22741.xml
+++ b/HGV_meta_EpiDoc/HGV23/22741.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22747.xml
+++ b/HGV_meta_EpiDoc/HGV23/22747.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22748.xml
+++ b/HGV_meta_EpiDoc/HGV23/22748.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22753.xml
+++ b/HGV_meta_EpiDoc/HGV23/22753.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22757.xml
+++ b/HGV_meta_EpiDoc/HGV23/22757.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22758.xml
+++ b/HGV_meta_EpiDoc/HGV23/22758.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22759.xml
+++ b/HGV_meta_EpiDoc/HGV23/22759.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22762.xml
+++ b/HGV_meta_EpiDoc/HGV23/22762.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22765.xml
+++ b/HGV_meta_EpiDoc/HGV23/22765.xml
@@ -48,7 +48,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22768.xml
+++ b/HGV_meta_EpiDoc/HGV23/22768.xml
@@ -48,7 +48,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22772.xml
+++ b/HGV_meta_EpiDoc/HGV23/22772.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22782.xml
+++ b/HGV_meta_EpiDoc/HGV23/22782.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22784.xml
+++ b/HGV_meta_EpiDoc/HGV23/22784.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22785.xml
+++ b/HGV_meta_EpiDoc/HGV23/22785.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22791.xml
+++ b/HGV_meta_EpiDoc/HGV23/22791.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22798.xml
+++ b/HGV_meta_EpiDoc/HGV23/22798.xml
@@ -36,7 +36,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22801.xml
+++ b/HGV_meta_EpiDoc/HGV23/22801.xml
@@ -48,7 +48,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22807.xml
+++ b/HGV_meta_EpiDoc/HGV23/22807.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22810.xml
+++ b/HGV_meta_EpiDoc/HGV23/22810.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22811.xml
+++ b/HGV_meta_EpiDoc/HGV23/22811.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22822.xml
+++ b/HGV_meta_EpiDoc/HGV23/22822.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22825.xml
+++ b/HGV_meta_EpiDoc/HGV23/22825.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22826.xml
+++ b/HGV_meta_EpiDoc/HGV23/22826.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22827.xml
+++ b/HGV_meta_EpiDoc/HGV23/22827.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22830.xml
+++ b/HGV_meta_EpiDoc/HGV23/22830.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22846.xml
+++ b/HGV_meta_EpiDoc/HGV23/22846.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22848.xml
+++ b/HGV_meta_EpiDoc/HGV23/22848.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22857.xml
+++ b/HGV_meta_EpiDoc/HGV23/22857.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22858.xml
+++ b/HGV_meta_EpiDoc/HGV23/22858.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22876.xml
+++ b/HGV_meta_EpiDoc/HGV23/22876.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22877.xml
+++ b/HGV_meta_EpiDoc/HGV23/22877.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22881.xml
+++ b/HGV_meta_EpiDoc/HGV23/22881.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22882.xml
+++ b/HGV_meta_EpiDoc/HGV23/22882.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22899.xml
+++ b/HGV_meta_EpiDoc/HGV23/22899.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22929.xml
+++ b/HGV_meta_EpiDoc/HGV23/22929.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22931.xml
+++ b/HGV_meta_EpiDoc/HGV23/22931.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22932.xml
+++ b/HGV_meta_EpiDoc/HGV23/22932.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22934.xml
+++ b/HGV_meta_EpiDoc/HGV23/22934.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22935.xml
+++ b/HGV_meta_EpiDoc/HGV23/22935.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22936.xml
+++ b/HGV_meta_EpiDoc/HGV23/22936.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22937.xml
+++ b/HGV_meta_EpiDoc/HGV23/22937.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22938.xml
+++ b/HGV_meta_EpiDoc/HGV23/22938.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22940.xml
+++ b/HGV_meta_EpiDoc/HGV23/22940.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22941.xml
+++ b/HGV_meta_EpiDoc/HGV23/22941.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22942.xml
+++ b/HGV_meta_EpiDoc/HGV23/22942.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22945a.xml
+++ b/HGV_meta_EpiDoc/HGV23/22945a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22945b.xml
+++ b/HGV_meta_EpiDoc/HGV23/22945b.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22947.xml
+++ b/HGV_meta_EpiDoc/HGV23/22947.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22948.xml
+++ b/HGV_meta_EpiDoc/HGV23/22948.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22949a.xml
+++ b/HGV_meta_EpiDoc/HGV23/22949a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22949b.xml
+++ b/HGV_meta_EpiDoc/HGV23/22949b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22951.xml
+++ b/HGV_meta_EpiDoc/HGV23/22951.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22953.xml
+++ b/HGV_meta_EpiDoc/HGV23/22953.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22966a.xml
+++ b/HGV_meta_EpiDoc/HGV23/22966a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22966b.xml
+++ b/HGV_meta_EpiDoc/HGV23/22966b.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22974.xml
+++ b/HGV_meta_EpiDoc/HGV23/22974.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22979.xml
+++ b/HGV_meta_EpiDoc/HGV23/22979.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22984.xml
+++ b/HGV_meta_EpiDoc/HGV23/22984.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22985.xml
+++ b/HGV_meta_EpiDoc/HGV23/22985.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22987a.xml
+++ b/HGV_meta_EpiDoc/HGV23/22987a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22987b.xml
+++ b/HGV_meta_EpiDoc/HGV23/22987b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22992.xml
+++ b/HGV_meta_EpiDoc/HGV23/22992.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22994.xml
+++ b/HGV_meta_EpiDoc/HGV23/22994.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22995.xml
+++ b/HGV_meta_EpiDoc/HGV23/22995.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22996.xml
+++ b/HGV_meta_EpiDoc/HGV23/22996.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV23/22997.xml
+++ b/HGV_meta_EpiDoc/HGV23/22997.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23004.xml
+++ b/HGV_meta_EpiDoc/HGV24/23004.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23006.xml
+++ b/HGV_meta_EpiDoc/HGV24/23006.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23009.xml
+++ b/HGV_meta_EpiDoc/HGV24/23009.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23012.xml
+++ b/HGV_meta_EpiDoc/HGV24/23012.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23249.xml
+++ b/HGV_meta_EpiDoc/HGV24/23249.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23250.xml
+++ b/HGV_meta_EpiDoc/HGV24/23250.xml
@@ -48,7 +48,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23255.xml
+++ b/HGV_meta_EpiDoc/HGV24/23255.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23476.xml
+++ b/HGV_meta_EpiDoc/HGV24/23476.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23519.xml
+++ b/HGV_meta_EpiDoc/HGV24/23519.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23523.xml
+++ b/HGV_meta_EpiDoc/HGV24/23523.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23525.xml
+++ b/HGV_meta_EpiDoc/HGV24/23525.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23540.xml
+++ b/HGV_meta_EpiDoc/HGV24/23540.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23547.xml
+++ b/HGV_meta_EpiDoc/HGV24/23547.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23558.xml
+++ b/HGV_meta_EpiDoc/HGV24/23558.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23559.xml
+++ b/HGV_meta_EpiDoc/HGV24/23559.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23560.xml
+++ b/HGV_meta_EpiDoc/HGV24/23560.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23561.xml
+++ b/HGV_meta_EpiDoc/HGV24/23561.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23562.xml
+++ b/HGV_meta_EpiDoc/HGV24/23562.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23563.xml
+++ b/HGV_meta_EpiDoc/HGV24/23563.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23579.xml
+++ b/HGV_meta_EpiDoc/HGV24/23579.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23581.xml
+++ b/HGV_meta_EpiDoc/HGV24/23581.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23582.xml
+++ b/HGV_meta_EpiDoc/HGV24/23582.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23588.xml
+++ b/HGV_meta_EpiDoc/HGV24/23588.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23593.xml
+++ b/HGV_meta_EpiDoc/HGV24/23593.xml
@@ -44,7 +44,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23603.xml
+++ b/HGV_meta_EpiDoc/HGV24/23603.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23604.xml
+++ b/HGV_meta_EpiDoc/HGV24/23604.xml
@@ -41,7 +41,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23672.xml
+++ b/HGV_meta_EpiDoc/HGV24/23672.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23680.xml
+++ b/HGV_meta_EpiDoc/HGV24/23680.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23681.xml
+++ b/HGV_meta_EpiDoc/HGV24/23681.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23682.xml
+++ b/HGV_meta_EpiDoc/HGV24/23682.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23683.xml
+++ b/HGV_meta_EpiDoc/HGV24/23683.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23684.xml
+++ b/HGV_meta_EpiDoc/HGV24/23684.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23685.xml
+++ b/HGV_meta_EpiDoc/HGV24/23685.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23686.xml
+++ b/HGV_meta_EpiDoc/HGV24/23686.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23687.xml
+++ b/HGV_meta_EpiDoc/HGV24/23687.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23730.xml
+++ b/HGV_meta_EpiDoc/HGV24/23730.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23744.xml
+++ b/HGV_meta_EpiDoc/HGV24/23744.xml
@@ -44,7 +44,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23749.xml
+++ b/HGV_meta_EpiDoc/HGV24/23749.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23779.xml
+++ b/HGV_meta_EpiDoc/HGV24/23779.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23780.xml
+++ b/HGV_meta_EpiDoc/HGV24/23780.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23793.xml
+++ b/HGV_meta_EpiDoc/HGV24/23793.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23849.xml
+++ b/HGV_meta_EpiDoc/HGV24/23849.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23893.xml
+++ b/HGV_meta_EpiDoc/HGV24/23893.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23898a.xml
+++ b/HGV_meta_EpiDoc/HGV24/23898a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23898b.xml
+++ b/HGV_meta_EpiDoc/HGV24/23898b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23898c.xml
+++ b/HGV_meta_EpiDoc/HGV24/23898c.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23898d.xml
+++ b/HGV_meta_EpiDoc/HGV24/23898d.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23898e.xml
+++ b/HGV_meta_EpiDoc/HGV24/23898e.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23899.xml
+++ b/HGV_meta_EpiDoc/HGV24/23899.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV24/23951.xml
+++ b/HGV_meta_EpiDoc/HGV24/23951.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV25/24610.xml
+++ b/HGV_meta_EpiDoc/HGV25/24610.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV25/24611.xml
+++ b/HGV_meta_EpiDoc/HGV25/24611.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV25/24888.xml
+++ b/HGV_meta_EpiDoc/HGV25/24888.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV25/24889.xml
+++ b/HGV_meta_EpiDoc/HGV25/24889.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV26/25124.xml
+++ b/HGV_meta_EpiDoc/HGV26/25124.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV26/25306.xml
+++ b/HGV_meta_EpiDoc/HGV26/25306.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV26/25433.xml
+++ b/HGV_meta_EpiDoc/HGV26/25433.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV26/25434.xml
+++ b/HGV_meta_EpiDoc/HGV26/25434.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV26/25435.xml
+++ b/HGV_meta_EpiDoc/HGV26/25435.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV26/25460.xml
+++ b/HGV_meta_EpiDoc/HGV26/25460.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV26/25473.xml
+++ b/HGV_meta_EpiDoc/HGV26/25473.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV27/26152.xml
+++ b/HGV_meta_EpiDoc/HGV27/26152.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV27/26539.xml
+++ b/HGV_meta_EpiDoc/HGV27/26539.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV27/26960.xml
+++ b/HGV_meta_EpiDoc/HGV27/26960.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV28/27877.xml
+++ b/HGV_meta_EpiDoc/HGV28/27877.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV28/27975.xml
+++ b/HGV_meta_EpiDoc/HGV28/27975.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV29/28977.xml
+++ b/HGV_meta_EpiDoc/HGV29/28977.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV29/28979.xml
+++ b/HGV_meta_EpiDoc/HGV29/28979.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV29/28980.xml
+++ b/HGV_meta_EpiDoc/HGV29/28980.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV29/28981.xml
+++ b/HGV_meta_EpiDoc/HGV29/28981.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV3/2933.xml
+++ b/HGV_meta_EpiDoc/HGV3/2933.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV30/29091.xml
+++ b/HGV_meta_EpiDoc/HGV30/29091.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV30/29099.xml
+++ b/HGV_meta_EpiDoc/HGV30/29099.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV30/29250.xml
+++ b/HGV_meta_EpiDoc/HGV30/29250.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV30/29514.xml
+++ b/HGV_meta_EpiDoc/HGV30/29514.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV31/30084.xml
+++ b/HGV_meta_EpiDoc/HGV31/30084.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV31/30085.xml
+++ b/HGV_meta_EpiDoc/HGV31/30085.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV31/30086.xml
+++ b/HGV_meta_EpiDoc/HGV31/30086.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV31/30249.xml
+++ b/HGV_meta_EpiDoc/HGV31/30249.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV31/30366.xml
+++ b/HGV_meta_EpiDoc/HGV31/30366.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV31/30411.xml
+++ b/HGV_meta_EpiDoc/HGV31/30411.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV31/30413.xml
+++ b/HGV_meta_EpiDoc/HGV31/30413.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV31/30750.xml
+++ b/HGV_meta_EpiDoc/HGV31/30750.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV31/30985.xml
+++ b/HGV_meta_EpiDoc/HGV31/30985.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV31/30993.xml
+++ b/HGV_meta_EpiDoc/HGV31/30993.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV31/30994.xml
+++ b/HGV_meta_EpiDoc/HGV31/30994.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV317/316214.xml
+++ b/HGV_meta_EpiDoc/HGV317/316214.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV317/316227.xml
+++ b/HGV_meta_EpiDoc/HGV317/316227.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV317/316258.xml
+++ b/HGV_meta_EpiDoc/HGV317/316258.xml
@@ -36,7 +36,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV317/316259.xml
+++ b/HGV_meta_EpiDoc/HGV317/316259.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV317/316260.xml
+++ b/HGV_meta_EpiDoc/HGV317/316260.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV317/316261.xml
+++ b/HGV_meta_EpiDoc/HGV317/316261.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV317/316262.xml
+++ b/HGV_meta_EpiDoc/HGV317/316262.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31018.xml
+++ b/HGV_meta_EpiDoc/HGV32/31018.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31022.xml
+++ b/HGV_meta_EpiDoc/HGV32/31022.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31023.xml
+++ b/HGV_meta_EpiDoc/HGV32/31023.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31024.xml
+++ b/HGV_meta_EpiDoc/HGV32/31024.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31025.xml
+++ b/HGV_meta_EpiDoc/HGV32/31025.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31027.xml
+++ b/HGV_meta_EpiDoc/HGV32/31027.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31092.xml
+++ b/HGV_meta_EpiDoc/HGV32/31092.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31268.xml
+++ b/HGV_meta_EpiDoc/HGV32/31268.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31269.xml
+++ b/HGV_meta_EpiDoc/HGV32/31269.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31270.xml
+++ b/HGV_meta_EpiDoc/HGV32/31270.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31293.xml
+++ b/HGV_meta_EpiDoc/HGV32/31293.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31381.xml
+++ b/HGV_meta_EpiDoc/HGV32/31381.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31718.xml
+++ b/HGV_meta_EpiDoc/HGV32/31718.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31906.xml
+++ b/HGV_meta_EpiDoc/HGV32/31906.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV32/31989.xml
+++ b/HGV_meta_EpiDoc/HGV32/31989.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32002.xml
+++ b/HGV_meta_EpiDoc/HGV33/32002.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32003.xml
+++ b/HGV_meta_EpiDoc/HGV33/32003.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32004.xml
+++ b/HGV_meta_EpiDoc/HGV33/32004.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32005.xml
+++ b/HGV_meta_EpiDoc/HGV33/32005.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32012.xml
+++ b/HGV_meta_EpiDoc/HGV33/32012.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32024.xml
+++ b/HGV_meta_EpiDoc/HGV33/32024.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32026.xml
+++ b/HGV_meta_EpiDoc/HGV33/32026.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32028.xml
+++ b/HGV_meta_EpiDoc/HGV33/32028.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32032.xml
+++ b/HGV_meta_EpiDoc/HGV33/32032.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32033.xml
+++ b/HGV_meta_EpiDoc/HGV33/32033.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32035.xml
+++ b/HGV_meta_EpiDoc/HGV33/32035.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32036.xml
+++ b/HGV_meta_EpiDoc/HGV33/32036.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32037.xml
+++ b/HGV_meta_EpiDoc/HGV33/32037.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32042.xml
+++ b/HGV_meta_EpiDoc/HGV33/32042.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32044.xml
+++ b/HGV_meta_EpiDoc/HGV33/32044.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32045.xml
+++ b/HGV_meta_EpiDoc/HGV33/32045.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32055.xml
+++ b/HGV_meta_EpiDoc/HGV33/32055.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32056.xml
+++ b/HGV_meta_EpiDoc/HGV33/32056.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32057.xml
+++ b/HGV_meta_EpiDoc/HGV33/32057.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32183.xml
+++ b/HGV_meta_EpiDoc/HGV33/32183.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32184.xml
+++ b/HGV_meta_EpiDoc/HGV33/32184.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32306.xml
+++ b/HGV_meta_EpiDoc/HGV33/32306.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32489.xml
+++ b/HGV_meta_EpiDoc/HGV33/32489.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32541.xml
+++ b/HGV_meta_EpiDoc/HGV33/32541.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32553.xml
+++ b/HGV_meta_EpiDoc/HGV33/32553.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32634.xml
+++ b/HGV_meta_EpiDoc/HGV33/32634.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32639.xml
+++ b/HGV_meta_EpiDoc/HGV33/32639.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32712.xml
+++ b/HGV_meta_EpiDoc/HGV33/32712.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32762.xml
+++ b/HGV_meta_EpiDoc/HGV33/32762.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32763.xml
+++ b/HGV_meta_EpiDoc/HGV33/32763.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32764.xml
+++ b/HGV_meta_EpiDoc/HGV33/32764.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32766.xml
+++ b/HGV_meta_EpiDoc/HGV33/32766.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32767.xml
+++ b/HGV_meta_EpiDoc/HGV33/32767.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32768.xml
+++ b/HGV_meta_EpiDoc/HGV33/32768.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32770.xml
+++ b/HGV_meta_EpiDoc/HGV33/32770.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32771.xml
+++ b/HGV_meta_EpiDoc/HGV33/32771.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32773.xml
+++ b/HGV_meta_EpiDoc/HGV33/32773.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32777.xml
+++ b/HGV_meta_EpiDoc/HGV33/32777.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32881.xml
+++ b/HGV_meta_EpiDoc/HGV33/32881.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32882.xml
+++ b/HGV_meta_EpiDoc/HGV33/32882.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32886.xml
+++ b/HGV_meta_EpiDoc/HGV33/32886.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32912.xml
+++ b/HGV_meta_EpiDoc/HGV33/32912.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32944.xml
+++ b/HGV_meta_EpiDoc/HGV33/32944.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV33/32952.xml
+++ b/HGV_meta_EpiDoc/HGV33/32952.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33053.xml
+++ b/HGV_meta_EpiDoc/HGV34/33053.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33054.xml
+++ b/HGV_meta_EpiDoc/HGV34/33054.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33193.xml
+++ b/HGV_meta_EpiDoc/HGV34/33193.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33204.xml
+++ b/HGV_meta_EpiDoc/HGV34/33204.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33284.xml
+++ b/HGV_meta_EpiDoc/HGV34/33284.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33285.xml
+++ b/HGV_meta_EpiDoc/HGV34/33285.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33286.xml
+++ b/HGV_meta_EpiDoc/HGV34/33286.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33348.xml
+++ b/HGV_meta_EpiDoc/HGV34/33348.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33349.xml
+++ b/HGV_meta_EpiDoc/HGV34/33349.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33477.xml
+++ b/HGV_meta_EpiDoc/HGV34/33477.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33538.xml
+++ b/HGV_meta_EpiDoc/HGV34/33538.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33699.xml
+++ b/HGV_meta_EpiDoc/HGV34/33699.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV34/33701.xml
+++ b/HGV_meta_EpiDoc/HGV34/33701.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV342/341723.xml
+++ b/HGV_meta_EpiDoc/HGV342/341723.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV342/341724.xml
+++ b/HGV_meta_EpiDoc/HGV342/341724.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV342/341725.xml
+++ b/HGV_meta_EpiDoc/HGV342/341725.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34779.xml
+++ b/HGV_meta_EpiDoc/HGV35/34779.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34780.xml
+++ b/HGV_meta_EpiDoc/HGV35/34780.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34781.xml
+++ b/HGV_meta_EpiDoc/HGV35/34781.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34782.xml
+++ b/HGV_meta_EpiDoc/HGV35/34782.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34849.xml
+++ b/HGV_meta_EpiDoc/HGV35/34849.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34850.xml
+++ b/HGV_meta_EpiDoc/HGV35/34850.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34851.xml
+++ b/HGV_meta_EpiDoc/HGV35/34851.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34852.xml
+++ b/HGV_meta_EpiDoc/HGV35/34852.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34853.xml
+++ b/HGV_meta_EpiDoc/HGV35/34853.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34854.xml
+++ b/HGV_meta_EpiDoc/HGV35/34854.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34855.xml
+++ b/HGV_meta_EpiDoc/HGV35/34855.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34856.xml
+++ b/HGV_meta_EpiDoc/HGV35/34856.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34857.xml
+++ b/HGV_meta_EpiDoc/HGV35/34857.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV35/34886.xml
+++ b/HGV_meta_EpiDoc/HGV35/34886.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35025.xml
+++ b/HGV_meta_EpiDoc/HGV36/35025.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35035.xml
+++ b/HGV_meta_EpiDoc/HGV36/35035.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35046.xml
+++ b/HGV_meta_EpiDoc/HGV36/35046.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35075.xml
+++ b/HGV_meta_EpiDoc/HGV36/35075.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35089.xml
+++ b/HGV_meta_EpiDoc/HGV36/35089.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35167.xml
+++ b/HGV_meta_EpiDoc/HGV36/35167.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35184.xml
+++ b/HGV_meta_EpiDoc/HGV36/35184.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35185.xml
+++ b/HGV_meta_EpiDoc/HGV36/35185.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35216.xml
+++ b/HGV_meta_EpiDoc/HGV36/35216.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35219.xml
+++ b/HGV_meta_EpiDoc/HGV36/35219.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35220.xml
+++ b/HGV_meta_EpiDoc/HGV36/35220.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35231.xml
+++ b/HGV_meta_EpiDoc/HGV36/35231.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35237a.xml
+++ b/HGV_meta_EpiDoc/HGV36/35237a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35237b.xml
+++ b/HGV_meta_EpiDoc/HGV36/35237b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35238.xml
+++ b/HGV_meta_EpiDoc/HGV36/35238.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35291.xml
+++ b/HGV_meta_EpiDoc/HGV36/35291.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35465.xml
+++ b/HGV_meta_EpiDoc/HGV36/35465.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35484.xml
+++ b/HGV_meta_EpiDoc/HGV36/35484.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35499.xml
+++ b/HGV_meta_EpiDoc/HGV36/35499.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35527.xml
+++ b/HGV_meta_EpiDoc/HGV36/35527.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35528.xml
+++ b/HGV_meta_EpiDoc/HGV36/35528.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35531.xml
+++ b/HGV_meta_EpiDoc/HGV36/35531.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35536.xml
+++ b/HGV_meta_EpiDoc/HGV36/35536.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35566.xml
+++ b/HGV_meta_EpiDoc/HGV36/35566.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35672.xml
+++ b/HGV_meta_EpiDoc/HGV36/35672.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35717.xml
+++ b/HGV_meta_EpiDoc/HGV36/35717.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35821.xml
+++ b/HGV_meta_EpiDoc/HGV36/35821.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35839.xml
+++ b/HGV_meta_EpiDoc/HGV36/35839.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35849.xml
+++ b/HGV_meta_EpiDoc/HGV36/35849.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35850.xml
+++ b/HGV_meta_EpiDoc/HGV36/35850.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35851.xml
+++ b/HGV_meta_EpiDoc/HGV36/35851.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35852.xml
+++ b/HGV_meta_EpiDoc/HGV36/35852.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35872.xml
+++ b/HGV_meta_EpiDoc/HGV36/35872.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35890.xml
+++ b/HGV_meta_EpiDoc/HGV36/35890.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35935.xml
+++ b/HGV_meta_EpiDoc/HGV36/35935.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35938.xml
+++ b/HGV_meta_EpiDoc/HGV36/35938.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35943.xml
+++ b/HGV_meta_EpiDoc/HGV36/35943.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35945.xml
+++ b/HGV_meta_EpiDoc/HGV36/35945.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35946.xml
+++ b/HGV_meta_EpiDoc/HGV36/35946.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35947.xml
+++ b/HGV_meta_EpiDoc/HGV36/35947.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35948.xml
+++ b/HGV_meta_EpiDoc/HGV36/35948.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35952.xml
+++ b/HGV_meta_EpiDoc/HGV36/35952.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35953.xml
+++ b/HGV_meta_EpiDoc/HGV36/35953.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35954.xml
+++ b/HGV_meta_EpiDoc/HGV36/35954.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35955.xml
+++ b/HGV_meta_EpiDoc/HGV36/35955.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35956.xml
+++ b/HGV_meta_EpiDoc/HGV36/35956.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35957.xml
+++ b/HGV_meta_EpiDoc/HGV36/35957.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35958.xml
+++ b/HGV_meta_EpiDoc/HGV36/35958.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35959.xml
+++ b/HGV_meta_EpiDoc/HGV36/35959.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35960.xml
+++ b/HGV_meta_EpiDoc/HGV36/35960.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35961.xml
+++ b/HGV_meta_EpiDoc/HGV36/35961.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35962.xml
+++ b/HGV_meta_EpiDoc/HGV36/35962.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35963.xml
+++ b/HGV_meta_EpiDoc/HGV36/35963.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35964.xml
+++ b/HGV_meta_EpiDoc/HGV36/35964.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV36/35965.xml
+++ b/HGV_meta_EpiDoc/HGV36/35965.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36024.xml
+++ b/HGV_meta_EpiDoc/HGV37/36024.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36028.xml
+++ b/HGV_meta_EpiDoc/HGV37/36028.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36034.xml
+++ b/HGV_meta_EpiDoc/HGV37/36034.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36067.xml
+++ b/HGV_meta_EpiDoc/HGV37/36067.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36069.xml
+++ b/HGV_meta_EpiDoc/HGV37/36069.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36075.xml
+++ b/HGV_meta_EpiDoc/HGV37/36075.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36227.xml
+++ b/HGV_meta_EpiDoc/HGV37/36227.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36265.xml
+++ b/HGV_meta_EpiDoc/HGV37/36265.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36266.xml
+++ b/HGV_meta_EpiDoc/HGV37/36266.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36280.xml
+++ b/HGV_meta_EpiDoc/HGV37/36280.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36295.xml
+++ b/HGV_meta_EpiDoc/HGV37/36295.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36576.xml
+++ b/HGV_meta_EpiDoc/HGV37/36576.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36647.xml
+++ b/HGV_meta_EpiDoc/HGV37/36647.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36649.xml
+++ b/HGV_meta_EpiDoc/HGV37/36649.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36650.xml
+++ b/HGV_meta_EpiDoc/HGV37/36650.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36652.xml
+++ b/HGV_meta_EpiDoc/HGV37/36652.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36864.xml
+++ b/HGV_meta_EpiDoc/HGV37/36864.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36873.xml
+++ b/HGV_meta_EpiDoc/HGV37/36873.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36939.xml
+++ b/HGV_meta_EpiDoc/HGV37/36939.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36943.xml
+++ b/HGV_meta_EpiDoc/HGV37/36943.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36944.xml
+++ b/HGV_meta_EpiDoc/HGV37/36944.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36946.xml
+++ b/HGV_meta_EpiDoc/HGV37/36946.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36951.xml
+++ b/HGV_meta_EpiDoc/HGV37/36951.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36952.xml
+++ b/HGV_meta_EpiDoc/HGV37/36952.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV37/36982.xml
+++ b/HGV_meta_EpiDoc/HGV37/36982.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37204.xml
+++ b/HGV_meta_EpiDoc/HGV38/37204.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37294.xml
+++ b/HGV_meta_EpiDoc/HGV38/37294.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37300.xml
+++ b/HGV_meta_EpiDoc/HGV38/37300.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37300a.xml
+++ b/HGV_meta_EpiDoc/HGV38/37300a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37300b.xml
+++ b/HGV_meta_EpiDoc/HGV38/37300b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37482.xml
+++ b/HGV_meta_EpiDoc/HGV38/37482.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37500.xml
+++ b/HGV_meta_EpiDoc/HGV38/37500.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37502.xml
+++ b/HGV_meta_EpiDoc/HGV38/37502.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37554.xml
+++ b/HGV_meta_EpiDoc/HGV38/37554.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37555.xml
+++ b/HGV_meta_EpiDoc/HGV38/37555.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37575.xml
+++ b/HGV_meta_EpiDoc/HGV38/37575.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37642.xml
+++ b/HGV_meta_EpiDoc/HGV38/37642.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37664.xml
+++ b/HGV_meta_EpiDoc/HGV38/37664.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37666.xml
+++ b/HGV_meta_EpiDoc/HGV38/37666.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV38/37667.xml
+++ b/HGV_meta_EpiDoc/HGV38/37667.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38211.xml
+++ b/HGV_meta_EpiDoc/HGV39/38211.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38225.xml
+++ b/HGV_meta_EpiDoc/HGV39/38225.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38237.xml
+++ b/HGV_meta_EpiDoc/HGV39/38237.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38238.xml
+++ b/HGV_meta_EpiDoc/HGV39/38238.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38239.xml
+++ b/HGV_meta_EpiDoc/HGV39/38239.xml
@@ -50,7 +50,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38240.xml
+++ b/HGV_meta_EpiDoc/HGV39/38240.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38253a.xml
+++ b/HGV_meta_EpiDoc/HGV39/38253a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38253b.xml
+++ b/HGV_meta_EpiDoc/HGV39/38253b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38257.xml
+++ b/HGV_meta_EpiDoc/HGV39/38257.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38264.xml
+++ b/HGV_meta_EpiDoc/HGV39/38264.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38268.xml
+++ b/HGV_meta_EpiDoc/HGV39/38268.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38269.xml
+++ b/HGV_meta_EpiDoc/HGV39/38269.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38286.xml
+++ b/HGV_meta_EpiDoc/HGV39/38286.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38287.xml
+++ b/HGV_meta_EpiDoc/HGV39/38287.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38288.xml
+++ b/HGV_meta_EpiDoc/HGV39/38288.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38319.xml
+++ b/HGV_meta_EpiDoc/HGV39/38319.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38397.xml
+++ b/HGV_meta_EpiDoc/HGV39/38397.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38408.xml
+++ b/HGV_meta_EpiDoc/HGV39/38408.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38433.xml
+++ b/HGV_meta_EpiDoc/HGV39/38433.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38458.xml
+++ b/HGV_meta_EpiDoc/HGV39/38458.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38460.xml
+++ b/HGV_meta_EpiDoc/HGV39/38460.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38508.xml
+++ b/HGV_meta_EpiDoc/HGV39/38508.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38524.xml
+++ b/HGV_meta_EpiDoc/HGV39/38524.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38525.xml
+++ b/HGV_meta_EpiDoc/HGV39/38525.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38532.xml
+++ b/HGV_meta_EpiDoc/HGV39/38532.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38541.xml
+++ b/HGV_meta_EpiDoc/HGV39/38541.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38649.xml
+++ b/HGV_meta_EpiDoc/HGV39/38649.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38674.xml
+++ b/HGV_meta_EpiDoc/HGV39/38674.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38677.xml
+++ b/HGV_meta_EpiDoc/HGV39/38677.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38719.xml
+++ b/HGV_meta_EpiDoc/HGV39/38719.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38747.xml
+++ b/HGV_meta_EpiDoc/HGV39/38747.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38753.xml
+++ b/HGV_meta_EpiDoc/HGV39/38753.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38754.xml
+++ b/HGV_meta_EpiDoc/HGV39/38754.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38755.xml
+++ b/HGV_meta_EpiDoc/HGV39/38755.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38756.xml
+++ b/HGV_meta_EpiDoc/HGV39/38756.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38757.xml
+++ b/HGV_meta_EpiDoc/HGV39/38757.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38758.xml
+++ b/HGV_meta_EpiDoc/HGV39/38758.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38759.xml
+++ b/HGV_meta_EpiDoc/HGV39/38759.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38760.xml
+++ b/HGV_meta_EpiDoc/HGV39/38760.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38824.xml
+++ b/HGV_meta_EpiDoc/HGV39/38824.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38830.xml
+++ b/HGV_meta_EpiDoc/HGV39/38830.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38859.xml
+++ b/HGV_meta_EpiDoc/HGV39/38859.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38860.xml
+++ b/HGV_meta_EpiDoc/HGV39/38860.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38861.xml
+++ b/HGV_meta_EpiDoc/HGV39/38861.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38862.xml
+++ b/HGV_meta_EpiDoc/HGV39/38862.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38866.xml
+++ b/HGV_meta_EpiDoc/HGV39/38866.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV39/38873.xml
+++ b/HGV_meta_EpiDoc/HGV39/38873.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3102.xml
+++ b/HGV_meta_EpiDoc/HGV4/3102.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3103.xml
+++ b/HGV_meta_EpiDoc/HGV4/3103.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3104.xml
+++ b/HGV_meta_EpiDoc/HGV4/3104.xml
@@ -50,7 +50,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3107.xml
+++ b/HGV_meta_EpiDoc/HGV4/3107.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3108.xml
+++ b/HGV_meta_EpiDoc/HGV4/3108.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3109.xml
+++ b/HGV_meta_EpiDoc/HGV4/3109.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3110.xml
+++ b/HGV_meta_EpiDoc/HGV4/3110.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3111.xml
+++ b/HGV_meta_EpiDoc/HGV4/3111.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3112.xml
+++ b/HGV_meta_EpiDoc/HGV4/3112.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3118.xml
+++ b/HGV_meta_EpiDoc/HGV4/3118.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV4/3952.xml
+++ b/HGV_meta_EpiDoc/HGV4/3952.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39259.xml
+++ b/HGV_meta_EpiDoc/HGV40/39259.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39260.xml
+++ b/HGV_meta_EpiDoc/HGV40/39260.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39265.xml
+++ b/HGV_meta_EpiDoc/HGV40/39265.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39268.xml
+++ b/HGV_meta_EpiDoc/HGV40/39268.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39269.xml
+++ b/HGV_meta_EpiDoc/HGV40/39269.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39270.xml
+++ b/HGV_meta_EpiDoc/HGV40/39270.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39271.xml
+++ b/HGV_meta_EpiDoc/HGV40/39271.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39272.xml
+++ b/HGV_meta_EpiDoc/HGV40/39272.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39273.xml
+++ b/HGV_meta_EpiDoc/HGV40/39273.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39274.xml
+++ b/HGV_meta_EpiDoc/HGV40/39274.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39275.xml
+++ b/HGV_meta_EpiDoc/HGV40/39275.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39276.xml
+++ b/HGV_meta_EpiDoc/HGV40/39276.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39277.xml
+++ b/HGV_meta_EpiDoc/HGV40/39277.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39278.xml
+++ b/HGV_meta_EpiDoc/HGV40/39278.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39363.xml
+++ b/HGV_meta_EpiDoc/HGV40/39363.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39364.xml
+++ b/HGV_meta_EpiDoc/HGV40/39364.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39576.xml
+++ b/HGV_meta_EpiDoc/HGV40/39576.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39577.xml
+++ b/HGV_meta_EpiDoc/HGV40/39577.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39587.xml
+++ b/HGV_meta_EpiDoc/HGV40/39587.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39589.xml
+++ b/HGV_meta_EpiDoc/HGV40/39589.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39591.xml
+++ b/HGV_meta_EpiDoc/HGV40/39591.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39598.xml
+++ b/HGV_meta_EpiDoc/HGV40/39598.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39618.xml
+++ b/HGV_meta_EpiDoc/HGV40/39618.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39663.xml
+++ b/HGV_meta_EpiDoc/HGV40/39663.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39664.xml
+++ b/HGV_meta_EpiDoc/HGV40/39664.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV40/39945.xml
+++ b/HGV_meta_EpiDoc/HGV40/39945.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV41/40714.xml
+++ b/HGV_meta_EpiDoc/HGV41/40714.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV45/44668.xml
+++ b/HGV_meta_EpiDoc/HGV45/44668.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV46/45049.xml
+++ b/HGV_meta_EpiDoc/HGV46/45049.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV46/45412.xml
+++ b/HGV_meta_EpiDoc/HGV46/45412.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV46/45512.xml
+++ b/HGV_meta_EpiDoc/HGV46/45512.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47023.xml
+++ b/HGV_meta_EpiDoc/HGV48/47023.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47240.xml
+++ b/HGV_meta_EpiDoc/HGV48/47240.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47241a.xml
+++ b/HGV_meta_EpiDoc/HGV48/47241a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47241b.xml
+++ b/HGV_meta_EpiDoc/HGV48/47241b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47242.xml
+++ b/HGV_meta_EpiDoc/HGV48/47242.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47243.xml
+++ b/HGV_meta_EpiDoc/HGV48/47243.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47244a.xml
+++ b/HGV_meta_EpiDoc/HGV48/47244a.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47244b.xml
+++ b/HGV_meta_EpiDoc/HGV48/47244b.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47245.xml
+++ b/HGV_meta_EpiDoc/HGV48/47245.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47246.xml
+++ b/HGV_meta_EpiDoc/HGV48/47246.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47248.xml
+++ b/HGV_meta_EpiDoc/HGV48/47248.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV48/47259.xml
+++ b/HGV_meta_EpiDoc/HGV48/47259.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV49/48613.xml
+++ b/HGV_meta_EpiDoc/HGV49/48613.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV49/48615.xml
+++ b/HGV_meta_EpiDoc/HGV49/48615.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV5/4523.xml
+++ b/HGV_meta_EpiDoc/HGV5/4523.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV57/56355.xml
+++ b/HGV_meta_EpiDoc/HGV57/56355.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV57/56356a.xml
+++ b/HGV_meta_EpiDoc/HGV57/56356a.xml
@@ -48,7 +48,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV57/56356b.xml
+++ b/HGV_meta_EpiDoc/HGV57/56356b.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV57/56357.xml
+++ b/HGV_meta_EpiDoc/HGV57/56357.xml
@@ -48,7 +48,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV57/56358.xml
+++ b/HGV_meta_EpiDoc/HGV57/56358.xml
@@ -48,7 +48,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV57/56359.xml
+++ b/HGV_meta_EpiDoc/HGV57/56359.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV57/56360.xml
+++ b/HGV_meta_EpiDoc/HGV57/56360.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV57/56361.xml
+++ b/HGV_meta_EpiDoc/HGV57/56361.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV59/58483.xml
+++ b/HGV_meta_EpiDoc/HGV59/58483.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5286.xml
+++ b/HGV_meta_EpiDoc/HGV6/5286.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5292a.xml
+++ b/HGV_meta_EpiDoc/HGV6/5292a.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5292b.xml
+++ b/HGV_meta_EpiDoc/HGV6/5292b.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5292c.xml
+++ b/HGV_meta_EpiDoc/HGV6/5292c.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5703.xml
+++ b/HGV_meta_EpiDoc/HGV6/5703.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV6/5794.xml
+++ b/HGV_meta_EpiDoc/HGV6/5794.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV65/64373.xml
+++ b/HGV_meta_EpiDoc/HGV65/64373.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV65/64556.xml
+++ b/HGV_meta_EpiDoc/HGV65/64556.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV65/64564.xml
+++ b/HGV_meta_EpiDoc/HGV65/64564.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV65/64720.xml
+++ b/HGV_meta_EpiDoc/HGV65/64720.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV65/64975.xml
+++ b/HGV_meta_EpiDoc/HGV65/64975.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV698/697558.xml
+++ b/HGV_meta_EpiDoc/HGV698/697558.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69754.xml
+++ b/HGV_meta_EpiDoc/HGV70/69754.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69755.xml
+++ b/HGV_meta_EpiDoc/HGV70/69755.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69756.xml
+++ b/HGV_meta_EpiDoc/HGV70/69756.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69758.xml
+++ b/HGV_meta_EpiDoc/HGV70/69758.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69759.xml
+++ b/HGV_meta_EpiDoc/HGV70/69759.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69762.xml
+++ b/HGV_meta_EpiDoc/HGV70/69762.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69764.xml
+++ b/HGV_meta_EpiDoc/HGV70/69764.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69765.xml
+++ b/HGV_meta_EpiDoc/HGV70/69765.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69766.xml
+++ b/HGV_meta_EpiDoc/HGV70/69766.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69767.xml
+++ b/HGV_meta_EpiDoc/HGV70/69767.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69768.xml
+++ b/HGV_meta_EpiDoc/HGV70/69768.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69769.xml
+++ b/HGV_meta_EpiDoc/HGV70/69769.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69779.xml
+++ b/HGV_meta_EpiDoc/HGV70/69779.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69780.xml
+++ b/HGV_meta_EpiDoc/HGV70/69780.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69781.xml
+++ b/HGV_meta_EpiDoc/HGV70/69781.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69783.xml
+++ b/HGV_meta_EpiDoc/HGV70/69783.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69785.xml
+++ b/HGV_meta_EpiDoc/HGV70/69785.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69787.xml
+++ b/HGV_meta_EpiDoc/HGV70/69787.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69789.xml
+++ b/HGV_meta_EpiDoc/HGV70/69789.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69925.xml
+++ b/HGV_meta_EpiDoc/HGV70/69925.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69961.xml
+++ b/HGV_meta_EpiDoc/HGV70/69961.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69963.xml
+++ b/HGV_meta_EpiDoc/HGV70/69963.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69964.xml
+++ b/HGV_meta_EpiDoc/HGV70/69964.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV70/69976.xml
+++ b/HGV_meta_EpiDoc/HGV70/69976.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV704/703010.xml
+++ b/HGV_meta_EpiDoc/HGV704/703010.xml
@@ -34,7 +34,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70176.xml
+++ b/HGV_meta_EpiDoc/HGV71/70176.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70177.xml
+++ b/HGV_meta_EpiDoc/HGV71/70177.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70178.xml
+++ b/HGV_meta_EpiDoc/HGV71/70178.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70180.xml
+++ b/HGV_meta_EpiDoc/HGV71/70180.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70186.xml
+++ b/HGV_meta_EpiDoc/HGV71/70186.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70188.xml
+++ b/HGV_meta_EpiDoc/HGV71/70188.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70241.xml
+++ b/HGV_meta_EpiDoc/HGV71/70241.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70242.xml
+++ b/HGV_meta_EpiDoc/HGV71/70242.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70289.xml
+++ b/HGV_meta_EpiDoc/HGV71/70289.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70302.xml
+++ b/HGV_meta_EpiDoc/HGV71/70302.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70307.xml
+++ b/HGV_meta_EpiDoc/HGV71/70307.xml
@@ -42,7 +42,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70308.xml
+++ b/HGV_meta_EpiDoc/HGV71/70308.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70309.xml
+++ b/HGV_meta_EpiDoc/HGV71/70309.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70311.xml
+++ b/HGV_meta_EpiDoc/HGV71/70311.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70329.xml
+++ b/HGV_meta_EpiDoc/HGV71/70329.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV71/70334.xml
+++ b/HGV_meta_EpiDoc/HGV71/70334.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV78/77996.xml
+++ b/HGV_meta_EpiDoc/HGV78/77996.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV787/786088.xml
+++ b/HGV_meta_EpiDoc/HGV787/786088.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV787/786096.xml
+++ b/HGV_meta_EpiDoc/HGV787/786096.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV787/786097.xml
+++ b/HGV_meta_EpiDoc/HGV787/786097.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV787/786102.xml
+++ b/HGV_meta_EpiDoc/HGV787/786102.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78026.xml
+++ b/HGV_meta_EpiDoc/HGV79/78026.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78027.xml
+++ b/HGV_meta_EpiDoc/HGV79/78027.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78088.xml
+++ b/HGV_meta_EpiDoc/HGV79/78088.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78097.xml
+++ b/HGV_meta_EpiDoc/HGV79/78097.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78098.xml
+++ b/HGV_meta_EpiDoc/HGV79/78098.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78195.xml
+++ b/HGV_meta_EpiDoc/HGV79/78195.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78198.xml
+++ b/HGV_meta_EpiDoc/HGV79/78198.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78204.xml
+++ b/HGV_meta_EpiDoc/HGV79/78204.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78208.xml
+++ b/HGV_meta_EpiDoc/HGV79/78208.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78301.xml
+++ b/HGV_meta_EpiDoc/HGV79/78301.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78444.xml
+++ b/HGV_meta_EpiDoc/HGV79/78444.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78449.xml
+++ b/HGV_meta_EpiDoc/HGV79/78449.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78713.xml
+++ b/HGV_meta_EpiDoc/HGV79/78713.xml
@@ -36,7 +36,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78805.xml
+++ b/HGV_meta_EpiDoc/HGV79/78805.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78807.xml
+++ b/HGV_meta_EpiDoc/HGV79/78807.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78953.xml
+++ b/HGV_meta_EpiDoc/HGV79/78953.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78954.xml
+++ b/HGV_meta_EpiDoc/HGV79/78954.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79123.xml
+++ b/HGV_meta_EpiDoc/HGV80/79123.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79124.xml
+++ b/HGV_meta_EpiDoc/HGV80/79124.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79190.xml
+++ b/HGV_meta_EpiDoc/HGV80/79190.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79191.xml
+++ b/HGV_meta_EpiDoc/HGV80/79191.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79196.xml
+++ b/HGV_meta_EpiDoc/HGV80/79196.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79197.xml
+++ b/HGV_meta_EpiDoc/HGV80/79197.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79264.xml
+++ b/HGV_meta_EpiDoc/HGV80/79264.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79306.xml
+++ b/HGV_meta_EpiDoc/HGV80/79306.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79307.xml
+++ b/HGV_meta_EpiDoc/HGV80/79307.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79362.xml
+++ b/HGV_meta_EpiDoc/HGV80/79362.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79444.xml
+++ b/HGV_meta_EpiDoc/HGV80/79444.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV80/79445.xml
+++ b/HGV_meta_EpiDoc/HGV80/79445.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82031.xml
+++ b/HGV_meta_EpiDoc/HGV83/82031.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82032.xml
+++ b/HGV_meta_EpiDoc/HGV83/82032.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82046.xml
+++ b/HGV_meta_EpiDoc/HGV83/82046.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82052.xml
+++ b/HGV_meta_EpiDoc/HGV83/82052.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82056.xml
+++ b/HGV_meta_EpiDoc/HGV83/82056.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82066.xml
+++ b/HGV_meta_EpiDoc/HGV83/82066.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82069.xml
+++ b/HGV_meta_EpiDoc/HGV83/82069.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82073.xml
+++ b/HGV_meta_EpiDoc/HGV83/82073.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82092.xml
+++ b/HGV_meta_EpiDoc/HGV83/82092.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82099.xml
+++ b/HGV_meta_EpiDoc/HGV83/82099.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82102.xml
+++ b/HGV_meta_EpiDoc/HGV83/82102.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82106.xml
+++ b/HGV_meta_EpiDoc/HGV83/82106.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82108.xml
+++ b/HGV_meta_EpiDoc/HGV83/82108.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82111.xml
+++ b/HGV_meta_EpiDoc/HGV83/82111.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82131.xml
+++ b/HGV_meta_EpiDoc/HGV83/82131.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82136.xml
+++ b/HGV_meta_EpiDoc/HGV83/82136.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82137.xml
+++ b/HGV_meta_EpiDoc/HGV83/82137.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82186.xml
+++ b/HGV_meta_EpiDoc/HGV83/82186.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82197.xml
+++ b/HGV_meta_EpiDoc/HGV83/82197.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82203.xml
+++ b/HGV_meta_EpiDoc/HGV83/82203.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82209.xml
+++ b/HGV_meta_EpiDoc/HGV83/82209.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82222.xml
+++ b/HGV_meta_EpiDoc/HGV83/82222.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV83/82225.xml
+++ b/HGV_meta_EpiDoc/HGV83/82225.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV87/86376.xml
+++ b/HGV_meta_EpiDoc/HGV87/86376.xml
@@ -34,7 +34,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV902/901318.xml
+++ b/HGV_meta_EpiDoc/HGV902/901318.xml
@@ -34,7 +34,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91670.xml
+++ b/HGV_meta_EpiDoc/HGV92/91670.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91671.xml
+++ b/HGV_meta_EpiDoc/HGV92/91671.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91672.xml
+++ b/HGV_meta_EpiDoc/HGV92/91672.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91673.xml
+++ b/HGV_meta_EpiDoc/HGV92/91673.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91674.xml
+++ b/HGV_meta_EpiDoc/HGV92/91674.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91675.xml
+++ b/HGV_meta_EpiDoc/HGV92/91675.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91677.xml
+++ b/HGV_meta_EpiDoc/HGV92/91677.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91679.xml
+++ b/HGV_meta_EpiDoc/HGV92/91679.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91680.xml
+++ b/HGV_meta_EpiDoc/HGV92/91680.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91681.xml
+++ b/HGV_meta_EpiDoc/HGV92/91681.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91682.xml
+++ b/HGV_meta_EpiDoc/HGV92/91682.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91683.xml
+++ b/HGV_meta_EpiDoc/HGV92/91683.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91684.xml
+++ b/HGV_meta_EpiDoc/HGV92/91684.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91685.xml
+++ b/HGV_meta_EpiDoc/HGV92/91685.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91686.xml
+++ b/HGV_meta_EpiDoc/HGV92/91686.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91687.xml
+++ b/HGV_meta_EpiDoc/HGV92/91687.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91688.xml
+++ b/HGV_meta_EpiDoc/HGV92/91688.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91689.xml
+++ b/HGV_meta_EpiDoc/HGV92/91689.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91690.xml
+++ b/HGV_meta_EpiDoc/HGV92/91690.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91691.xml
+++ b/HGV_meta_EpiDoc/HGV92/91691.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91692.xml
+++ b/HGV_meta_EpiDoc/HGV92/91692.xml
@@ -48,7 +48,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91693.xml
+++ b/HGV_meta_EpiDoc/HGV92/91693.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91696.xml
+++ b/HGV_meta_EpiDoc/HGV92/91696.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91697.xml
+++ b/HGV_meta_EpiDoc/HGV92/91697.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91698.xml
+++ b/HGV_meta_EpiDoc/HGV92/91698.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91699.xml
+++ b/HGV_meta_EpiDoc/HGV92/91699.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91700.xml
+++ b/HGV_meta_EpiDoc/HGV92/91700.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91701.xml
+++ b/HGV_meta_EpiDoc/HGV92/91701.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91702.xml
+++ b/HGV_meta_EpiDoc/HGV92/91702.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91703.xml
+++ b/HGV_meta_EpiDoc/HGV92/91703.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91704.xml
+++ b/HGV_meta_EpiDoc/HGV92/91704.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91705.xml
+++ b/HGV_meta_EpiDoc/HGV92/91705.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91706.xml
+++ b/HGV_meta_EpiDoc/HGV92/91706.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91707.xml
+++ b/HGV_meta_EpiDoc/HGV92/91707.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91708.xml
+++ b/HGV_meta_EpiDoc/HGV92/91708.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91709.xml
+++ b/HGV_meta_EpiDoc/HGV92/91709.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91715.xml
+++ b/HGV_meta_EpiDoc/HGV92/91715.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91716.xml
+++ b/HGV_meta_EpiDoc/HGV92/91716.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91717.xml
+++ b/HGV_meta_EpiDoc/HGV92/91717.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91718.xml
+++ b/HGV_meta_EpiDoc/HGV92/91718.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91719.xml
+++ b/HGV_meta_EpiDoc/HGV92/91719.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91720.xml
+++ b/HGV_meta_EpiDoc/HGV92/91720.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91721.xml
+++ b/HGV_meta_EpiDoc/HGV92/91721.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91722.xml
+++ b/HGV_meta_EpiDoc/HGV92/91722.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91723.xml
+++ b/HGV_meta_EpiDoc/HGV92/91723.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91724.xml
+++ b/HGV_meta_EpiDoc/HGV92/91724.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91725.xml
+++ b/HGV_meta_EpiDoc/HGV92/91725.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91726.xml
+++ b/HGV_meta_EpiDoc/HGV92/91726.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91727.xml
+++ b/HGV_meta_EpiDoc/HGV92/91727.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91728.xml
+++ b/HGV_meta_EpiDoc/HGV92/91728.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91729.xml
+++ b/HGV_meta_EpiDoc/HGV92/91729.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91730.xml
+++ b/HGV_meta_EpiDoc/HGV92/91730.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91731.xml
+++ b/HGV_meta_EpiDoc/HGV92/91731.xml
@@ -40,7 +40,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91732.xml
+++ b/HGV_meta_EpiDoc/HGV92/91732.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91733.xml
+++ b/HGV_meta_EpiDoc/HGV92/91733.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91735.xml
+++ b/HGV_meta_EpiDoc/HGV92/91735.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91736.xml
+++ b/HGV_meta_EpiDoc/HGV92/91736.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91737.xml
+++ b/HGV_meta_EpiDoc/HGV92/91737.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91738.xml
+++ b/HGV_meta_EpiDoc/HGV92/91738.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91739.xml
+++ b/HGV_meta_EpiDoc/HGV92/91739.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91740.xml
+++ b/HGV_meta_EpiDoc/HGV92/91740.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91741.xml
+++ b/HGV_meta_EpiDoc/HGV92/91741.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91742.xml
+++ b/HGV_meta_EpiDoc/HGV92/91742.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91743.xml
+++ b/HGV_meta_EpiDoc/HGV92/91743.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91745.xml
+++ b/HGV_meta_EpiDoc/HGV92/91745.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91746.xml
+++ b/HGV_meta_EpiDoc/HGV92/91746.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91747.xml
+++ b/HGV_meta_EpiDoc/HGV92/91747.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91748.xml
+++ b/HGV_meta_EpiDoc/HGV92/91748.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV92/91749.xml
+++ b/HGV_meta_EpiDoc/HGV92/91749.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV93/92453.xml
+++ b/HGV_meta_EpiDoc/HGV93/92453.xml
@@ -37,7 +37,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV98/97097.xml
+++ b/HGV_meta_EpiDoc/HGV98/97097.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV98/97143.xml
+++ b/HGV_meta_EpiDoc/HGV98/97143.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV98/97191.xml
+++ b/HGV_meta_EpiDoc/HGV98/97191.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV98/97195.xml
+++ b/HGV_meta_EpiDoc/HGV98/97195.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV98/97248.xml
+++ b/HGV_meta_EpiDoc/HGV98/97248.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV98/97250.xml
+++ b/HGV_meta_EpiDoc/HGV98/97250.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV98/97251.xml
+++ b/HGV_meta_EpiDoc/HGV98/97251.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV98/97358.xml
+++ b/HGV_meta_EpiDoc/HGV98/97358.xml
@@ -35,7 +35,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV984/983542.xml
+++ b/HGV_meta_EpiDoc/HGV984/983542.xml
@@ -41,7 +41,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV984/983562.xml
+++ b/HGV_meta_EpiDoc/HGV984/983562.xml
@@ -39,7 +39,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV998/997950.xml
+++ b/HGV_meta_EpiDoc/HGV998/997950.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV998/997957.xml
+++ b/HGV_meta_EpiDoc/HGV998/997957.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV998/997962.xml
+++ b/HGV_meta_EpiDoc/HGV998/997962.xml
@@ -38,7 +38,11 @@
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
-                                   ref="https://pleiades.stoa.org/places/727122 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                                   ref="https://pleiades.stoa.org/places/756574 https://www.trismegistos.org/place/816">Hermopolis</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>


### PR DESCRIPTION
I have added the nome and region for documents from Hermopolis (with a reference to TM Geo 816).

I have also corrected the Pleiades reference, using [756574](https://pleiades.stoa.org/places/756574) which is the one from TM. The previous pleiades reference to [727122](https://pleiades.stoa.org/places/727122) was somewhere in the delta.

However, I noticed that some documents from Hermopolis (TM Geo 816) have the nome Arsinoite in the data, e.g. 10029, 10037, 10038, 10042. I am not sure if the nome is wrong or the TM identifier is wrong, since there is also an Hermopolis in the Arsinoite (TM Geo 813)... but it means that maybe some of the files I just corrected are from the Arsinoite nome instead of Hermopolite ?