### PR TITLE
Root element `<bibl>` typo Pylon 5

### DIFF
--- a/Biblio/97/96860.xml
+++ b/Biblio/97/96860.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96860">
-      <title level="a" type="main">An Inscription from the Reign of Probus: Reflections on the Port of Berenike in the Third Century CE</title>
-      <author n="1">
-         <forename>Rodney</forename>
-         <surname>Ast</surname>
-      </author>
-      <date>2024</date>
-      <biblScope type="issue">5</biblScope>
-      <biblScope type="article" n="6">Article 6</biblScope>
-      <ptr target="https://doi.org/10.48631/pylon.2024.5.105730"/>
-      <relatedItem type="appearsIn" n="1">
-         <bibl>
-            <ptr target="https://papyri.info/biblio/2374"/>
-         </bibl>
-      </relatedItem>
-      <idno type="pi">96860</idno>
-   </bibl>
-</TEI>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" type="article" subtype="journal" xml:lang="en"
+   xml:id="b96860">
+   <title level="a" type="main">An Inscription from the Reign of Probus: Reflections on the Port of
+      Berenike in the Third Century CE</title>
+   <author n="1">
+      <forename>Rodney</forename>
+      <surname>Ast</surname>
+   </author>
+   <date>2024</date>
+   <biblScope type="issue">5</biblScope>
+   <biblScope type="article" n="6">Article 6</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2024.5.105730"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">96860</idno>
+</bibl>

--- a/Biblio/97/96861.xml
+++ b/Biblio/97/96861.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96861">
-      <title level="a" type="main">Edition of the Homeric Fragment P.Oxy. 4 758 descr. (Ε 583‒596)</title>
-      <author n="1">
-         <forename>Andrea</forename>
-         <surname>Bernini</surname>
-      </author>
-      <date>2024</date>
-      <biblScope type="issue">5</biblScope>
-      <biblScope type="article" n="4">Article 4</biblScope>
-      <ptr target="https://doi.org/10.48631/pylon.2024.5.105727"/>
-      <relatedItem type="appearsIn" n="1">
-         <bibl>
-            <ptr target="https://papyri.info/biblio/2374"/>
-         </bibl>
-      </relatedItem>
-      <idno type="pi">96861</idno>
-      <relatedItem type="mentions" n="1">
-         <bibl>
-            <title level="s" type="short">P.Oxy</title>
-            <biblScope type="vol">4</biblScope>
-            <biblScope type="num">758</biblScope>
-            <idno type="dclp">p.oxy;4;758</idno>
-         </bibl>
-      </relatedItem>
-   </bibl>
-</TEI>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" type="article" subtype="journal" xml:lang="en"
+   xml:id="b96861">
+   <title level="a" type="main">Edition of the Homeric Fragment P.Oxy. 4 758 descr. (Ε
+      583‒596)</title>
+   <author n="1">
+      <forename>Andrea</forename>
+      <surname>Bernini</surname>
+   </author>
+   <date>2024</date>
+   <biblScope type="issue">5</biblScope>
+   <biblScope type="article" n="4">Article 4</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2024.5.105727"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">96861</idno>
+   <relatedItem type="mentions" n="1">
+      <bibl>
+         <title level="s" type="short">P.Oxy</title>
+         <biblScope type="vol">4</biblScope>
+         <biblScope type="num">758</biblScope>
+         <idno type="dclp">p.oxy;4;758</idno>
+      </bibl>
+   </relatedItem>
+</bibl>

--- a/Biblio/97/96862.xml
+++ b/Biblio/97/96862.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96862">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" type="article" subtype="journal" xml:lang="en" xml:id="b96862">
       <title level="a" type="main">Another Receipt for the Poll Tax from Elephantine</title>
       <author n="1">
          <forename>Lincoln H.</forename>
@@ -27,4 +26,3 @@
          </bibl>
       </relatedItem>
    </bibl>
-</TEI>

--- a/Biblio/97/96863.xml
+++ b/Biblio/97/96863.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96863">
-      <title level="a" type="main">Notes on Papyri from Roman Egypt II</title>
-      <author n="1">
-         <forename>W. Graham</forename>
-         <surname>Claytor</surname>
-      </author>
-      <date>2024</date>
-      <biblScope type="issue">5</biblScope>
-      <biblScope type="article" n="10">Article 10</biblScope>
-      <ptr target="https://doi.org/10.48631/pylon.2024.5.105735"/>
-      <relatedItem type="appearsIn" n="1">
-         <bibl>
-            <ptr target="https://papyri.info/biblio/2374"/>
-         </bibl>
-      </relatedItem>
-      <idno type="pi">96863</idno>
-   </bibl>
-</TEI>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" type="article" subtype="journal" xml:lang="en"
+   xml:id="b96863">
+   <title level="a" type="main">Notes on Papyri from Roman Egypt II</title>
+   <author n="1">
+      <forename>W. Graham</forename>
+      <surname>Claytor</surname>
+   </author>
+   <date>2024</date>
+   <biblScope type="issue">5</biblScope>
+   <biblScope type="article" n="10">Article 10</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2024.5.105735"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">96863</idno>
+</bibl>

--- a/Biblio/97/96864.xml
+++ b/Biblio/97/96864.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <bibl type="article" subtype="journal" xml:lang="de" xml:id="b96864">
-      <title level="a" type="main">Wilckens Briefwechsel mit Eduard Schwartz zur Edition von P.Würzb. 1</title>
-      <author n="1">
-         <forename>Holger</forename>
-         <surname>Essler</surname>
-      </author>
-      <date>2024</date>
-      <biblScope type="issue">5</biblScope>
-      <biblScope type="article" n="3">Article 3</biblScope>
-      <ptr target="https://doi.org/10.48631/pylon.2024.5.105725"/>
-      <relatedItem type="appearsIn" n="1">
-         <bibl>
-            <ptr target="https://papyri.info/biblio/2374"/>
-         </bibl>
-      </relatedItem>
-      <idno type="pi">96864</idno>
-   </bibl>
-</TEI>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" type="article" subtype="journal" xml:lang="de"
+   xml:id="b96864">
+   <title level="a" type="main">Wilckens Briefwechsel mit Eduard Schwartz zur Edition von P.Würzb.
+      1</title>
+   <author n="1">
+      <forename>Holger</forename>
+      <surname>Essler</surname>
+   </author>
+   <date>2024</date>
+   <biblScope type="issue">5</biblScope>
+   <biblScope type="article" n="3">Article 3</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2024.5.105725"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">96864</idno>
+</bibl>

--- a/Biblio/97/96865.xml
+++ b/Biblio/97/96865.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96865">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" type="article" subtype="journal" xml:lang="en" xml:id="b96865">
       <title level="a" type="main">P.Ross.Georg. 2 13 and Other Corrections to Published Papyri</title>
       <author n="1">
          <forename>Lavinia</forename>
@@ -17,4 +16,3 @@
       </relatedItem>
       <idno type="pi">96865</idno>
    </bibl>
-</TEI>

--- a/Biblio/97/96866.xml
+++ b/Biblio/97/96866.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96866">
-      <title level="a" type="main">Zenon Papyri and Others: Letters of C.C. Edgar to H.I. Bell, 1919–1935 </title>
-      <author n="1">
-         <forename>Nikolaos</forename>
-         <surname>Gonis</surname>
-      </author>
-      <author n="2">
-         <forename>Anna</forename>
-         <surname>Szajbély</surname>
-      </author>
-      <date>2024</date>
-      <biblScope type="issue">5</biblScope>
-      <biblScope type="article" n="8">Article 8</biblScope>
-      <ptr target="https://doi.org/10.48631/pylon.2024.5.105733"/>
-      <relatedItem type="appearsIn" n="1">
-         <bibl>
-            <ptr target="https://papyri.info/biblio/2374"/>
-         </bibl>
-      </relatedItem>
-      <idno type="pi">96866</idno>
-   </bibl>
-</TEI>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" type="article" subtype="journal" xml:lang="en"
+   xml:id="b96866">
+   <title level="a" type="main">Zenon Papyri and Others: Letters of C.C. Edgar to H.I. Bell,
+      1919–1935 </title>
+   <author n="1">
+      <forename>Nikolaos</forename>
+      <surname>Gonis</surname>
+   </author>
+   <author n="2">
+      <forename>Anna</forename>
+      <surname>Szajbély</surname>
+   </author>
+   <date>2024</date>
+   <biblScope type="issue">5</biblScope>
+   <biblScope type="article" n="8">Article 8</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2024.5.105733"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">96866</idno>
+</bibl>

--- a/Biblio/97/96867.xml
+++ b/Biblio/97/96867.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96867">
-      <title level="a" type="main">School Tablet with Divisions and Demonstrations in the Chester Beatty Library</title>
-      <author n="1">
-         <forename>Julia</forename>
-         <surname>Lougovaya</surname>
-      </author>
-      <date>2024</date>
-      <biblScope type="issue">5</biblScope>
-      <biblScope type="article" n="1">Article 1</biblScope>
-      <ptr target="https://doi.org/10.48631/pylon.2024.5.105710"/>
-      <relatedItem type="appearsIn" n="1">
-         <bibl>
-            <ptr target="https://papyri.info/biblio/2374"/>
-         </bibl>
-      </relatedItem>
-      <idno type="pi">96867</idno>
-      <relatedItem type="mentions" n="1">
-         <bibl>
-            <title level="s" type="short">Pylon</title>
-            <biblScope type="vol">5</biblScope>
-            <biblScope type="num">1</biblScope>
-            <idno type="dclp">pylon;5;1</idno>
-         </bibl>
-      </relatedItem>
-   </bibl>
-</TEI>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" type="article" subtype="journal" xml:lang="en"
+   xml:id="b96867">
+   <title level="a" type="main">School Tablet with Divisions and Demonstrations in the Chester
+      Beatty Library</title>
+   <author n="1">
+      <forename>Julia</forename>
+      <surname>Lougovaya</surname>
+   </author>
+   <date>2024</date>
+   <biblScope type="issue">5</biblScope>
+   <biblScope type="article" n="1">Article 1</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2024.5.105710"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">96867</idno>
+   <relatedItem type="mentions" n="1">
+      <bibl>
+         <title level="s" type="short">Pylon</title>
+         <biblScope type="vol">5</biblScope>
+         <biblScope type="num">1</biblScope>
+         <idno type="dclp">pylon;5;1</idno>
+      </bibl>
+   </relatedItem>
+</bibl>

--- a/Biblio/97/96868.xml
+++ b/Biblio/97/96868.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <bibl type="article" subtype="journal" xml:lang="en" xml:id="b96868">
-      <title level="a" type="main">Selling an Inheritance for an Under-age Owner in 7th Century Aphrodite </title>
-      <author n="1">
-         <forename>Maria</forename>
-         <surname>Nowak</surname>
-      </author>
-      <author n="2">
-         <forename>Brian</forename>
-         <surname>McGing</surname>
-      </author>
-      <date>2024</date>
-      <biblScope type="issue">5</biblScope>
-      <biblScope type="article" n="2">Article 2</biblScope>
-      <ptr target="https://doi.org/10.48631/pylon.2024.5.105716"/>
-      <relatedItem type="appearsIn" n="1">
-         <bibl>
-            <ptr target="https://papyri.info/biblio/2374"/>
-         </bibl>
-      </relatedItem>
-      <idno type="pi">96868</idno>
-   </bibl>
-</TEI>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" type="article" subtype="journal" xml:lang="en"
+   xml:id="b96868">
+   <title level="a" type="main">Selling an Inheritance for an Under-age Owner in 7th Century
+      Aphrodite </title>
+   <author n="1">
+      <forename>Maria</forename>
+      <surname>Nowak</surname>
+   </author>
+   <author n="2">
+      <forename>Brian</forename>
+      <surname>McGing</surname>
+   </author>
+   <date>2024</date>
+   <biblScope type="issue">5</biblScope>
+   <biblScope type="article" n="2">Article 2</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2024.5.105716"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">96868</idno>
+</bibl>

--- a/Biblio/97/96869.xml
+++ b/Biblio/97/96869.xml
@@ -1,40 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <bibl type="article" subtype="journal" xml:lang="de" xml:id="b96869">
-      <title level="a" type="main">Zwei Ilias-Papyri aus Yale</title>
-      <author n="1">
-         <forename>Moritz</forename>
-         <surname>Schwemer</surname>
-      </author>
-      <author n="2">
-         <forename>Johanna</forename>
-         <surname>Strauss</surname>
-      </author>
-      <date>2024</date>
-      <biblScope type="issue">5</biblScope>
-      <biblScope type="article" n="7">Article 7</biblScope>
-      <ptr target="https://doi.org/10.48631/pylon.2024.5.105732"/>
-      <relatedItem type="appearsIn" n="1">
-         <bibl>
-            <ptr target="https://papyri.info/biblio/2374"/>
-         </bibl>
-      </relatedItem>
-      <idno type="pi">96869</idno>
-      <relatedItem type="mentions" n="1">
-         <bibl>
-            <title level="s" type="short">P.Oxy</title>
-            <biblScope type="vol">6</biblScope>
-            <biblScope type="num">952</biblScope>
-            <idno type="dclp">p.oxy;6;952</idno>
-         </bibl>
-      </relatedItem>
-      <relatedItem type="mentions" n="2">
-         <bibl>
-            <title level="s" type="short">P.Yale</title>
-            <biblScope type="vol">1</biblScope>
-            <biblScope type="num">12</biblScope>
-            <idno type="dclp">p.yale;1;12</idno>
-         </bibl>
-      </relatedItem>
-   </bibl>
-</TEI>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" type="article" subtype="journal" xml:lang="de"
+   xml:id="b96869">
+   <title level="a" type="main">Zwei Ilias-Papyri aus Yale</title>
+   <author n="1">
+      <forename>Moritz</forename>
+      <surname>Schwemer</surname>
+   </author>
+   <author n="2">
+      <forename>Johanna</forename>
+      <surname>Strauss</surname>
+   </author>
+   <date>2024</date>
+   <biblScope type="issue">5</biblScope>
+   <biblScope type="article" n="7">Article 7</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2024.5.105732"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">96869</idno>
+   <relatedItem type="mentions" n="1">
+      <bibl>
+         <title level="s" type="short">P.Oxy</title>
+         <biblScope type="vol">6</biblScope>
+         <biblScope type="num">952</biblScope>
+         <idno type="dclp">p.oxy;6;952</idno>
+      </bibl>
+   </relatedItem>
+   <relatedItem type="mentions" n="2">
+      <bibl>
+         <title level="s" type="short">P.Yale</title>
+         <biblScope type="vol">1</biblScope>
+         <biblScope type="num">12</biblScope>
+         <idno type="dclp">p.yale;1;12</idno>
+      </bibl>
+   </relatedItem>
+</bibl>


### PR DESCRIPTION
Oddly for TEI documents, files in `Biblio` don't use `<TEI>` as their root element (but rather `<bibl>`). I've updated the files for Pylon 5 (and also my `XSLT`) to account for this peculiarity.