### PR TITLE
Xwalk

### DIFF
--- a/DDB_EpiDoc_XML/bgu/bgu.1/bgu.1.182.xml
+++ b/DDB_EpiDoc_XML/bgu/bgu.1/bgu.1.182.xml
@@ -14,7 +14,7 @@
             <idno type="filename">bgu.1.182</idno>
             <idno type="ddb-perseus-style">0001;1;182</idno>
             <idno type="ddb-hybrid">bgu;1;182</idno>
-            <idno type="filename">14869a 14869b</idno>
+            <idno type="HGV">14869a 14869b</idno>
             <idno type="TM">14869 14869</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>

--- a/DDB_EpiDoc_XML/p.amh/p.amh.2/p.amh.2.128-r.xml
+++ b/DDB_EpiDoc_XML/p.amh/p.amh.2/p.amh.2.128-r.xml
@@ -14,7 +14,7 @@
             <idno type="filename">p.amh.2.128-r</idno>
             <idno type="ddb-perseus-style">0057;2;128,r</idno>
             <idno type="ddb-hybrid">p.amh;2;128,r</idno>
-            <idno type="filename">17079 17055</idno>
+            <idno type="HGV">17079 17055</idno>
             <idno type="TM">17079 17055</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>

--- a/DDB_EpiDoc_XML/p.oxy/p.oxy.2/p.oxy.2.357.xml
+++ b/DDB_EpiDoc_XML/p.oxy/p.oxy.2/p.oxy.2.357.xml
@@ -14,10 +14,8 @@
             <idno type="filename">p.oxy.2.357</idno>
             <idno type="ddb-perseus-style">0181;2;357</idno>
             <idno type="ddb-hybrid">p.oxy;2;357</idno>
-            <idno type="HGV">26162</idno>
-            <idno type="HGV">26163</idno>
-            <idno type="TM">26162</idno>
-            <idno type="TM">26163</idno>
+            <idno type="HGV">26162 26163</idno>
+            <idno type="TM">26162 26163</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/DDB_EpiDoc_XML/p.tebt/p.tebt.1/p.tebt.1.72A.xml
+++ b/DDB_EpiDoc_XML/p.tebt/p.tebt.1/p.tebt.1.72A.xml
@@ -14,7 +14,7 @@
             <idno type="filename">p.tebt.1.72A</idno>
             <idno type="ddb-perseus-style">0206;1;72A</idno>
             <idno type="ddb-hybrid">p.tebt;1;72A</idno>
-            <idno type="filename">3708b</idno>
+            <idno type="HGV">3708b</idno>
             <idno type="TM">3708</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>


### PR DESCRIPTION
place multiple HGV and TM numbers in one TEI:idno tag of the respective type separated by a blank space