### PR TITLE
Pylon 5 Xwalk

### DIFF
--- a/Biblio/97/96860.xml
+++ b/Biblio/97/96860.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96860">
+      <title level="a" type="main">An Inscription from the Reign of Probus: Reflections on the Port of Berenike in the Third Century CE</title>
+      <author n="1">
+         <forename>Rodney</forename>
+         <surname>Ast</surname>
+      </author>
+      <date>2024</date>
+      <biblScope type="issue">5</biblScope>
+      <biblScope type="article" n="6">Article 6</biblScope>
+      <ptr target="https://doi.org/10.48631/pylon.2024.5.105730"/>
+      <relatedItem type="appearsIn" n="1">
+         <bibl>
+            <ptr target="https://papyri.info/biblio/2374"/>
+         </bibl>
+      </relatedItem>
+      <idno type="pi">96860</idno>
+   </bibl>
+</TEI>

--- a/Biblio/97/96861.xml
+++ b/Biblio/97/96861.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96861">
+      <title level="a" type="main">Edition of the Homeric Fragment P.Oxy. 4 758 descr. (Ε 583‒596)</title>
+      <author n="1">
+         <forename>Andrea</forename>
+         <surname>Bernini</surname>
+      </author>
+      <date>2024</date>
+      <biblScope type="issue">5</biblScope>
+      <biblScope type="article" n="4">Article 4</biblScope>
+      <ptr target="https://doi.org/10.48631/pylon.2024.5.105727"/>
+      <relatedItem type="appearsIn" n="1">
+         <bibl>
+            <ptr target="https://papyri.info/biblio/2374"/>
+         </bibl>
+      </relatedItem>
+      <idno type="pi">96861</idno>
+      <relatedItem type="mentions" n="1">
+         <bibl>
+            <title level="s" type="short">P.Oxy</title>
+            <biblScope type="vol">4</biblScope>
+            <biblScope type="num">758</biblScope>
+            <idno type="dclp">p.oxy;4;758</idno>
+         </bibl>
+      </relatedItem>
+   </bibl>
+</TEI>

--- a/Biblio/97/96862.xml
+++ b/Biblio/97/96862.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96862">
+      <title level="a" type="main">Another Receipt for the Poll Tax from Elephantine</title>
+      <author n="1">
+         <forename>Lincoln H.</forename>
+         <surname>Blumell</surname>
+      </author>
+      <date>2024</date>
+      <biblScope type="issue">5</biblScope>
+      <biblScope type="article" n="5">Article 5</biblScope>
+      <ptr target="https://doi.org/10.48631/pylon.2024.5.105729"/>
+      <relatedItem type="appearsIn" n="1">
+         <bibl>
+            <ptr target="https://papyri.info/biblio/2374"/>
+         </bibl>
+      </relatedItem>
+      <idno type="pi">96862</idno>
+      <relatedItem type="mentions" n="1">
+         <bibl>
+            <title level="s" type="short">Pylon</title>
+            <biblScope type="vol">5</biblScope>
+            <biblScope type="num">5</biblScope>
+            <idno type="ddb">pylon;5;5</idno>
+            <idno type="tm">998499</idno>
+            <idno type="invNo">Inv. no. 451</idno>
+         </bibl>
+      </relatedItem>
+   </bibl>
+</TEI>

--- a/Biblio/97/96863.xml
+++ b/Biblio/97/96863.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96863">
+      <title level="a" type="main">Notes on Papyri from Roman Egypt II</title>
+      <author n="1">
+         <forename>W. Graham</forename>
+         <surname>Claytor</surname>
+      </author>
+      <date>2024</date>
+      <biblScope type="issue">5</biblScope>
+      <biblScope type="article" n="10">Article 10</biblScope>
+      <ptr target="https://doi.org/10.48631/pylon.2024.5.105735"/>
+      <relatedItem type="appearsIn" n="1">
+         <bibl>
+            <ptr target="https://papyri.info/biblio/2374"/>
+         </bibl>
+      </relatedItem>
+      <idno type="pi">96863</idno>
+   </bibl>
+</TEI>

--- a/Biblio/97/96864.xml
+++ b/Biblio/97/96864.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <bibl type="article" subtype="journal" xml:lang="de" xml:id="b96864">
+      <title level="a" type="main">Wilckens Briefwechsel mit Eduard Schwartz zur Edition von P.Würzb. 1</title>
+      <author n="1">
+         <forename>Holger</forename>
+         <surname>Essler</surname>
+      </author>
+      <date>2024</date>
+      <biblScope type="issue">5</biblScope>
+      <biblScope type="article" n="3">Article 3</biblScope>
+      <ptr target="https://doi.org/10.48631/pylon.2024.5.105725"/>
+      <relatedItem type="appearsIn" n="1">
+         <bibl>
+            <ptr target="https://papyri.info/biblio/2374"/>
+         </bibl>
+      </relatedItem>
+      <idno type="pi">96864</idno>
+   </bibl>
+</TEI>

--- a/Biblio/97/96865.xml
+++ b/Biblio/97/96865.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96865">
+      <title level="a" type="main">P.Ross.Georg. 2 13 and Other Corrections to Published Papyri</title>
+      <author n="1">
+         <forename>Lavinia</forename>
+         <surname>Ferretti</surname>
+      </author>
+      <date>2024</date>
+      <biblScope type="issue">5</biblScope>
+      <biblScope type="article" n="9">Article 9</biblScope>
+      <ptr target="https://doi.org/10.48631/pylon.2024.5.105734"/>
+      <relatedItem type="appearsIn" n="1">
+         <bibl>
+            <ptr target="https://papyri.info/biblio/2374"/>
+         </bibl>
+      </relatedItem>
+      <idno type="pi">96865</idno>
+   </bibl>
+</TEI>

--- a/Biblio/97/96866.xml
+++ b/Biblio/97/96866.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96866">
+      <title level="a" type="main">Zenon Papyri and Others: Letters of C.C. Edgar to H.I. Bell, 1919–1935 </title>
+      <author n="1">
+         <forename>Nikolaos</forename>
+         <surname>Gonis</surname>
+      </author>
+      <author n="2">
+         <forename>Anna</forename>
+         <surname>Szajbély</surname>
+      </author>
+      <date>2024</date>
+      <biblScope type="issue">5</biblScope>
+      <biblScope type="article" n="8">Article 8</biblScope>
+      <ptr target="https://doi.org/10.48631/pylon.2024.5.105733"/>
+      <relatedItem type="appearsIn" n="1">
+         <bibl>
+            <ptr target="https://papyri.info/biblio/2374"/>
+         </bibl>
+      </relatedItem>
+      <idno type="pi">96866</idno>
+   </bibl>
+</TEI>

--- a/Biblio/97/96867.xml
+++ b/Biblio/97/96867.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96867">
+      <title level="a" type="main">School Tablet with Divisions and Demonstrations in the Chester Beatty Library</title>
+      <author n="1">
+         <forename>Julia</forename>
+         <surname>Lougovaya</surname>
+      </author>
+      <date>2024</date>
+      <biblScope type="issue">5</biblScope>
+      <biblScope type="article" n="1">Article 1</biblScope>
+      <ptr target="https://doi.org/10.48631/pylon.2024.5.105710"/>
+      <relatedItem type="appearsIn" n="1">
+         <bibl>
+            <ptr target="https://papyri.info/biblio/2374"/>
+         </bibl>
+      </relatedItem>
+      <idno type="pi">96867</idno>
+      <relatedItem type="mentions" n="1">
+         <bibl>
+            <title level="s" type="short">Pylon</title>
+            <biblScope type="vol">5</biblScope>
+            <biblScope type="num">1</biblScope>
+            <idno type="dclp">pylon;5;1</idno>
+         </bibl>
+      </relatedItem>
+   </bibl>
+</TEI>

--- a/Biblio/97/96868.xml
+++ b/Biblio/97/96868.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96868">
+      <title level="a" type="main">Selling an Inheritance for an Under-age Owner in 7th Century Aphrodite </title>
+      <author n="1">
+         <forename>Maria</forename>
+         <surname>Nowak</surname>
+      </author>
+      <author n="2">
+         <forename>Brian</forename>
+         <surname>McGing</surname>
+      </author>
+      <date>2024</date>
+      <biblScope type="issue">5</biblScope>
+      <biblScope type="article" n="2">Article 2</biblScope>
+      <ptr target="https://doi.org/10.48631/pylon.2024.5.105716"/>
+      <relatedItem type="appearsIn" n="1">
+         <bibl>
+            <ptr target="https://papyri.info/biblio/2374"/>
+         </bibl>
+      </relatedItem>
+      <idno type="pi">96868</idno>
+   </bibl>
+</TEI>

--- a/Biblio/97/96869.xml
+++ b/Biblio/97/96869.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <bibl type="article" subtype="journal" xml:lang="de" xml:id="b96869">
+      <title level="a" type="main">Zwei Ilias-Papyri aus Yale</title>
+      <author n="1">
+         <forename>Moritz</forename>
+         <surname>Schwemer</surname>
+      </author>
+      <author n="2">
+         <forename>Johanna</forename>
+         <surname>Strauss</surname>
+      </author>
+      <date>2024</date>
+      <biblScope type="issue">5</biblScope>
+      <biblScope type="article" n="7">Article 7</biblScope>
+      <ptr target="https://doi.org/10.48631/pylon.2024.5.105732"/>
+      <relatedItem type="appearsIn" n="1">
+         <bibl>
+            <ptr target="https://papyri.info/biblio/2374"/>
+         </bibl>
+      </relatedItem>
+      <idno type="pi">96869</idno>
+      <relatedItem type="mentions" n="1">
+         <bibl>
+            <title level="s" type="short">P.Oxy</title>
+            <biblScope type="vol">6</biblScope>
+            <biblScope type="num">952</biblScope>
+            <idno type="dclp">p.oxy;6;952</idno>
+         </bibl>
+      </relatedItem>
+      <relatedItem type="mentions" n="2">
+         <bibl>
+            <title level="s" type="short">P.Yale</title>
+            <biblScope type="vol">1</biblScope>
+            <biblScope type="num">12</biblScope>
+            <idno type="dclp">p.yale;1;12</idno>
+         </bibl>
+      </relatedItem>
+   </bibl>
+</TEI>

--- a/DCLP/61/60370.xml
+++ b/DCLP/61/60370.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.23/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="m60370" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="m60370">
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>P. Yale. 1 12</title>
+            <title>Fragmente eines Homer-Papyrus, Il. 22.254–299, 350–355 und 358–365</title>
          </titleStmt>
          <publicationStmt>
             <authority>Digital Corpus of Literary Papyri</authority>
@@ -40,7 +40,7 @@
                <history>
                   <origin>
                      <origPlace>Found: Euhemeria (Arsinoites, Egypt); written: Euhemeria (Arsinoites, Egypt)</origPlace>
-                     <origDate notBefore="0001" notAfter="0199">1 - 199</origDate>
+                     <origDate notBefore="0001" notAfter="0099">1 - 99</origDate>
                   </origin>
                   <provenance type="found">
                      <p>
@@ -62,8 +62,8 @@
       </fileDesc>
       <encodingDesc>
          <p>
-                This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+            This file encoded to comply with EpiDoc Guidelines and Schema version 8
+            <ref>http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -73,7 +73,6 @@
                <term>epic</term>
                <term type="culture">literature</term>
                <term type="religion">classical</term>
-               <term type="overview">Homerus; Ilias 022.254-290, 328, 350-354, 358-365</term>
             </keywords>
          </textClass>
          <langUsage>
@@ -82,31 +81,132 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
+         <change when="2024-07-11-05:00" who="DCLP">Xwalk from Pylon
+                            </change>
          <change when="2014-12-10" who="DCLP">Crosswalked to EpiDoc XML</change>
       </revisionDesc>
    </teiHeader>
    <text>
       <body>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
+             <div n="1" subtype="part" type="textpart">
+<div n="i" subtype="column" type="textpart"><ab>
+<lb n="1"/><supplied reason="lost">ἀλλ’ ἄγε δεῦρο θεοὺς ἐπιδώμεθα· τοὶ γὰρ</supplied> <unclear>ἄ</unclear>ριστοι
+<lb n="2"/><supplied reason="lost">μάρτυροι ἔσσονται καὶ ἐπίσκοπ</supplied>οι ἁρμονιά<supplied reason="lost">ων</supplied>
+<lb n="3"/><supplied reason="lost"><unclear>ο</unclear>ὐ γὰρ ἐγὼ σ’ ἔκπαγλον ἀεικίω, αἴ κε</supplied><unclear>ν</unclear> ἐμοὶ <unclear>Ζε</unclear>ύ<unclear>ς</unclear>
+<lb n="4"/><supplied reason="lost">δώηι καμμονίην, σὴν δὲ ψυχὴ</supplied><unclear>ν</unclear> ἀφέλωμαι·
+<lb n="5"/><supplied reason="lost">ἀλλ’ ἐπεὶ ἄρ κέ σε συλήσω</supplied> <unclear>κ</unclear>λυ<supplied reason="lost">τὰ τεύχε’,</supplied> <unclear>Ἀχ</unclear>ι<unclear>λλεῦ</unclear>,
+<lb n="6"/><supplied reason="lost">νεκρὸν Ἀχαιοῖσιν δώσω</supplied> πά<supplied reason="lost">λιν· ὣ</supplied>ς δὲ σὺ ῥέζ<supplied reason="lost">ειν.</supplied>
+<lb n="7"/><supplied reason="lost">τὸν δ’ ἄρ’ ὑπόδρα ἰδὼν προ</supplied>σέφ<supplied reason="lost">η πό</supplied>δας ὠκὺς Ἀ<unclear>χι</unclear><supplied reason="lost">λλεύς·</supplied>
+<lb n="8"/><supplied reason="lost">Ἕκτορ μή μοι, ἄλαστε, συ</supplied>νημ<supplied reason="lost">οσύ</supplied>νας ἀ<unclear>γ</unclear>ό<unclear>ρε</unclear><supplied reason="lost">υε·</supplied>
+<lb n="9"/><supplied reason="lost">ὡς οὐκ ἔστι λέουσι καὶ ἀ</supplied>νδρ<unclear>ά</unclear><supplied reason="lost">σιν</supplied> ὅρκια <unclear>π</unclear><supplied reason="lost">ιστά,</supplied>
+<lb n="10,minf"/><supplied reason="lost">οὐδὲ λύκοι τε κα</supplied>ὶ ἄρνες ὁ<unclear>μό</unclear>φρον<supplied reason="lost">α θυμὸν ἔχουσιν,</supplied>
+<lb n="11"/><supplied reason="lost">ἀλλὰ κακὰ φρονέου</supplied><unclear>σ</unclear>ι διαμπ<supplied reason="lost">ερὲ</supplied><unclear>ς</unclear> ἀλλ<unclear>ήλ</unclear>ο<supplied reason="lost">ισιν,</supplied>
+<lb n="12"/><supplied reason="lost">ὣς οὐκ ἔστ’ ἐμὲ καὶ σ</supplied><unclear>ὲ</unclear> φ<unclear>ι</unclear>λήμε<supplied reason="lost">ναι, ο</supplied>ὐδέ <unclear>τ</unclear>ι ν<supplied reason="lost">ῶϊν</supplied>
+<lb n="13"/><supplied reason="lost">ὅρκια ἔσσονται, πρί</supplied><unclear>ν</unclear> <unclear>ἠ</unclear>’ <unclear>ἕτε</unclear><supplied reason="lost">ρόν γ</supplied><unclear>ε</unclear> πεσ<unclear>ό</unclear><supplied reason="lost">ντα</supplied>
+<lb n="14"/><supplied reason="lost">αἵματος ἆσαι Ἄρηα τ</supplied>αλαύρ<unclear>ι</unclear><supplied reason="lost">νον</supplied> πολ<supplied reason="lost">εμ</supplied><unclear>ι</unclear><supplied reason="lost">στήν.</supplied>
+<lb n="15"/><supplied reason="lost">παντοίης ἀρετῆς μι</supplied>μνήσκ<supplied reason="lost">εο· νῦ</supplied>ν σε μάλ<unclear>α</unclear> <supplied reason="lost">χρή</supplied>
+<lb n="16"/><supplied reason="lost">αἰχμητήν τ’ ἔμεναι</supplied> καὶ θαρ<supplied reason="lost">σαλέο</supplied>ν πολε<unclear>μ</unclear><supplied reason="lost">ιστήν.</supplied>
+<lb n="17"/><supplied reason="lost">οὔ τοι ἔτ’ ἔσθ’ ὑπάλυξ</supplied>ις, ἄφαρ δ<supplied reason="lost">έ σε</supplied> Παλλὰ<unclear>ς</unclear> <supplied reason="lost">Ἀθήνη</supplied>
+<lb n="18"/><supplied reason="lost">ἔγχει ἐμῶι δαμάαι.</supplied> <unclear>ν</unclear>ῦν δ’ ἀθ<supplied reason="lost">ρόα π</supplied>άντ’ ἀπ<supplied reason="lost">οτίσεις</supplied>
+<lb n="19"/><supplied reason="lost">κήδε’ ἐμῶν ἑτάρω</supplied>ν οὓ<supplied reason="lost">ς ἔκταν</supplied>ες ἔγχε<supplied reason="lost">ϊ θύμων.</supplied>
+<lb n="20"/><supplied reason="lost">ἦ ῥα, καὶ ἀμπεπελὼν</supplied> πρ<unclear>ο</unclear><supplied reason="lost">ΐει δολιχό</supplied>σκιον ἔ<supplied reason="lost">γχος·</supplied>
+<lb n="21"/><supplied reason="lost">καὶ τὸ μὲν ἄντα ἰδ</supplied>ὼν ἠ<supplied reason="lost">λεύατο φ</supplied><unclear>α</unclear>ίδιμο<unclear>ς</unclear> <supplied reason="lost">Ἕκτωρ·</supplied>
+<lb n="22"/><supplied reason="lost">ἕζετο γὰρ προϊδών,</supplied> τὸ δ’ <supplied reason="lost">ὑπέρπτατο</supplied> χάλκ<supplied reason="lost">εο</supplied>ν <supplied reason="lost">ἔγχος,</supplied>
+<lb n="23"/><supplied reason="lost">ἐν γαίηι δ’ ἐπάγη· ἀνὰ</supplied> <unclear>δ</unclear>’ ἥ<unclear>ρ</unclear><supplied reason="lost">πασε Παλ</supplied>λὰς Ἀθ<supplied reason="lost">ή</supplied>νη,
+<lb n="24"/><supplied reason="lost">ἂψ δ’ Ἀχιλῆϊ δίδου, λάθ</supplied>ε δ<unclear>’</unclear> <supplied reason="lost">Ἕκτορα ποι</supplied>μέ<unclear>ν</unclear><supplied reason="lost">α λ</supplied>αῶν.
+<lb n="25"/><supplied reason="lost">Ἕκτωρ δὲ προσέειπ</supplied>εν ἀμ<supplied reason="lost">ύμονα Π</supplied>ηλε<unclear>ΐων</unclear>α·
+<lb n="26"/><supplied reason="lost">ἤμβροτες, οὐδ’ ἄρα</supplied> πώ τι θε<unclear>ο</unclear><supplied reason="lost">ῖς ἐπιείκ</supplied>ελ’ Ἀχ<unclear>ιλ</unclear><supplied reason="lost">λ</supplied>εῦ
+<lb n="27"/><supplied reason="lost">ἐκ Διὸς ἠείδης τὸν ἐ</supplied>μὸν μόρ<supplied reason="lost">ον, ἦ τοι</supplied> <unclear>ἔ</unclear>φης <supplied reason="lost">γε·</supplied>
+<lb n="28"/><supplied reason="lost">ἀλλά τις ἀρτιεπὴς κα</supplied><unclear>ὶ</unclear> ἐπίκλο<unclear>π</unclear><supplied reason="lost">ος ἔπλεο</supplied> μύθ<unclear>ω</unclear><supplied reason="lost">ν,</supplied>
+<lb n="29"/><supplied reason="lost">ἄφρά σ’ ὑποδείσας μ</supplied>ένεος ἀ<supplied reason="lost">λκῆς τε</supplied> λάθ<supplied reason="lost">ωμαι.</supplied>
+<lb n="30"/><supplied reason="lost">οὐ μέν μοι φεύγοντ</supplied>ι μεταφ<supplied reason="lost">ρένωι ἐν δόρυ πήξεις,</supplied>
+<lb n="31"/><supplied reason="lost">ἀλλ’ ἰθὺς μεμαῶτι δ</supplied>ιὰ <unclear>σ</unclear>τήθ<supplied reason="lost">εσφιν ἔλασσον</supplied>
+<lb n="32"/><supplied reason="lost">εἴ τοι ἔδωκε θεός· ν</supplied><unclear>ῦν</unclear> αὖτ’ ἐμ<supplied reason="lost">ὸν ἔγχος ἄλευαι</supplied>
+<lb n="33"/><supplied reason="lost">χάλκεον· ὡς δή μιν σ</supplied>ῶι ἐν χ<supplied reason="lost">ροῒ πᾶν κομίσαιο.</supplied>
+<lb n="34"/><supplied reason="lost">καί κεν ἐλαφρότερ</supplied>ος πόλεμ<supplied reason="lost">ος Τρώεσσι γένοιτο</supplied>
+<lb n="35"/><supplied reason="lost">σεῖο καταφθιμέ</supplied>ν<supplied reason="lost">ο</supplied>ιο σὺ γά<supplied reason="lost">ρ σφισι πῆμα μέγιστον.</supplied>
+<lb n="36"/><supplied reason="lost">ἦ ῥα, καὶ ἀμπεπαλὼ</supplied>ν προ<hi rend="diaeresis">ΐ</hi>ει δ<supplied reason="lost">ολιχόσκιον ἔγχοσς,</supplied>
+<lb n="37"/><supplied reason="lost">καὶ βάλε Πηλεΐδ</supplied>αο μέσον σ<supplied reason="lost">άκος οὐδ’ ἀφάμαρτε·</supplied>
+</ab></div>
+<div n="ii" subtype="column" type="textpart"><ab>
+<lb n="38"/><supplied reason="lost">τῆλε δ’ ἀπεπλάγχ</supplied>θ<unclear>η</unclear> <supplied reason="lost">σάκ</supplied><unclear>εος</unclear> <unclear>δόρ</unclear>υ· χώσα<supplied reason="lost">το δ’ Ἕκτωρ</supplied>
+<lb n="39"/><supplied reason="lost">ὅττί ῥά οἱ βέλος ὠκὺ ἐτ</supplied><unclear>ώσ</unclear>ιον ἔκφυ<unclear>γ</unclear><supplied reason="lost">ε χειρός,</supplied>
+<lb n="40"/><supplied reason="lost">στῆ δὲ κατηφήσας, οὐδ’ ἄ</supplied>λλ’ <unclear>ἔχ</unclear><supplied reason="lost">ε</supplied> μείλ<supplied reason="lost">ινον ἔγχος.</supplied>
+<lb n="41"/><supplied reason="lost">Δηΐφοβον δ’ ἐκάλει λε</supplied>υκάσπ<supplied reason="lost">ιδα μακρὸν ἀΰσας·</supplied>
+<lb n="42"/><supplied reason="lost">ἤιτεέ μιν δόρυ μακρόν·</supplied> ὃ δ’ οὔ τ<supplied reason="lost">ί οἱ ἐγγύθεν ἦεν.</supplied>
+<lb n="43"/><supplied reason="lost">Ἕκτωρ δ’ ἔγνω ἧισιν ἐνὶ</supplied> φρεσὶ <supplied reason="lost">φώνησέν τε·</supplied>
+<lb n="44"/><supplied reason="lost">ὢ πόποι ἦ Μάλα δή με θεο</supplied>ὶ θάνα<supplied reason="lost">τόνδε κάλεσσαν·</supplied>
+<lb n="45"/><supplied reason="lost">Δηΐφοβον γὰρ ἔγωγ’ ἐφά</supplied>μην <unclear>ἥ</unclear><supplied reason="lost">ρωα παρεῖναι·</supplied>
+<lb n="46"/><gap reason="illegible" quantity="1" unit="line"><desc>vestiges</desc></gap>
+<lb n="46"/><gap reason="lost" extent="unknown" unit="line"/>
+</ab></div>
+<div n="iii" subtype="column" type="textpart"><ab>
+<lb n="47"/><gap reason="lost" extent="unknown" unit="line"/>
+<lb n="47"/><supplied reason="lost">στήσωσ’ ἐνθάδ’ ἄγοντες,</supplied> ὑ<unclear>π</unclear><supplied reason="lost">όσχωνται δὲ καὶ ἄλλα,</supplied>
+<lb n="48"/><supplied reason="lost">οὐδ’ εἴ κέν σ’ αὐτὸν χρυσ</supplied>ῶι ἐ<unclear>ρύ</unclear>σασθ<supplied reason="lost">αι ἀνώγοι</supplied>
+<lb n="49"/><supplied reason="lost">Δαρδανίδης Πρίαμος· ο</supplied>ὐδ’ ὧς σέ γε π<supplied reason="lost">ότνια μήτηρ</supplied>
+<lb n="50"/><supplied reason="lost">ἐνθεμένη λεξέεσσι γο</supplied><unclear>ή</unclear>σεται ὃν <unclear>τ</unclear><supplied reason="lost">έκεν αὐτή,</supplied>
+<lb n="51"/><supplied reason="lost">ἀλλὰ κύνες τε καὶ οἰω</supplied>νο<unclear>ὶ</unclear> κατὰ <supplied reason="lost">πάντα δάσονται.</supplied>
+<lb n="52"/><gap reason="illegible" quantity="1" unit="line"><desc>vestiges</desc></gap>
+<lb n="52"/><gap reason="lost" quantity="2" unit="line" precision="low"/>
+<lb n="55"/><supplied reason="lost">φράζεο νῦ</supplied><unclear>ν</unclear>, <unclear>μ</unclear><supplied reason="lost">ή τοί τι θεῶν μήνιμα γένωμαι</supplied>
+<lb n="56"/><supplied reason="lost">ἤματι τῶι ὅτ</supplied>ε κ<unclear>έ</unclear><supplied reason="lost">ν σε Πάρις</supplied> <unclear>καὶ</unclear> <supplied reason="lost">Φοῖβος Ἀπόλλων</supplied>
+<lb n="57"/><supplied reason="lost">ἐσθλὸν ἐό</supplied><unclear>ν</unclear>τ’ ὀλέ<supplied reason="lost">σωσιν ἐν</supplied>ὶ Σκ<unclear>α</unclear><supplied reason="lost">ιῆισι πύληισιν.</supplied>
+<lb n="58"/><supplied reason="lost">ὣς ἄρα μιν ε</supplied><unclear>ἰ</unclear>πόντα  <supplied reason="lost">τέλ</supplied>ος θανά<unclear>τ</unclear><supplied reason="lost">οιο κάλυψε,</supplied>
+<lb n="59"/><supplied reason="lost">ψυχὴ δ’ ἐκ ῥε</supplied>θέων π<supplied reason="lost">τ</supplied>α<unclear>μ</unclear>ένη Ἄ<unclear>ϊ</unclear><supplied reason="lost">δος δὲ βεβήκει</supplied>
+<lb n="60"/><supplied reason="lost">τὸν καὶ τεθν</supplied>ειῶ<supplied reason="lost">τ</supplied>α π<supplied reason="lost">ρ</supplied>οσηύ<supplied reason="lost">δ</supplied>α <supplied reason="lost">δῖος Ἀχιλλεύς·</supplied>
+<lb n="61"/><supplied reason="lost">τέθναθι· κῆ</supplied><unclear>ρ</unclear>α δ’ <supplied reason="lost">ἐ</supplied><unclear>γ</unclear>ὼ τ<supplied reason="lost">ότε δέξομαι ὁππότε κεν δή</supplied>
+</ab></div>
+</div>
+<div n="2" subtype="part" type="textpart"><ab>
+<lb n="62"/>μ<gap reason="lost" extent="unknown" unit="character"/>
+<lb n="63"/><gap reason="illegible" quantity="2" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
+<lb n="64"/><gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
+<lb n="65"/><gap reason="lost" extent="unknown" unit="character"/> 
+<lb n="66"/><gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
+<lb n="67"/>ρο<gap reason="lost" extent="unknown" unit="character"/>
+<lb n="68"/>σι<gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
+<lb n="69"/><gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
+<lb n="69"/><gap reason="lost" extent="unknown" unit="line"/>
+</ab></div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl type="publication" subtype="principal">
+               <bibl type="reference" subtype="previous">
                   <ptr target="http://papyri.info/biblio/7096"/>
-                  <biblScope unit="number">12</biblScope>
-                  <!--ignore - start, i.e. SoSOL users may not edit this-->
                   <title level="s" type="abbreviated">P. Yale</title>
                   <biblScope unit="volume">1</biblScope>
-                  <!--ignore - stop-->
+                  <biblScope unit="number">12</biblScope>
+                  <biblScope unit="generic">descr.</biblScope>
+               </bibl>
+               <bibl type="reference" subtype="previous">
+                  <ptr target="http://papyri.info/biblio/95143"/>
+                  <title level="s" type="abbreviated">P. Fay</title>
+                  <biblScope unit="number">211</biblScope>
+                  <biblScope unit="generic">descr.</biblScope>
                </bibl>
                <bibl type="reference" subtype="catalogue">
-                  <!-- ignore - start, i.e. SoSOL users may not edit this -->
                   <title level="m" type="main">Studies in the Text and Transmission of the Iliad.</title>
                   <author>
                      <surname>West</surname>
                      <forename>Martin L.</forename>
                   </author>
-                  <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/16711"/>
                   <biblScope unit="number">255</biblScope>
+               </bibl>
+               <bibl type="publication" subtype="principal">
+                  <ptr target="https://papyri.info/biblio/96869"/>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <listBibl>
+               <bibl type="online">
+                  <ptr target="https://doi.org/10.48631/pylon.2024.5.105732"/>
+               </bibl>
+               <bibl type="printed">Liège</bibl>
+               <bibl type="online">
+                  <ptr target="http://hdl.handle.net/10079/digcoll/2756786"/>
                </bibl>
             </listBibl>
          </div>
@@ -117,15 +217,17 @@
                   <title type="main"
                          level="m"
                          ref="http://www.trismegistos.org/authorwork/511">Ilias</title>
-               </bibl>
-            </listBibl>
-         </div>
-         <div type="edition" xml:space="preserve" xml:lang="grc"/>
-         <div type="bibliography" subtype="illustrations">
-            <listBibl>
-               <bibl type="printed">Liège</bibl>
-               <bibl type="online">
-                  <ptr target="http://hdl.handle.net/10079/digcoll/2756786"/>
+                  <biblScope n="1" unit="book">22</biblScope>
+                  <biblScope n="2" unit="line" from="254" to="290">254-290</biblScope>
+                  <biblScope n="3" unit="generic">and</biblScope>
+                  <biblScope n="4" unit="book">22</biblScope>
+                  <biblScope n="5" unit="line">328</biblScope>
+                  <biblScope n="6" unit="generic">and</biblScope>
+                  <biblScope n="7" unit="book">22</biblScope>
+                  <biblScope n="8" unit="line" from="350" to="354">350-354</biblScope>
+                  <biblScope n="9" unit="generic">and</biblScope>
+                  <biblScope n="10" unit="book">22</biblScope>
+                  <biblScope n="11" unit="line" from="358" to="365">358-365</biblScope>
                </bibl>
             </listBibl>
          </div>

--- a/DCLP/61/60740.xml
+++ b/DCLP/61/60740.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.23/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="m60740" xml:lang="en">
-  <teiHeader>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="m60740">
+   <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Homer, Iliad 5.583-596</title>
+            <title>An Oxyrhynchite Fragment of Iliad 5</title>
          </titleStmt>
          <publicationStmt>
             <authority>Digital Corpus of Literary Papyri</authority>
@@ -15,16 +15,14 @@
             <idno type="dclp-hybrid">p.oxy;4;758</idno>
             <idno type="MP3">00757.000</idno>
             <availability>
-               <p>
-            © Digital Corpus of Literary Papyri. This work is licensed under a
-            <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>
-            .
-          </p>
+               <p>© Digital Corpus of Literary Papyri. This work is licensed under a
+                            <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
+                  <repository/>
                   <idno type="invNo">New Haven, Yale University, Beinecke Library P. CtYBR 69</idno>
                </msIdentifier>
                <physDesc>
@@ -93,8 +91,8 @@
       </fileDesc>
       <encodingDesc>
          <p>
-        This file encoded to comply with EpiDoc Guidelines and Schema version 8
-        <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+                    This file encoded to comply with EpiDoc Guidelines and Schema version 8
+                    <ref>http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -112,6 +110,8 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
+         <change when="2024-07-11-05:00" who="DCLP">Xwalk from Pylon
+                            </change>
          <change when="2024-05-21T11:16:45-04:00"
                  who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
          <change when="2024-05-21T11:09:31-04:00"
@@ -120,15 +120,31 @@
                  who="http://papyri.info/editor/users/james.cowey">Submit - Updated the metadata</change>
          <change when="2014-12-10" who="DCLP">Crosswalked to EpiDoc XML</change>
       </revisionDesc>
-  </teiHeader>
-  <text>
+   </teiHeader>
+   <text>
       <body>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
+<ab>
+<lb n="1"/>ἡν<supplied reason="lost">ί</supplied>α λεύκ’ <app type="alternative"><lem><app type="editorial"><lem>ἐλέ<unclear>φ</unclear><supplied reason="lost">αν</supplied>τα</lem><rdg resp="mss">ἐλέ<unclear>φ</unclear><supplied reason="lost">αν</supplied>τι</rdg></app></lem><rdg>ἐλε<unclear>φ</unclear><supplied reason="lost">αν</supplied>τά</rdg></app> χαμαὶ πέσον ἐν κον<supplied reason="lost">ίηισιν.</supplied>
+<lb n="2"/>Ἀ<unclear>ν</unclear>τίλοχος δ’<hi rend="acute">ἄ</hi>ρ’<g type="apostrophe"/> ἐπ<unclear>αΐ</unclear>ξας ξ<unclear>ί</unclear>φει ἤλασε κόρση<supplied reason="lost">ν·</supplied>
+<lb n="3"/>αὐ<unclear>τ</unclear>ὰρ<hi rend="asper"><hi rend="acute">ὅ</hi></hi> γ’<g type="apostrophe"/>  ἀσθμαίνων εὐεργέος ἔκπεσε <unclear>δ</unclear>ίφρου
+<lb n="4"/>κύ<unclear>μ</unclear>βαχος ἐν κονίηισιν <g type="high-punctus"/> ἐπὶ βρε<unclear>χ</unclear>μόν <choice><reg>τε</reg><orig>δε</orig></choice> καὶ ὤμ<supplied reason="lost">ους.</supplied>
+<lb n="5"/><supplied reason="lost">δη</supplied>θὰ μάλ’ εἱστήκε<unclear>ι</unclear>, <g type="high-punctus"/> τύχε γ<hi rend="acute">ά</hi>ρ ῥ’<g type="apostrophe"/> ἀμάθοιο βαθ<unclear>είη</unclear><supplied reason="lost">ς,</supplied>
+<lb n="6"/><supplied reason="lost">ὄφ</supplied><unclear>ρ</unclear>’<g type="apostrophe"/> ἵππω<surplus>ν</surplus> πλήξα<unclear>ν</unclear>τε χαμαὶ <app type="editorial"><lem>πέσον</lem><rdg resp="mss">βάλον</rdg></app> <unclear>ἐν</unclear> κο<unclear>νί</unclear><supplied reason="lost">ηισιν.</supplied>
+<lb n="7"/><supplied reason="lost">το</supplied><hi rend="asper">ὺ</hi>ς<hi rend="asper">ἵ</hi>μασ’ Ἀ<unclear>ν</unclear>τίλοχ<unclear>ο</unclear>ς, <g type="high-punctus"/> μετὰ δὲ στρατ<unclear>ὸ</unclear>ν ἤλ<supplied reason="lost">ασ’ Ἀχαιῶν.</supplied>
+<lb n="8"/><supplied reason="lost">το</supplied><unclear>ὺ</unclear>ς δ’ Ἕκτωρ ἐνόησ<unclear>ε</unclear> κατὰ στίχας, <g type="high-punctus"/> ὦρτο δ’ ἐπ’ α<supplied reason="lost">ὐτούς</supplied>
+<lb n="9"/><supplied reason="lost">κε</supplied>κληγώς· <g type="high-punctus"/> <hi rend="asper">ἅ</hi>μα δὲ Τρώων εἵποντο φάλαγ<supplied reason="lost">γες</supplied>
+<lb n="10"/><supplied reason="lost">καρ</supplied>τερα<supplied reason="lost">ί·</supplied> ἦρχε δ’ ἄρά σφιν Ἄρης καὶ <unclear>π</unclear>ότνι’ Ἐνυ<supplied reason="lost">ώ,</supplied>
+<lb n="11"/><supplied reason="lost">ἣ μὲ</supplied>ν ἔχ<supplied reason="lost">ουσα</supplied> <unclear>κ</unclear>υδοιμὸν ἀ<unclear>ν</unclear>α<unclear>ιδ</unclear>έα δηϊο<supplied reason="lost">τῆτος,</supplied>
+<lb n="12"/><supplied reason="lost">Ἄρης δ’ ἐν παλ</supplied><unclear>ά</unclear>μηισι πελώριον ἔγχο<unclear>ς</unclear> ἐ<unclear>ν</unclear><supplied reason="lost">ώμα,</supplied>
+<lb n="13"/><supplied reason="lost">φοίτα δ’ ἄλλοτε</supplied> <unclear>μ</unclear>ὲν πρόσθ’ Ἕ<unclear>κ</unclear>τορος, <g type="high-punctus"/> ἄλλο<supplied reason="lost">τ’ ὄπισθεν.</supplied>
+<lb n="14"/><supplied reason="lost">τὸν δὲ ἰδὼν ῥίγη</supplied><unclear>σ</unclear>ε βοὴν <unclear>ἀγαθ</unclear>ὸς Διομ<supplied reason="lost">ήδης·</supplied>
+<lb n="14"/><gap reason="lost" extent="unknown" unit="line"/>
+</ab></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="publication" subtype="principal">
+               <bibl n="1" type="reference" subtype="previous">
                   <title level="s" type="short-Checklist">P.Oxy. 4</title>
-                  <!-- ignore - start, i.e. SoSOL users may not edit this -->
-                  <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/95234"/>
                   <biblScope n="1" unit="number">758</biblScope>
                   <biblScope n="2" unit="generic">descr.</biblScope>
@@ -136,21 +152,32 @@
                </bibl>
                <bibl n="2" type="reference" subtype="catalogue">
                   <title level="m" type="main">Studies in the Text and Transmission of the Iliad.</title>
-                  <!-- ignore - start, i.e. SoSOL users may not edit this -->
-                  <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/16711"/>
                   <biblScope n="1" unit="number">72</biblScope>
                   <biblScope n="2" unit="book"/>
                   <biblScope n="3" unit="book"/>
                </bibl>
-               <bibl n="3" type="publication" subtype="principal">
+               <bibl n="3" type="reference" subtype="previous">
                   <title level="s" type="short-Checklist">P.Yale 1</title>
-                  <!-- ignore - start, i.e. SoSOL users may not edit this -->
-                  <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/7096"/>
                   <biblScope n="1" unit="number">7</biblScope>
                   <biblScope n="2" unit="chapter"/>
                   <biblScope n="3" unit="page"/>
+               </bibl>
+               <bibl type="publication" subtype="principal">
+                  <ptr target="https://papyri.info/biblio/96861"/>
+                  <!--Confirm other bibliography-->
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <listBibl>
+               <bibl type="online">
+                  <ptr target="https://doi.org/10.48631/pylon.2024.5.105727"/>
+               </bibl>
+               <bibl type="printed">Liège</bibl>
+               <bibl type="online">
+                  <ptr target="http://hdl.handle.net/10079/digcoll/2756860"/>
                </bibl>
             </listBibl>
          </div>
@@ -167,15 +194,6 @@
                </bibl>
             </listBibl>
          </div>
-         <div type="edition" xml:space="preserve" xml:lang="grc"/>
-         <div type="bibliography" subtype="illustrations">
-            <listBibl>
-               <bibl type="printed">Liège</bibl>
-               <bibl type="online">
-                  <ptr target="http://hdl.handle.net/10079/digcoll/2756860"/>
-               </bibl>
-            </listBibl>
-         </div>
       </body>
-  </text>
+   </text>
 </TEI>

--- a/DCLP/61/60741.xml
+++ b/DCLP/61/60741.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.23/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="m60741" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="m60741">
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>P. Oxy. 6 952</title>
+            <title>An Oxyrhynchite Fragment of Iliad 24</title>
          </titleStmt>
          <publicationStmt>
             <authority>Digital Corpus of Literary Papyri</authority>
@@ -40,7 +40,7 @@
                <history>
                   <origin>
                      <origPlace>Found: Oxyrhynchos (Oxyrhynchites, Egypt); written: Egypt</origPlace>
-                     <origDate notBefore="0100" notAfter="0299">100 - 299</origDate>
+                     <origDate notBefore="0200" notAfter="0299">200 - 299</origDate>
                   </origin>
                   <provenance type="found">
                      <p>
@@ -62,8 +62,8 @@
       </fileDesc>
       <encodingDesc>
          <p>
-                This file encoded to comply with EpiDoc Guidelines and Schema version 8
-                <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+            This file encoded to comply with EpiDoc Guidelines and Schema version 8
+            <ref>http://www.stoa.org/epidoc/gl/5/</ref>
          </p>
       </encodingDesc>
       <profileDesc>
@@ -73,7 +73,6 @@
                <term>epic</term>
                <term type="culture">literature</term>
                <term type="religion">classical</term>
-               <term type="overview">Homerus; Ilias 024.74-90</term>
             </keywords>
          </textClass>
          <langUsage>
@@ -82,31 +81,73 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
+         <change when="2024-07-11-05:00" who="DCLP">Xwalk from Pylon
+                            </change>
          <change when="2014-12-10" who="DCLP">Crosswalked to EpiDoc XML</change>
       </revisionDesc>
    </teiHeader>
    <text>
       <body>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
+<ab>
+<lb n="1"/><supplied reason="lost">ἀλλʼ εἴ τις καλέσει</supplied>ε θε<hi rend="circumflex">ῶ</hi>ν Θέ<unclear>τ</unclear><supplied reason="lost">ιν ἄσσον ἐμεῖο,</supplied>
+<lb n="2"/><supplied reason="lost">ὄφρα τί οἱ εἴπω πυ</supplied><unclear>κ</unclear><hi rend="grave">ι</hi>νὸν <hi rend="acute">ἔ</hi>πος, <supplied reason="lost">ὥς κεν Ἀχιλλεύς</supplied>
+<lb n="3"/><supplied reason="lost">δώρων ἐκ Πριά</supplied><unclear>μ</unclear><supplied reason="lost">o</supplied>ι<unclear>ο</unclear> <supplied reason="lost">λ</supplied>άχ<hi rend="acute">ῃ</hi> ἀπ<supplied reason="lost">ό θʼ Ἕκτορα λύσηι.</supplied>
+<lb n="4"/><supplied reason="lost">ὣς ἔφατʼ· ὦρτο δ</supplied>ὲ Ἶρις ἀελλ<supplied reason="lost">όπος ἀγγελέουσα.</supplied>
+<lb n="5"/><supplied reason="lost">μεσσηγὺς δὲ Σά</supplied>μου <app type="editorial"><lem resp="mss">τε</lem><rdg resp="om. pap"/></app> καὶ Ἴμ<supplied reason="lost">βρου παιπαλοέσσης</supplied>
+<lb n="6"/><supplied reason="lost">ἔνθορε μείλαν</supplied>ι π<supplied reason="lost">ό</supplied>ντῳ<g type="high-punctus"/> ἐπεστ<unclear>ο</unclear><supplied reason="lost">νάχησε δὲ λίμνη·</supplied>
+<lb n="7"/><supplied reason="lost">ἣ δὲ μολυβδαίν</supplied>ῃ <supplied reason="lost">ἰ</supplied>κέλη ἐς β<hi rend="grave">υ</hi>σ<unclear>σ</unclear><supplied reason="lost">ὸν ὄρουσεν,</supplied>
+<lb n="8"/><supplied reason="lost">ἥ τε κατʼ ἀγραύ</supplied>λ<unclear>οιο</unclear> βοὸς κ<hi rend="acute">έ</hi>ρας <unclear>ἐ</unclear><supplied reason="lost">μβεβαυῖα</supplied>
+<lb n="9"/><supplied reason="lost">ἔρχεται ὠμηστῆισι</supplied><unclear>ν</unclear> ἐπ’ ἰ<supplied reason="lost">χθύσι κῆρα φέρουσα.</supplied>
+<lb n="10"/><supplied reason="lost">ηὗρε δʼ ἐνὶ σπῆϊ γ</supplied>λαφυρ<unclear>ῷ</unclear> <supplied reason="lost">Θέτ</supplied>ι<unclear>ν</unclear>· <supplied reason="lost">ἀμφὶ δʼ ἄρʼ ἄλλαι</supplied>
+<lb n="11"/><supplied reason="lost">εἵαθʼ ὁμηγερέες <hi rend="acute">ἅ</hi></supplied>λια<unclear>ι</unclear> θ<hi rend="grave">ε</hi>α<supplied reason="lost">ί</supplied>, <unclear>ἣ</unclear> δ’ <unclear>ἐ</unclear><supplied reason="lost">νὶ μέσσηις</supplied>
+<lb n="12"/><supplied reason="lost">κλαῖε μόρον οὗ πα</supplied><unclear>ι</unclear>δ<unclear>ὸ</unclear>ς ἀμ<hi rend="acute">ύ</hi>μο<unclear>ν</unclear><supplied reason="lost">ος, ὅς οἱ ἔμελλεν</supplied>
+<lb n="13"/><supplied reason="lost">φθείσεσθʼ ἐν Τροί</supplied><unclear>ῃ</unclear> ἐριβώλακι, τ<supplied reason="lost">ηλόθι πάτρης.</supplied>
+<lb n="14"/><supplied reason="lost">ἀγχοῦ δʼ ἱσταμέν</supplied>η προσ<hi rend="acute">έ</hi>φη πόδ<unclear>α</unclear><supplied reason="lost">ς ὠκέα Ἶρις·</supplied>
+<lb n="15"/><supplied reason="lost">ὄρσο Θέτι· καλέει</supplied> Ζεὺς ἄφθιτα μ<hi rend="acute">ή</hi><unclear>δ</unclear><supplied reason="lost">εα εἰδώς.</supplied>
+<lb n="16"/><supplied reason="lost">τὴν δʼ ἠμείβετʼ ἔπε</supplied>ιτα θεὰ <unclear>Θ</unclear>έτις <unclear>ἀ</unclear>ρ<supplied reason="lost">γυρόπεζα·</supplied>
+<lb n="17"/><supplied reason="lost">τίπτε με κεῖνος ἄνω</supplied><unclear>γ</unclear>ε μ<unclear>έ</unclear><supplied reason="lost">γας θεός; αἰδέομαι δέ</supplied>
+<lb n="17"/><gap reason="lost" extent="unknown" unit="line"/>
+</ab></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl type="publication" subtype="principal">
+               <bibl type="reference" subtype="previous">
                   <ptr target="http://papyri.info/biblio/95236"/>
-                  <biblScope unit="number">952</biblScope>
-                  <!--ignore - start, i.e. SoSOL users may not edit this-->
                   <title level="s" type="abbreviated">P. Oxy.</title>
                   <biblScope unit="volume">6</biblScope>
-                  <!--ignore - stop-->
+                  <biblScope unit="number">952</biblScope>
+                  <biblScope unit="generic">descr.</biblScope>
                </bibl>
                <bibl type="reference" subtype="catalogue">
-                  <!-- ignore - start, i.e. SoSOL users may not edit this -->
                   <title level="m" type="main">Studies in the Text and Transmission of the Iliad.</title>
                   <author>
                      <surname>West</surname>
                      <forename>Martin L.</forename>
                   </author>
-                  <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/16711"/>
                   <biblScope unit="number">260</biblScope>
+               </bibl>
+               <bibl type="reference" subtype="previous">
+                  <title level="s" type="short-Checklist">P.Yale 1</title>
+                  <ptr target="http://papyri.info/biblio/7096"/>
+                  <biblScope n="1" unit="number">14</biblScope>
+                  <biblScope n="2" unit="generic">descr.</biblScope>
+                  <biblScope n="3" unit="page"/>
+               </bibl>
+               <bibl type="publication" subtype="principal">
+                  <ptr target="https://papyri.info/biblio/96869"/>
+                  <!--Confirm other bibliography-->
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <listBibl>
+               <bibl type="online">
+                  <ptr target="https://doi.org/10.48631/pylon.2024.5.105732"/>
+               </bibl>
+               <bibl type="printed">Liège</bibl>
+               <bibl type="online">
+                  <ptr target="http://hdl.handle.net/10079/digcoll/2760671"/>
                </bibl>
             </listBibl>
          </div>
@@ -117,15 +158,8 @@
                   <title type="main"
                          level="m"
                          ref="http://www.trismegistos.org/authorwork/511">Ilias</title>
-               </bibl>
-            </listBibl>
-         </div>
-         <div type="edition" xml:space="preserve" xml:lang="grc"/>
-         <div type="bibliography" subtype="illustrations">
-            <listBibl>
-               <bibl type="printed">Liège</bibl>
-               <bibl type="online">
-                  <ptr target="http://hdl.handle.net/10079/digcoll/2760671"/>
+                  <biblScope n="1" unit="book">24</biblScope>
+                  <biblScope n="2" unit="line" from="74" to="90">74-90</biblScope>
                </bibl>
             </listBibl>
          </div>

--- a/DCLP/999/998493.xml
+++ b/DCLP/999/998493.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.23/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="m998493">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>School Tablet with Divisions and Demonstrations</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Digital Corpus of Literary Papyri</authority>
+            <idno type="dclp">998493</idno>
+            <idno type="TM">998493</idno>
+            <idno type="LDAB">998493</idno>
+            <idno type="filename">998493</idno>
+            <idno type="dclp-hybrid">pylon;5;1</idno>
+            <availability>
+               <p>© Digital Corpus of Literary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <repository/>
+                  <idno>Dublin, Chester Beatty Library W. 142.2</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Wood</material>
+                           <dimensions>
+                              <width unit="cm">17.5</width>
+                              <height unit="cm">11.9</height>
+                           </dimensions>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>unbekannt</origPlace>
+                     <origDate notBefore="0501" notAfter="0600" cert="low" precision="low">VI (?)</origDate>
+                  </origin>
+               </history>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8 <ref>http://www.stoa.org/epidoc/gl/5/</ref>
+         </p>
+      </encodingDesc>
+      <profileDesc>
+         <textClass>
+            <keywords>
+               <term n="1" type="culture">science</term>
+               <term n="2">mathematics</term>
+            </keywords>
+         </textClass>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2024-07-11-05:00" who="DCLP">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
+<div n="A" subtype="side" type="textpart">
+<div n="i" subtype="column" type="textpart"><ab>
+<lb n="1"/><g type="stauros"/> <supplied reason="lost">τ</supplied>ὸ ϛʹ ἐν ψήφ<unclear>ων</unclear> <unclear>α</unclear>      <gap reason="illegible" quantity="1" unit="character"/>
+<lb n="2"/><choice><reg>τῆς</reg><orig>τῶν</orig></choice> <num value="1">α</num> <num value="1/6" rend="tick">ϛ</num> <num value="1/6" rend="tick">ϛ</num> <num value="1">α</num>
+<lb n="3"/>τῶν <num value="2">β</num> <num value="1/3" rend="tick"><unclear>γ</unclear></num> <num value="1/3" rend="tick"><unclear>γ</unclear></num> <num value="2"><unclear>β</unclear></num> 
+<lb n="4"/>τῶν <num value="3">γ</num> <num value="1/2"><unclear>𐅵</unclear></num> <num value="1/2"><unclear>𐅵</unclear></num> <num value="3">γ</num>
+<lb n="5"/>τῶν <num value="4">δ</num> <num value="2/3"><unclear>𐅷</unclear></num> <num value="2/3">𐅷</num> <num value="4"><unclear>δ</unclear></num>
+<lb n="6"/>τῶν <num value="5">ε</num> <num value="1/2"><unclear>𐅵</unclear></num><num value="1/3" rend="tick"><unclear>γ</unclear></num> <num value="1/2">𐅵</num> <num value="3">γ</num>· <num value="1/3" rend="tick"><unclear>γ</unclear></num> <supplied reason="lost"><num value="2">β</num></supplied>
+<lb n="7"/>τῶν <num value="6">ϛ</num> <num value="1">α</num> <num value="1"><unclear>α</unclear></num> <num value="6">ϛ</num>
+<lb n="8"/>τῶν <num value="7">ζ</num> <num value="1">α</num><num value="1/6" rend="tick">ϛ</num> <num value="1"><unclear>α</unclear></num> <num value="6"><unclear>ϛ</unclear></num>· <num value="1/6" rend="tick"><unclear>ϛ</unclear></num> <supplied reason="lost"><num value="1">α</num></supplied>
+<lb n="9"/>τῶν <num value="8">η</num> <num value="1">α</num><num value="1/3" rend="tick">γ</num> <num value="1">α</num> <num value="6">ϛ</num>· <num value="1/3" rend="tick">γ</num> <num value="2"><unclear>β</unclear></num>  
+<lb n="10"/>τῶν <num value="9">θ</num> <num value="1">α</num><num value="1/2">𐅵</num> <num value="1">α</num> <num value="6">ϛ</num>· <num value="1/2">𐅵</num> <num value="3">γ</num>
+<lb n="11"/>τῶν <num value="10">ι</num> <num value="1">α</num><num value="2/3">𐅷</num> <num value="1">α</num> <num value="6">ϛ</num>· <num value="2/3">𐅷</num> <num value="4">δ</num>
+<lb n="12"/>τῶν <num value="20">κ</num> <del rend="erasure"><unclear>α</unclear></del> <num value="3">γ</num><num value="1/3" rend="tick">γ</num> <num value="3">γ</num> <num value="6">ϛ</num> <num value="18">ιη</num>· <num value="1/3" rend="tick">γ</num> <num value="2">β</num>
+<lb n="13"/>τῶν <num value="30">λ</num> <num value="5">ε</num> <num value="5">ε</num> <num value="6">ϛ</num> <num value="30">λ</num>
+<lb n="14"/>τῶν <num value="40">μ</num> <num value="6">ϛ</num><num value="2/3">𐅷</num> <app type="editorial"><lem><num value="6">ϛ</num></lem><rdg resp="pap"><g type="slanting-stroke"/><num value="6">ϛ</num></rdg></app> <num value="6">ϛ</num> <num value="36">λϛ</num>· <num value="2/3"><unclear>𐅷</unclear></num> <num value="4"><unclear>δ</unclear></num>
+<lb n="15"/>τ<unclear>ῶ</unclear><supplied reason="lost">ν <num value="50">ν</num> <num value="8">η</num><num value="1/3" rend="tick">γ</num></supplied> <num value="8"><unclear>η</unclear></num> <num value="6">ϛ</num> <num value="48">μη</num>· <num value="1/3" rend="tick">γ</num> <supplied reason="lost"><num value="2">β</num></supplied>
+<lb n="16"/>τ<unclear>ῶ</unclear><supplied reason="lost">ν <num value="60">ξ</num> <num value="10">ι</num></supplied> <num value="10">ι</num> <num value="6">ϛ</num> <num value="60">ξ</num>
+</ab></div>
+<div n="ii" subtype="column" type="textpart"><ab>
+<lb n="1"/>τῶν <num value="200">σ</num> <num value="33">λγ</num><num value="1/3" rend="tick">γ</num> <num value="30">λ</num> <num value="6">ϛ</num> <num value="180">ρπ</num>· <num value="3">γ</num> <num value="6">ϛ</num> <num value="18">ιη</num>· <num value="1/3" rend="tick">γ</num> <num value="2"><unclear>β</unclear></num>
+<lb n="2"/>τῶν <num value="300">τ</num> <num value="50">ν</num> <num value="50">ν</num> <num value="6">ϛ</num> <num value="300">τ</num>
+<lb n="3"/>τῶν <num value="400">υ</num> <num value="66">ξϛ</num><num value="2/3">𐅷</num> <num value="60">ξ</num> <num value="6">ϛ</num> <num value="360">τξ</num>· <num value="6">ϛ</num> <num value="6">ϛ</num> <num value="36">λϛ</num>· <num value="2/3">𐅷</num> <num value="4"><unclear>δ</unclear></num>
+<lb n="4"/>τῶν <num value="500">φ</num> <num value="83">πγ</num><num value="1/3" rend="tick">γ</num> <num value="80">π</num> <num value="6">ϛ</num> <num value="480"><unclear>υπ</unclear></num>· <num value="3">γ</num> <num value="6">ϛ</num> <surplus>γ</surplus> <num value="18">ιη</num>· <num value="1/3" rend="tick">γ</num> <num value="2">β</num> 
+<lb n="5"/>τῶν <num value="600">χ</num> <num value="100">ρ</num> <supplied reason="lost"><num value="100">ρ</num></supplied> <num value="6">ϛ</num> <num value="600">χ</num>
+<lb n="6"/>τῶ<unclear>ν</unclear> <supplied reason="lost"><num value="700">ψ</num></supplied> <num value="116"><supplied reason="lost">ρ</supplied><unclear>ιϛ</unclear></num><num value="2/3"><unclear>𐅷</unclear></num> <num value="100"><unclear>ρ</unclear></num> <num value="6">ϛ</num> <num value="600"><unclear>χ</unclear></num>· <supplied reason="lost"><num value="10">ι</num></supplied> <num value="6">ϛ</num> <num value="60">ξ</num>· <num value="6">ϛ</num> <num value="6">ϛ</num> <num value="36">λϛ</num>·<add place="above"><num value="2/3">𐅷</num> <num value="4">δ</num></add>
+<lb n="7"/>τῶ<supplied reason="lost">ν <num value="800">ω</num></supplied> <num value="133">ρ<unclear>λ</unclear>γ</num><num value="1/3" rend="tick"><unclear>γ</unclear></num> <num value="100"><unclear>ρ</unclear></num> <num value="6">ϛ</num> <num value="600">χ</num>· <num value="30"><unclear>λ</unclear></num> <num value="6">ϛ</num> <num value="180">ρπ</num>· <num value="3">γ</num> <num value="6">ϛ</num> <num value="18">ιη</num>·<add place="above"><num value="1/3" rend="tick">γ</num> <num value="2">β</num></add>
+<lb n="8"/>τ<unclear>ῶ</unclear><supplied reason="lost">ν <num value="900">ϡ</num></supplied> <unclear>ρ</unclear><supplied reason="lost">ν</supplied><num value="150"/> <num value="100"><supplied reason="lost">ρ</supplied></num> <num value="6">ϛ</num> <num value="600"><unclear>χ</unclear></num>· <num value="50">ν</num> <num value="6">ϛ</num> <num value="300">τ</num>
+<lb n="9"/>τῶν <num value="1000">Α</num> <num value="166">ρ<supplied reason="lost">ξ</supplied>ϛ</num><num value="2/3"><unclear>𐅷</unclear></num> <supplied reason="lost"><num value="100">ρ</num></supplied> <num value="6">ϛ</num> <num value="600"><unclear>χ</unclear></num>· <num value="60">ξ</num> <num value="6">ϛ</num> <num value="360">τξ</num>· <num value="6">ϛ</num> <num value="6">ϛ</num> <num value="36">λϛ</num>·<add place="above"><num value="2/3">𐅷</num> <num value="4"><unclear>δ</unclear></num></add>
+<lb n="10"/>τῶν <num value="2000">Β</num> <num value="333">τλ<unclear>γ</unclear></num><supplied reason="lost"><num value="1/3" rend="tick">γ</num></supplied> <num value="300"><unclear>τ</unclear></num> <num value="6">ϛ</num> <num value="1800">Αω</num>· <num value="30">λ</num> <num value="6">ϛ</num> <num value="180">ρπ</num>· <num value="3">γ</num> <num value="6">ϛ</num> <add place="above"><num value="18">ιη</num>· <num value="1/3" rend="tick">γ</num> <supplied reason="lost"><num value="2">β</num></supplied></add>
+<lb n="11"/>τῶν <num value="3000">Γ</num> <num value="500"><unclear>φ</unclear></num> <num value="500">φ</num> <num value="6">ϛ</num> <num value="3000">Γ</num>
+<lb n="12"/>τῶν <num value="4000"><unclear>Δ</unclear></num> <num value="666"><unclear>χ</unclear><supplied reason="lost">ξϛ</supplied></num><num value="2/3">𐅷</num> <num value="600">χ</num> <num value="6">ϛ</num> <num value="3600">Γχ</num>· <num value="60">ξ</num> <num value="6">ϛ</num> <num value="360">τξ</num>· <num value="6">ϛ</num> <num value="6">ϛ</num> <add place="above"><num value="36"><unclear>λ</unclear>ϛ</num>· <num value="2/3">𐅷</num> <supplied reason="lost"><num value="4">δ</num></supplied></add>
+<lb n="13"/>τῶν <num value="5000"><unclear>Ε</unclear></num> <num value="833"><supplied reason="lost">ωλ</supplied><unclear>γ</unclear></num><num value="1/3" rend="tick"><unclear>γ</unclear></num> <num value="800">ω</num> <num value="6">ϛ</num> <num value="4800"><choice><reg>Δω</reg><orig>Δ𐅷</orig></choice></num>· <num value="30">λ</num> <num value="6">ϛ</num> <num value="180">ρ<unclear>π</unclear></num>· <num value="3">γ</num> <num value="6">ϛ</num> <add place="above"><num value="18">ιη</num>· <num value="1/3" rend="tick">γ</num> <supplied reason="lost"><num value="2">β</num></supplied></add>
+<lb n="14"/>τῶν <num value="6000"><unclear>Ϛ</unclear></num> <num value="1000"><unclear>Α</unclear></num> <num value="1000">Α</num> <num value="6">ϛ</num> <num value="6000">Ϛ</num>
+<lb n="15"/><unclear>τῶν</unclear> <num value="7000"><unclear>Ζ</unclear></num> <num value="1166"><supplied reason="lost">Α</supplied><unclear>ρ</unclear>ξϛ</num><num value="2/3">𐅷</num> <num value="1000">Α</num> <num value="6">ϛ</num> <num value="6000"><unclear>Ϛ</unclear></num>· <supplied reason="lost"><num value="100">ρ</num></supplied> <num value="6"><unclear>ϛ</unclear></num> <num value="600">χ</num>· <num value="60"><unclear>ξ</unclear></num> <num value="6"><unclear>ϛ</unclear></num> <num value="360">τξ</num>· <add place="above"><num value="6"><unclear>ϛ</unclear></num> <num value="6"><unclear>ϛ</unclear></num> <num value="36"><unclear>λϛ</unclear></num>· <num value="2/3"><unclear>𐅷</unclear></num> <supplied reason="lost"><num value="4">δ</num></supplied></add>
+<lb n="16"/>τῶ<supplied reason="lost">ν <num value="8000">Η</num></supplied> <num value="1333"><supplied reason="lost">Ατ</supplied>λ<unclear>γ</unclear></num><num value="1/3" rend="tick"><unclear>γ</unclear></num> <supplied reason="lost"><num value="1000">Α</num> <num value="6">ϛ</num></supplied> <num value="6000">Ϛ</num>· <num value="300">τ</num> <num value="6">ϛ</num> <num value="1800"><supplied reason="lost">Α</supplied>ω</num>· <supplied reason="lost"><num value="30">λ</num> <num value="6">ϛ</num> <num value="180">ρπ</num>·</supplied> <add place="above"><num value="3"><unclear>γ</unclear></num> <num value="6">ϛ</num> <supplied reason="lost"><num value="18">ιη</num>· <num value="1/3" rend="tick">γ</num> <num value="2">β</num></supplied></add>
+<lb n="17"/><unclear>τῶ</unclear><supplied reason="lost">ν</supplied> <num value="9000"><unclear>Θ</unclear></num> <num value="1500"><unclear>Αφ</unclear></num> <num value="1000"><unclear>Α</unclear></num> <supplied reason="lost"><num value="6">ϛ</num> <num value="6000">Ϛ</num></supplied>· <num value="500"><unclear>φ</unclear></num> <num value="6">ϛ</num> <num value="3000"><unclear>Γ</unclear></num>
+</ab></div>
+</div>
+<div n="B" subtype="side" type="textpart"><ab>
+<lb n="1"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap><gap reason="lost" extent="unknown" unit="character"/> <num value="857">ωνζ</num> <supplied reason="lost"><num value="1/7">ζ</num></supplied>
+<lb n="2"/>τ<gap reason="lost" quantity="2" unit="character"/> <num value="1">α</num> <num value="7"><unclear>ζ</unclear></num> <num value="7"><supplied reason="lost">ζ</supplied></num> <num value="1">α</num>
+<lb n="3"/>τῶν <num value="2"><unclear>β</unclear></num> <num value="1/4"><unclear>d</unclear></num> <num value="1/28">κ<hi rend="supraline"><unclear>η</unclear></hi></num> <num value="1/4"><unclear>d</unclear></num> <num value="1">α</num><num value="1/2">𐅵</num><num value="1/4"><unclear>d</unclear></num>· <num value="1/28">κ<hi rend="supraline">η</hi></num> <supplied reason="lost"><num value="1/4">d</num></supplied>
+<lb n="4"/>τῶν <num value="3">γ</num> <num value="1/3" rend="tick"><unclear>γ</unclear></num> <supplied reason="lost"><num value="1/14">ιδ</num> <num value="1/42">μβ</num></supplied> <supplied reason="lost"><num value="1/3" rend="tick">γ</num></supplied> <num value="2"><unclear>β</unclear></num><num value="1/3" rend="tick"><unclear>γ</unclear></num>· <num value="1/14">ιδ</num> <num value="1/2">𐅵</num>· <supplied reason="lost"><num value="1/42">μβ</num> <num value="1/6" rend="tick">ϛ</num></supplied> 
+<lb n="5"/>τῶν <num value="4"><unclear>δ</unclear></num> <supplied reason="lost"><num value="1/2">𐅵</num> <num value="1/14">ιδ</num></supplied> <num value="1/2"><unclear>𐅵</unclear></num> <num value="3">γ</num><num value="1/2">𐅵</num>· <supplied reason="lost"><num value="1/14">ιδ</num> <num value="1/2">𐅵</num></supplied>
+<lb n="6"/>τῶν <num value="5">ε</num> <num value="2/3">𐅷</num> <num value="1/21">κα</num> <supplied reason="lost"><num value="2/3">𐅷</num> <num value="4">δ</num><num value="2/3">𐅷</num>· <num value="1/21">κα</num> <num value="1/3" rend="tick">γ</num></supplied> 
+<lb n="7"/>τῶν <num value="6">ϛ</num> <num value="1/2"><unclear>𐅵</unclear></num> <num value="1/3" rend="tick"><unclear>γ</unclear></num> <num value="1/42">μβ</num> <num value="1/2"><unclear>𐅵</unclear></num> <num value="3"><unclear>γ</unclear></num><supplied reason="lost"><num value="1/2">𐅵</num>· <num value="1/3" rend="tick">γ</num> <num value="2">β</num><num value="1/3" rend="tick">γ</num>· <num value="1/42">μβ</num> <num value="1/6" rend="tick">ϛ</num></supplied>
+<lb n="8"/>τῶν <num value="7">ζ</num> <num value="1">α</num> <num value="1">α</num> <num value="7">ζ</num>
+<lb n="9"/>τῶν <num>η</num> <num value="1">α</num> <num value="1/7" rend="tick">ζ</num> <num value="1">α</num> <num value="7">ζ</num>· <num value="1/7" rend="tick">ζ</num> <supplied reason="lost"><num value="1">α</num></supplied>
+<lb n="10"/>τῶν <num value="9">θ</num> <num value="1">α</num> <num value="1/4"><supplied reason="lost">d</supplied></num> <num value="1/28">κ<hi rend="supraline"><unclear>η</unclear></hi></num> <num value="1">α</num> <num value="7">ζ</num>· <num value="1/4">d</num> <num value="1">α</num><num value="1/2">𐅵</num><num value="1/4"><unclear>d</unclear></num>· <num value="1/28">κ<hi rend="supraline"><unclear>η</unclear></hi></num> <num value="1/4"><unclear>d</unclear></num>
+<lb n="11"/>τῶν <num value="10">ι</num> <num value="1">α</num> <num value="1/3" rend="tick">γ</num> <num value="1/14">ιδ</num> <num value="1/42">μ<hi rend="supraline"><unclear>β</unclear></hi></num> <num value="1">α</num> <num value="7">ζ</num>· <num value="1/3" rend="tick">γ</num> <num value="2">β</num><num value="1/3" rend="tick"><unclear>γ</unclear></num>· <num value="1/14">ιδ</num> <num value="1/2"><unclear>𐅵</unclear></num>· <num value="1/42"><unclear>μ</unclear><supplied reason="lost">β</supplied></num> <supplied reason="lost"><num value="1/6" rend="tick">ϛ</num></supplied>
+<lb n="12"/>τῶν <num value="20">κ</num> <num value="2">β</num> <num value="1/2"><unclear>𐅵</unclear></num> <num value="1/3" rend="tick">γ</num> <num value="1/42">μ<hi rend="supraline">β</hi></num> <num value="2"><unclear>β</unclear></num> <num value="7">ζ</num> <num value="14">ιδ</num>· <num value="1/2">𐅵</num> <num value="3">γ</num><num value="1/2"><unclear>𐅵</unclear></num>· <num value="1/3" rend="tick"><unclear>γ</unclear></num> <num value="2">β</num><num value="1/3" rend="tick">γ</num>· <num value="1/42"><unclear>μβ</unclear></num> <num value="1/6" rend="tick">ϛ</num>
+<lb n="13"/>τῶν <num value="30"><unclear>λ</unclear></num> <num value="4"><unclear>δ</unclear></num> <num value="1/4"><unclear>d</unclear></num> <num value="1/28">κ<hi rend="supraline">η</hi></num> <num value="4"><unclear>δ</unclear></num> <num value="7">ζ</num> <num value="28"><unclear>κη</unclear></num>· <num value="1/4"><unclear>d</unclear></num> <num value="1"><unclear>α</unclear></num><num value="1/2"><supplied reason="lost">𐅵</supplied></num><num value="1/4"><unclear>d</unclear></num>· <num value="1/28">κη</num> <num value="1/4">d</num>
+<lb n="14"/>τ<unclear>ῶν</unclear> <num value="40">μ</num> <num value="5">ε</num> <num value="2/3">𐅷</num> <num value="1/21">κα</num> <num value="5">ε</num> <num value="7">ζ</num> <num value="35">λ<unclear>ε</unclear></num>· <num value="2/3"><unclear>𐅷</unclear></num> <supplied reason="lost"><num value="4">δ</num><num value="2/3">𐅷</num></supplied>· <num value="1/21"><unclear>κα</unclear></num> <num value="1/3" rend="tick"><unclear>γ</unclear></num>         
+<lb n="15"/>τῶν <num value="50"><unclear>ν</unclear></num> <num value="7"><unclear>ζ</unclear></num> <num value="1/7"><unclear>ζ</unclear></num> <num value="7">ζ</num> <num value="7">ζ</num> <num value="49">μθ</num>· <num value="1/7"><unclear>ζ</unclear></num> <supplied reason="lost"><num value="1">α</num></supplied>         
+</ab></div></div>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <ptr target="https://papyri.info/biblio/96867"/>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <listBibl>
+               <bibl type="online">
+                  <ptr target="https://doi.org/10.48631/pylon.2024.5.105710"/>
+               </bibl>
+               <bibl type="online">
+                  <ptr target="https://cbl01.intranda.com/viewer/image/W_142_2/1/LOG_0000/"/>
+               </bibl>
+            </listBibl>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.5/pylon.5.2.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.5/pylon.5.2.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Dialysis</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.5.2</idno>
+            <idno type="ddb-hybrid">pylon;5;2</idno>
+            <idno type="HGV">998492</idno>
+            <idno type="TM">998492</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change who="https://papyri.info/editor/users/DDBDP" when="2024-07-11-05:00">Xwalk from Pylon
+                        </change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
+<ab>
+<lb n="1"/><handShift new="m1"/>κτήτωρ <unclear>ἀπ</unclear>ὸ <unclear>κ</unclear>ώμης <expan>Ἀφροδί<ex>της</ex></expan> τοῦ Ἀνταιοπολίτου νομοῦ <g type="stauros"/> Αὐρηλίῳ <gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" quantity="7" unit="character" precision="low"/>
+<lb n="2"/><hi rend="diaeresis">υ</hi>ἱῷ <choice><reg>Βίκτορος</reg><orig>Βίκτωρος</orig></choice> <choice><reg>χαλκοπράτῃ</reg><orig>χαλκοπράτης</orig></choice> ἀπὸ τῆς αὐτῆς κώμης <expan>Ἀφ<unclear>ρ</unclear>οδί<ex>της</ex></expan> <unclear>χα</unclear><supplied reason="lost">ίρειν.</supplied> 
+<lb n="3"/><unclear>ἐπ</unclear>ειδήπερ πρὸ <unclear>χρό</unclear>ν<unclear>ου</unclear> <supplied reason="lost">ἱ</supplied><unclear>κα</unclear>ν<supplied reason="lost">οῦ δ</supplied><unclear>ιὰ</unclear> τῆς ἐγγράφ<unclear>ο</unclear>υ πράσεως <choice><reg>ὁμ<supplied reason="lost">ο</supplied>μητρίω<supplied reason="lost">ν</supplied></reg><orig>ὁ<unclear>μ</unclear><supplied reason="lost">ο</supplied><unclear>μητρίο</unclear><supplied reason="lost">υ</supplied></orig></choice>
+<lb n="4"/>μου <choice><reg>ἀδελφῶν</reg><orig>ἀδελφοῦ</orig></choice> εἰς τὸ μέρ<unclear>ο</unclear>ς αὐτῶν καὶ τὸ μέρος μου ἀπὸ τοῦ ὁλοκλήρου μητ<unclear>ρῴ</unclear>ου
+<lb n="5"/>μου <unclear>μέρ</unclear>ο<unclear>υς</unclear> καὶ <choice><reg>ἐγγυῶσιν</reg><orig>ἐγγυοῦσιν</orig></choice> <hi rend="diaeresis">ὑ</hi>πὲρ ἐμοῦ ἀπ<unclear>ὸ</unclear> <unclear>τ</unclear>ῆς γε<unclear>ν</unclear><supplied reason="lost">α</supplied><unclear>μ</unclear><supplied reason="lost">ένης</supplied> <gap reason="lost" quantity="20" unit="character" precision="low"/>
+<lb n="6"/>τῆς <choice><reg>γεγενημένης</reg><orig>γεγεναμένης</orig></choice> <choice><reg>αὐτοῖς</reg><orig>αὐτῶν</orig></choice> εἰς ὄνομά σου τῆς καὶ βεβαίας μεν<unclear>ο</unclear>ύση<supplied reason="lost">ς</supplied> <unclear>π</unclear><supplied reason="lost">α</supplied><unclear>ντ</unclear><supplied reason="lost">α</supplied><unclear>χ</unclear><supplied reason="lost">οῦ</supplied>
+<lb n="7"/><choice><reg>προφερομένης</reg><orig>προφερομένην</orig></choice>, τὰ νῦν δὲ <choice><reg>ἤλθαμεν</reg><orig>ἤλθαμε</orig></choice> εἰς <choice><reg><app type="alternative"><lem>νομίμην</lem><rdg>ἔννομον</rdg></app></reg><orig>νομον</orig></choice> ἡλικίαν καὶ <choice><reg>ἐζήτησας</reg><orig>ἐζύτησας</orig></choice> παρ’ <unclear>ἐμοῦ</unclear>
+<lb n="8"/>τὴν <choice><reg>ἔγγραφον</reg><orig>ἐγγράφου</orig></choice> <choice><reg>διάλυσιν</reg><orig>διαλ<unclear>ύ</unclear>σεως</orig></choice> διὰ τοῦτο, κατὰ τοῦτο εἰς ταύτη<unclear>ν</unclear> τὴ<unclear>ν</unclear> <choice><reg>ἔγγραφον</reg><orig><unclear>ἐγγράφου</unclear></orig></choice>
+<lb n="9"/><choice><reg>διάλυσιν</reg><orig>διαλ<unclear>ύ</unclear>σεως</orig></choice> μηδένα τοῦ <choice><reg>λοιποῦ</reg><orig>λιποῦ</orig></choice> <choice><reg>λόγον</reg><orig>λόγου</orig></choice> ἔχειν πρὸς σὲ τὸ σύνολον περὶ τοῦ
+<lb n="10"/>ὁλοκλήρου μου μέ<unclear>ρ</unclear>ο<unclear>υ</unclear><supplied reason="lost">ς</supplied> ἀπὸ τοῦ ὁλοκλήρου θησαυροῦ λεγομένου
+<lb n="11"/>Ψιμανοβετ καὶ μετὰ <choice><reg>πάντων</reg><orig>παντὸς</orig></choice> καὶ <choice><reg>ἀνηκόντων</reg><orig>ἀνηκόντον</orig></choice> καὶ προσκυρούντων το<unclear>ῦ</unclear> αὐτο<supplied reason="omitted">ῦ</supplied>
+<lb n="12"/>θησαυροῦ πρὸς τὴν δύναμιν τῆς ἐγγράφου πράσεως τῆς γεγεναμένης
+<lb n="13"/>σοι παρὰ τῶν προειρημένων Κολλ<unclear>ού</unclear>θου καὶ <choice><reg>Χριστοφόρου</reg><orig>Χρ<unclear>ι</unclear>στ<unclear>ο</unclear>φ<unclear>ο</unclear>ρί<unclear>ου</unclear></orig></choice> τ<unclear>ῶν</unclear> ἀδελφῶ<add place="above">ν</add>
+<lb n="14"/><hi rend="diaeresis">ὑ</hi>πὲρ αὐτῶν καὶ ὑπὲρ ἐμοῦ τῆς καὶ βεβαίας μενούσης πανταχοῦ <expan>προφερομέ<ex>νης</ex></expan>.
+<lb n="15"/>εἰ δὲ <choice><reg>θελήσομεν</reg><orig>θελή<unclear>σο</unclear>με</orig></choice> ποτε καιρῷ ἢ χρόνῳ <unclear>ὑπε</unclear>ξ<unclear>ε</unclear>λ vestig<gap reason="illegible" quantity="22" unit="character"/> τὸ
+<lb n="16"/><expan>προκ<ex>είμενόν</ex></expan> μου μέρος ἀπὸ τοῦ <expan>προκ<ex>ειμένου</ex></expan> θησαυροῦ μήτε ἐμὲ μήτε <choice><reg>τοὺς</reg><orig>τῶ<unclear>ν</unclear></orig></choice> <choice><reg>ἐμοὺς</reg><orig><unclear>ἐμ</unclear>ῶν</orig></choice>
+<lb n="17"/><choice><reg>κληρονόμους</reg><orig>κληρονόμον</orig></choice> ἢ <choice><reg>συνκληρονόμους</reg><orig>συνκληρονόμων</orig></choice> ἐπὶ <choice><reg>τοῦτο</reg><orig>τωτο</orig></choice> <hi rend="diaeresis">ὑ</hi>πεξ<unclear>ελε</unclear><gap reason="illegible" quantity="1" unit="character"/> vestig<gap reason="illegible" quantity="20" unit="character"/>. 
+<lb n="18"/>λόγῳ προστίμου ἐξεπερωτήσεως καὶ παραβάσεως χρ<unclear>υσίο</unclear>υ <unclear>νομισμά</unclear>τι<unclear>α</unclear>
+<lb n="19"/>εἴ<unclear>κο</unclear>σι <expan>γί<ex>νεται</ex></expan> <expan>χρ<ex>υσίου</ex></expan> <expan>νο<ex>μισμάτια</ex></expan> <num value="20">κ</num> ἔργῳ καὶ δυνάμει <choice><reg>ἀπαιτούμενα</reg><orig>ἀπετούμενα</orig></choice> καὶ <choice><reg>καταβαλλόμενα</reg><orig>καταβαλλώμενα</orig></choice> <add place="above">καὶ μετὰ τοῦ διαφέροντ<unclear>ος</unclear> <unclear>πρὸς</unclear></add> ταύτην
+<lb n="20"/>τὴν διάλυσιν κυρίαν οὖσαν καὶ βεβαίαν πανταχοῦ προφερομέν<unclear>ην</unclear>. καὶ πρὸς
+<lb n="21"/>ἐντελεστέραν ἀσφάλειαν <choice><reg><app type="alternative"><lem>ἐπομνύμενοι</lem><rdg>ἐπομνύμενος</rdg></app></reg><orig><hi rend="diaeresis">ὑ</hi>πομνήμενοι</orig></choice> <choice><reg>τόν τε</reg><orig>τὼν δὲ</orig></choice> παντοκράτορα θεὸν καὶ τὴν
+<lb n="22"/>νίκην καὶ σωτηρίαν τῶν εὐσεβεστάτων καὶ γαληνοτάτων καὶ <choice><reg>θεοστεφῶν</reg><orig>θε<unclear>ο</unclear>στεφοῦς</orig></choice>
+<lb n="23"/>ἡμῶν <choice><reg>δεσποτῶν</reg><orig>δεσπότου</orig></choice> <expan>Φλ<ex>αουίων</ex></expan> Ἡρακλείου καὶ Αἰλίας Εὐδοκίας τῶν αἰωνίων
+<lb n="24"/><choice><reg>Αὐγούστων</reg><orig>Αὐγούστου</orig></choice> <choice><reg>Αὐτοκρατόρων</reg><orig>Αὐτοκράτορος</orig></choice> καὶ <choice><reg>μεγίστων</reg><orig>μεγίστου</orig></choice> <choice><reg>εὐεργετῶν</reg><orig>εὐεργέτου</orig></choice> διαφυλάξαι δι<unclear>ὰ</unclear> π<unclear>α</unclear>ντὸς
+<lb n="25"/>ταύτην τὴν διάλυσιν ἀρραγῆ καὶ ἀσάλευτον εἶναι καὶ εἰσχυρὰν πανταχοῦ
+<lb n="26"/><unclear>πρ</unclear><supplied reason="lost">ο</supplied><unclear>φ</unclear>ερ<unclear>ομένην</unclear> ἥνπ<unclear>ε</unclear>ρ <unclear>ἁ</unclear>πλῆν <choice><reg>γραφεῖσαν</reg><orig>γραφὴν</orig></choice> <choice><reg>ἑκὼν</reg><orig>ἑκόντες</orig></choice> καὶ <choice><reg>πεπισμένος</reg><orig>πεπισμέ<unclear>ν</unclear>οι</orig></choice> ἐθέμ<unclear>ην</unclear>
+<lb n="27"/>σοι ἄνευ βίας καὶ ἀπάτη<surplus>η</surplus>ς καὶ πλάνης <surplus>καὶ</surplus> πάσης καὶ φόβου καὶ δόλου τινὸς
+<lb n="28"/><unclear>ἐν</unclear> <unclear>δημ</unclear>οσίῳ ἀρχείῳ καὶ κατὰ νόμους τετελειωμένην μεθ’ <hi rend="diaeresis">ὑ</hi>πογραφῆς ἐμῆς
+<lb n="29"/>καὶ τῶν ἑξῆς <choice><reg>συνηθῶν</reg><orig>συνηθο͂ν</orig></choice> κατὰ παράκλησιν ἐμὴν μαρτυρησάντων μαρτύ<unclear>ρ</unclear>ων
+<lb n="30"/><unclear>καὶ</unclear> <choice><reg>ἐξεδόμην</reg><orig>ἐξετόμη</orig></choice> σοι πρὸς ἀσφάλειαν καὶ εἰς τὴν <choice><reg>ἔκτισιν</reg><orig>ἔκτησιν</orig></choice> τοῦ προστίμου ταύτην <add place="above">τὴν διάλυσιν</add>
+<lb n="31"/>πάντων μου τῶν <hi rend="diaeresis">ὑ</hi>παρχόντων καὶ <hi rend="diaeresis">ὑ</hi>παρξόντων πραγμάτων κινητῶν
+<lb n="32"/><supplied reason="lost">τ</supplied>ε κ<unclear>αὶ</unclear> <unclear>ἀκινή</unclear>των καὶ <choice><reg>αὐτοκινήτων</reg><orig>αὐτωκινήτων</orig></choice> γενικῶς καὶ <supplied reason="omitted">ἰδικῶς ἐν παντὶ</supplied> <choice><reg>εἴδει</reg><orig><hi rend="diaeresis">ἴ</hi>δι</orig></choice> καὶ γένει ἐνεχύρου <unclear>λό</unclear>γῳ
+<lb n="33"/><unclear>καὶ</unclear> <unclear>ὑ</unclear><supplied reason="lost">πο</supplied><unclear>θήκης</unclear> <unclear>δι</unclear>καίῳ καθάπερ <unclear>ἐκ</unclear> <unclear>δί</unclear>κης. <unclear>καὶ</unclear> <supplied reason="lost">ἐπερωτηθεὶς ταῦτα οὕτως ἔχειν</supplied>
+<lb n="34"/>ποι<unclear>εῖ</unclear>ν φυλάττ<unclear>ει</unclear>ν <unclear>ὡ</unclear>μολόγησα. <g type="stauros"/> <handShift new="m2"/><g type="stauros"/> Α<unclear>ὐ</unclear>ρήλι<unclear>ος</unclear> <unclear>Βασίλε</unclear>ιος Α<gap reason="illegible" quantity="2" unit="character"/><gap reason="lost" quantity="10" unit="character" precision="low"/>
+<lb n="35"/><gap reason="illegible" quantity="11" unit="character"/> <choice><reg>ἐθέμην</reg><orig>ἔθημεν</orig></choice> ταύτην τὴν <unclear>δ</unclear>ιάλησ<unclear>ιν</unclear> <unclear>κ</unclear><supplied reason="lost">αὶ</supplied> <unclear>σ</unclear><supplied reason="lost">τοιχεῖ</supplied>
+<lb n="36"/>μοι π<unclear>άν</unclear>τα τὰ <choice><reg>ἐγγεγραμμένα</reg><orig>ἐνγεγραμένοι</orig></choice>, καὶ ὤμο<unclear>σα</unclear> <unclear>τὸν</unclear> <supplied reason="lost">θεῖον ὅρκον</supplied>
+<lb n="37"/><supplied reason="lost">ὡς πρόκειται. <handShift new="m3"/><g type="stauros"/> Αὐρήλιος</supplied> <hi rend="diaeresis">Ἰ</hi>ωάνν<unclear>η</unclear>ς <unclear>Ἰσακ</unclear> <unclear>μαρτ</unclear>υ<supplied reason="lost">ρῶ ταύτῃ τῇ διαλύσει ἀκούσας</supplied>
+<lb n="38"/>παρὰ τοῦ θεμένου.  <handShift new="m4"/><g type="stauros"/> Αὐρήλιος Γεώργιος Ἑρμαυῶτος μαρτυρ<unclear>ῶ</unclear> <supplied reason="lost">ταύτῃ τῇ διαλύσει ἀ</supplied><unclear>κούσας</unclear>
+<lb n="39"/><unclear>παρὰ</unclear> <unclear>τοῦ</unclear> <supplied reason="lost">θεμένου</supplied> <unclear><g type="stauros"/></unclear> <handShift new="m5"/><unclear><g type="stauros"/></unclear> <supplied reason="lost">Αὐρ</supplied><unclear>ήλ</unclear>ιος Παῦλος Ἀπολλῶτος <choice><reg>κτήτωρ</reg><orig>κτήτορ</orig></choice> μαρτυρῶ
+<lb n="40"/>τ<unclear>αύ</unclear>τῃ τῇ διαλύσει<surplus>ς</surplus> ἀκούσας παρὰ τοῦ θεμένου <g type="stauros"/>
+<lb n="41"/><handShift new="m1"/><g type="stauros"/> δι’ ἐμοῦ Κωνσταντίνου σὺν <expan>θ<ex>εῷ</ex></expan> <expan>ταβελλ<ex>ίωνος</ex></expan> <expan>ἐγρ<ex>άφη</ex></expan> <g type="stauros"/><unclear><g type="stauros"/></unclear><g type="stauros"/>
+</ab></div>
+      </body>
+   </text>
+</TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.5/pylon.5.5.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.5/pylon.5.5.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Receipt for the poll tax from Elephantine</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.5.5</idno>
+            <idno type="ddb-hybrid">pylon;5;5</idno>
+            <idno type="HGV">998499</idno>
+            <idno type="TM">998499</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change who="https://papyri.info/editor/users/DDBDP" when="2024-07-11-05:00">Xwalk from Pylon
+                        </change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="grc" type="edition" xml:space="preserve"><ab>
+<lb n="1"/><expan>διέγ<ex>ραψεν</ex></expan> Παχνοῦβις 
+<lb n="2"/>Φανώφεως <expan>μη<ex>τρὸς</ex></expan> <expan>Τισάτ<ex>ιος</ex></expan>
+<lb n="3"/><expan>λα<unclear>ο</unclear><ex>γραφίας</ex></expan> τοῦ <num value="17">ιζ</num> <expan><ex>ἔτους</ex></expan> Τραιανοῦ 
+<lb n="4"/>τοῦ κυρίου <expan><ex>δραχμὰς</ex></expan> <num value="17">ιζ</num>, Παῦνι
+<lb n="5" rend="indent"/><num value="16">ιϛ</num> διὰ <expan>Πολυβίο<ex>υ</ex></expan>.
+</ab></div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV999/998492.xml
+++ b/HGV_meta_EpiDoc/HGV999/998492.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv998492">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Dialysis</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="TM">998492</idno>
+            <idno type="filename">998492</idno>
+            <idno type="ddb-filename">pylon.5.2</idno>
+            <idno type="ddb-hybrid">pylon;5;2</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>Dublin</settlement>
+                  </placeName>
+                  <collection>Chester Beatty Library</collection>
+                  <idno type="invNo">CBL Pap. 1016 02130</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Papyrus</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate notBefore="0610" notAfter="0612">610 - 612</origDate>
+                     <origPlace>Aphrodites Kome</origPlace>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName type="ancient"
+                                   ref="https://www.trismegistos.org/place/237 https://pleiades.stoa.org/places/756532">Aphrodites Kome</placeName>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96868"/>
+               </bibl>
+            </listBibl>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change who="https://papyri.info/editor/users/HGV" when="2024-07-11-05:00">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">Pylon</title>
+                  <biblScope n="1" type="volume">5</biblScope>
+                  <biblScope n="2" type="fascicle">(2024)</biblScope>
+                  <biblScope n="3" type="generic">Art. 2</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV999/998499.xml
+++ b/HGV_meta_EpiDoc/HGV999/998499.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv998499">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Receipt for the poll tax from Elephantine</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="TM">998499</idno>
+            <idno type="filename">998499</idno>
+            <idno type="ddb-filename">pylon.5.5</idno>
+            <idno type="ddb-hybrid">pylon;5;5</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>Ismailia</settlement>
+                  </placeName>
+                  <collection>Ismailia Museum</collection>
+                  <idno type="invNo">Inv. no. 451</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Ostrakon</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Elephantine</origPlace>
+                     <origDate when="0207-05-22">22. Mai 207</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p xml:id="geoCHJI22">
+                        <placeName type="ancient"
+                                   ref="https://pleiades.stoa.org/places/786021 https://www.trismegistos.org/place/621">Elephantine</placeName>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96862"/>
+               </bibl>
+            </listBibl>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Quittung</term>
+               <term n="2">Steuer (Kopfsteuer)</term>
+               <term n="3">Geld</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change who="https://papyri.info/editor/users/HGV" when="2024-07-11-05:00">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">Pylon</title>
+                  <biblScope n="1" type="volume">5</biblScope>
+                  <biblScope n="2" type="fascicle">(2024)</biblScope>
+                  <biblScope n="3" type="generic">Art. 5</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_trans_EpiDoc/998492.xml
+++ b/HGV_trans_EpiDoc/998492.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title type="main">Dialysis</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">998492</idno>
+            <idno type="TM">998492</idno>
+            <idno type="HGV">998492</idno>
+            <idno type="ddb-hybrid">pylon;5;2</idno>
+            <availability>
+               <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p>The contents of this document are generated from SOSOL.</p>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change who="https://papyri.info/editor/users/HGV" when="2024-07-11-05:00">Xwalk from Pylon
+                        </change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="en" type="translation" xml:space="preserve">
+            <p>… [Aurelius Basileios], landowner, from the village of Aphrodite in the Antaiopolite nome, to Aurelios … son of Victor, dealer in copper ware, from the same village of Aphrodite, greetings. Since, some time ago, through the written sale made by my maternal brothers with regard to their share and my share of my mother’s entire lot and they are acting as guarantors for me  ... of the deed drawn up by them in your name which remains valid wherever produced; and now that I have reached the legal age and for this reason you have sought from me the written agreement, [I have come] accordingly to this written agreement [by which I acknowledge that] henceforth no one has any claim against you at all with regard to this written settlement concerning my entire share of the entire granary named Psimanobet with everything and appurtenances and adjoining parts of the same granary in virtue of the written sale which was made for you by my aforementioned brothers Kollouthos and Christophorios on their behalf and on mine, which remains valid wherever produced. If we should at any moment or time want to withdraw (from the sale) ... in relation to the above share of mine of the above granary, neither I nor any of my heirs or co-heirs will withdraw (?) ... on this matter [and I agree to pay] on account of the stipulated penalty and transgression, twenty gold solidi, total 20 gold solidi, to be demanded as a matter of fact and with full legal power, and with what belongs to this settlement, it being valid wherever produced. And for your fuller assurance swearing, by almighty god and by the victory and preservation of our most pious and serene and god-crowned masters Flavii Heraclius and Aelia Eudokia, the perpetual Augusti and Imperatores and greatest Benefactors, to preserve this agreement permanently, unbroken and undisturbed, and in force wherever it is produced, which I have of my own free will and consent deposited for you in the public registry as a single deed, free of violence, deceit, all fraud, intimidation, all trickery, and completed according to the laws with my subscription, followed in order by those customary witnesses who have upon my request borne witness; and I have surrendered this settlement for you as a security and for the payment of the penalty, [and I mortgaged] all my possessions present and future, movable and immovable and live-stock, generally and severally, [in every class and] kind, by way of pledge and by right of mortgage as though by decree of court. And [having been asked the formal question] I have consented that these things are so, to do and to preserve.  I, Aurelios Basileios ... have made this settlement, and I agree with all that is written herein, and I have sworn the divine oath, [as aforementioned]. I, Ioannes son of Isak ... [bear witness to this settlement having heard it] from the party.  I, Aurelios Georgios son of Hermauos bear witness [to this agreement] having heard it from the party. I, Aurelios Paulos son of Apollos, landowner, bear witness to this agreement having heard it from the party. Written by me, Konstantinos, God willing, tabellio </p>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_trans_EpiDoc/998499.xml
+++ b/HGV_trans_EpiDoc/998499.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>
+               <title type="main">Receipt for the poll tax from Elephantine</title>
+            </title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">998499</idno>
+            <idno type="TM">998499</idno>
+            <idno type="HGV">998499</idno>
+            <idno type="ddb-hybrid">pylon;5;5</idno>
+            <availability>
+               <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p>The contents of this document are generated from SOSOL.</p>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change who="https://papyri.info/editor/users/HGV" when="2024-07-11-05:00">Xwalk from Pylon
+                        </change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="en" type="translation" xml:space="preserve">
+            <p>
+               Pachnoubis, son of Phanophis, whose mother is Tisatis, paid 17 drachmas for the poll tax for year 17 of Trajan the lord. Pauni 16, though Polybios.
+            </p>
+         </div>
+      </body>
+   </text>
+</TEI>


### PR DESCRIPTION
Thanks to the power of [`XSLT`](https://github.com/jcowey/P3/blob/master/xslt/pylonPostFormatting.xsl), these commits Xwalk new material from [Pylon 5](https://journals.ub.uni-heidelberg.de/index.php/pylon/issue/view/7074) into `PN`. Only two notes need to be added:

1. HGV keywords were not supplied originally and so are missing here
2. Lougovaya's translation was formatted for Pylon in a table, and requires further adjustment before deposit in `PN`.