### PR TITLE
Gurob - added nome/region

### DIFF
--- a/HGV_meta_EpiDoc/HGV119/118687.xml
+++ b/HGV_meta_EpiDoc/HGV119/118687.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoDHB7CI">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV3/2491.xml
+++ b/HGV_meta_EpiDoc/HGV3/2491.xml
@@ -55,6 +55,10 @@
                      <p xml:id="geoIFHEC4">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV382/381300.xml
+++ b/HGV_meta_EpiDoc/HGV382/381300.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoGCIJA8">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV382/381301.xml
+++ b/HGV_meta_EpiDoc/HGV382/381301.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoCHEJAI">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV382/381302.xml
+++ b/HGV_meta_EpiDoc/HGV382/381302.xml
@@ -39,6 +39,10 @@
                      <p xml:id="geoIBEG68">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388474.xml
+++ b/HGV_meta_EpiDoc/HGV389/388474.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoEDCJH9">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388475.xml
+++ b/HGV_meta_EpiDoc/HGV389/388475.xml
@@ -39,6 +39,10 @@
                      <p xml:id="geoCEFHG">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388476.xml
+++ b/HGV_meta_EpiDoc/HGV389/388476.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoGJIAC2">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388477.xml
+++ b/HGV_meta_EpiDoc/HGV389/388477.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoJEFHC">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388478.xml
+++ b/HGV_meta_EpiDoc/HGV389/388478.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoB1GJ9C">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388479.xml
+++ b/HGV_meta_EpiDoc/HGV389/388479.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoIFADC3">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388480.xml
+++ b/HGV_meta_EpiDoc/HGV389/388480.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoHFA0JI">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388481.xml
+++ b/HGV_meta_EpiDoc/HGV389/388481.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoGJBHCE">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388482.xml
+++ b/HGV_meta_EpiDoc/HGV389/388482.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoFDC222">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388483.xml
+++ b/HGV_meta_EpiDoc/HGV389/388483.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoGI8E6B">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388484.xml
+++ b/HGV_meta_EpiDoc/HGV389/388484.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoCE2AI4">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388485.xml
+++ b/HGV_meta_EpiDoc/HGV389/388485.xml
@@ -39,6 +39,10 @@
                      <p xml:id="geoDCJE2">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388486.xml
+++ b/HGV_meta_EpiDoc/HGV389/388486.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoBGID6H">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388487.xml
+++ b/HGV_meta_EpiDoc/HGV389/388487.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoJGAEH7">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388488.xml
+++ b/HGV_meta_EpiDoc/HGV389/388488.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoEDIJ9A">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388489.xml
+++ b/HGV_meta_EpiDoc/HGV389/388489.xml
@@ -43,6 +43,10 @@
                      <p xml:id="geoIHJBAE">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388490.xml
+++ b/HGV_meta_EpiDoc/HGV389/388490.xml
@@ -39,6 +39,10 @@
                      <p xml:id="geoBIF1A">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388491.xml
+++ b/HGV_meta_EpiDoc/HGV389/388491.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoEGJIAB">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388492.xml
+++ b/HGV_meta_EpiDoc/HGV389/388492.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoJCFG25">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388493.xml
+++ b/HGV_meta_EpiDoc/HGV389/388493.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoBGF66D">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388494.xml
+++ b/HGV_meta_EpiDoc/HGV389/388494.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoBAF05">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388495.xml
+++ b/HGV_meta_EpiDoc/HGV389/388495.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoFAJHGI">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388496.xml
+++ b/HGV_meta_EpiDoc/HGV389/388496.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoJDF9BG">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388497.xml
+++ b/HGV_meta_EpiDoc/HGV389/388497.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoFHCBE7">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388498.xml
+++ b/HGV_meta_EpiDoc/HGV389/388498.xml
@@ -39,6 +39,10 @@
                      <p xml:id="geoDJFBH">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388499.xml
+++ b/HGV_meta_EpiDoc/HGV389/388499.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoCEI4J2">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388500.xml
+++ b/HGV_meta_EpiDoc/HGV389/388500.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoCJ99AE">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388501.xml
+++ b/HGV_meta_EpiDoc/HGV389/388501.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoGBHIEA">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388502.xml
+++ b/HGV_meta_EpiDoc/HGV389/388502.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoDI8EFA">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388503.xml
+++ b/HGV_meta_EpiDoc/HGV389/388503.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoGDHE3J">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388504.xml
+++ b/HGV_meta_EpiDoc/HGV389/388504.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoBIHG7J">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388505.xml
+++ b/HGV_meta_EpiDoc/HGV389/388505.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoDIAB18">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388506.xml
+++ b/HGV_meta_EpiDoc/HGV389/388506.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoHF5JID">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388507.xml
+++ b/HGV_meta_EpiDoc/HGV389/388507.xml
@@ -42,6 +42,10 @@
                             <p>
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                         </provenance>
                         <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV389/388508.xml
+++ b/HGV_meta_EpiDoc/HGV389/388508.xml
@@ -39,6 +39,10 @@
                      <p xml:id="geoBCJ2F">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV42/41569.xml
+++ b/HGV_meta_EpiDoc/HGV42/41569.xml
@@ -39,6 +39,10 @@
                      <p xml:id="geoIAH8FB">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV44/43092.xml
+++ b/HGV_meta_EpiDoc/HGV44/43092.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoEBI4D8">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV45/44432.xml
+++ b/HGV_meta_EpiDoc/HGV45/44432.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoIJF5CE">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV7/6220.xml
+++ b/HGV_meta_EpiDoc/HGV7/6220.xml
@@ -60,6 +60,10 @@
                      <p xml:id="geoIH8GB">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV79/78716.xml
+++ b/HGV_meta_EpiDoc/HGV79/78716.xml
@@ -43,6 +43,10 @@
                      <p>
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV8/7459.xml
+++ b/HGV_meta_EpiDoc/HGV8/7459.xml
@@ -43,6 +43,10 @@
                      <p>
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">

--- a/HGV_meta_EpiDoc/HGV8/7635.xml
+++ b/HGV_meta_EpiDoc/HGV8/7635.xml
@@ -56,6 +56,10 @@
                      <p xml:id="geoJDIHBA">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV8/7649.xml
+++ b/HGV_meta_EpiDoc/HGV8/7649.xml
@@ -49,6 +49,10 @@
                      <p xml:id="geoBEC1G">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV8/7654.xml
+++ b/HGV_meta_EpiDoc/HGV8/7654.xml
@@ -56,6 +56,10 @@
                      <p xml:id="geoBJH1F9">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV8/7666.xml
+++ b/HGV_meta_EpiDoc/HGV8/7666.xml
@@ -56,6 +56,10 @@
                      <p xml:id="geoBIA0JD">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>

--- a/HGV_meta_EpiDoc/HGV8/7667.xml
+++ b/HGV_meta_EpiDoc/HGV8/7667.xml
@@ -51,6 +51,10 @@
                      <p xml:id="geoEFCHB5">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="3" type="composed">

--- a/HGV_meta_EpiDoc/HGV8/7669.xml
+++ b/HGV_meta_EpiDoc/HGV8/7669.xml
@@ -49,6 +49,10 @@
                      <p xml:id="geoCEIDJH">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="3" type="composed">

--- a/HGV_meta_EpiDoc/HGV8/7670.xml
+++ b/HGV_meta_EpiDoc/HGV8/7670.xml
@@ -51,6 +51,10 @@
                      <p xml:id="geoFDBJEA">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="3" type="composed">

--- a/HGV_meta_EpiDoc/HGV8/7671.xml
+++ b/HGV_meta_EpiDoc/HGV8/7671.xml
@@ -51,6 +51,10 @@
                      <p xml:id="geoBHIFE5">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="3" type="composed">

--- a/HGV_meta_EpiDoc/HGV8/7672.xml
+++ b/HGV_meta_EpiDoc/HGV8/7672.xml
@@ -51,6 +51,10 @@
                      <p xml:id="geoGJBI89">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="3" type="composed">

--- a/HGV_meta_EpiDoc/HGV8/7673.xml
+++ b/HGV_meta_EpiDoc/HGV8/7673.xml
@@ -51,6 +51,10 @@
                      <p xml:id="geoG6BE1D">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="3" type="composed">

--- a/HGV_meta_EpiDoc/HGV8/7676.xml
+++ b/HGV_meta_EpiDoc/HGV8/7676.xml
@@ -51,6 +51,10 @@
                      <p xml:id="geoGI8JCA">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="3" type="composed">

--- a/HGV_meta_EpiDoc/HGV8/7677.xml
+++ b/HGV_meta_EpiDoc/HGV8/7677.xml
@@ -43,6 +43,10 @@
                      <p>
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="sent">

--- a/HGV_meta_EpiDoc/HGV8/7679.xml
+++ b/HGV_meta_EpiDoc/HGV8/7679.xml
@@ -43,6 +43,10 @@
                      <p xml:id="geoICGD3B">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="located">

--- a/HGV_meta_EpiDoc/HGV8/7680.xml
+++ b/HGV_meta_EpiDoc/HGV8/7680.xml
@@ -51,6 +51,10 @@
                      <p xml:id="geoDBHCAG">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="3" type="composed">

--- a/HGV_meta_EpiDoc/HGV874/873621.xml
+++ b/HGV_meta_EpiDoc/HGV874/873621.xml
@@ -42,6 +42,10 @@
                      <p xml:id="geoJFCEA5">
                         <placeName type="ancient"
                                    ref="https://www.trismegistos.org/place/720 https://pleiades.stoa.org/places/736943">Gurob</placeName>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                   <provenance n="2" type="composed">


### PR DESCRIPTION
There is one Gurob in TM (Geo 720), for which there are about 800 documents found or written.

Gurob is also a variation of Abu Gurab (TM Geo 2781), but has no document associated.

So it seemed fairly sure that the idno was correct and they are all from Gurob (720) in Arsinoite.