### PR TITLE
XWalk Tyche 36-37 to HGV

### DIFF
--- a/APIS/columbia/xml/columbia.apis.p1723.xml
+++ b/APIS/columbia/xml/columbia.apis.p1723.xml
@@ -9,7 +9,10 @@
          <publicationStmt>
             <authority>APIS</authority>
             <idno type="controlNo">(NNC)p1723</idno>
-           <idno type="apisid">columbia.apis.p1723</idno>
+            <idno type="apisid">columbia.apis.p1723</idno>
+            <idno type="TM">321187</idno>
+            <idno type="HGV">321187</idno>
+            <idno type="ddb-hybrid">tyche;36;133</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/HGV_meta_EpiDoc/HGV322/321187.xml
+++ b/HGV_meta_EpiDoc/HGV322/321187.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>An Oxyrhynchan Deed of Surety for a Registered Sailor  from the Dossier of Flavia Anastasia</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">321187</idno>
+            <idno type="TM">321187</idno>
+            <idno type="ddb-filename">tyche.36.133</idno>
+            <idno type="ddb-hybrid">tyche;36;133</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>New York</settlement>
+                  </placeName>
+                  <collection>Columbia University</collection>
+                  <idno type="invNo">P.Col. inv. 523</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Papyrus</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Oxyrhynchus</origPlace>
+                     <origDate when="0571-05-16">16. Mai 571</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName n="1" type="ancient"
+                                   ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchus</placeName>
+                        <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96879"/>
+                  <biblScope type="pp">133</biblScope>
+               </bibl>
+            </listBibl>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Bürgschaft</term>
+               <term n="2">Gestellung</term>
+               <term n="3">Seemann</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2024-08-03" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">Tyche</title>
+                  <biblScope type="volume">36</biblScope>
+                  <biblScope type="fascicle">(2021)</biblScope>
+                  <biblScope type="pages">S. 133</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">Tafel 22, 23</bibl>
+            </p>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV370/369457.xml
+++ b/HGV_meta_EpiDoc/HGV370/369457.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Loan of Money from a signifer</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">369457</idno>
+            <idno type="TM">369457</idno>
+            <idno type="ddb-filename">tyche.37.94</idno>
+            <idno type="ddb-hybrid">tyche;37;94</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>London</settlement>
+                  </placeName>
+                  <collection>British Library</collection>
+                  <idno type="invNo">Papyrus 2288</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Papyrus</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Antinoites</origPlace>
+                     <origDate notBefore="0302-09-28" notAfter="0302-10-27">28. Sept. - 27. Okt. 302</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName type="ancient" subtype="nome"
+                                   ref="https://www.trismegistos.org/place/2973 https://pleiades.stoa.org/places/756517">Antinoites</placeName>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96886"/>
+                  <biblScope type="pp">94</biblScope>
+               </bibl>
+            </listBibl>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Darlehen</term>
+               <term n="2">Geld</term>
+               <term n="3">Signifer</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2024-08-03" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">Tyche</title>
+                  <biblScope type="volume">37</biblScope>
+                  <biblScope type="fascicle">(2022)</biblScope>
+                  <biblScope type="pages">S. 94</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">Tafel 13</bibl>
+            </p>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV988/987075.xml
+++ b/HGV_meta_EpiDoc/HGV988/987075.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Account of Tax Payments in Money</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">987075</idno>
+            <idno type="TM">987075</idno>
+            <idno type="ddb-filename">tyche.36.65_1</idno>
+            <idno type="ddb-hybrid">tyche;36;65_1</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>Philadelphia</settlement>
+                  </placeName>
+                  <collection>University of Pennsylvania Museum</collection>
+                  <idno type="invNo">E 16760</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Papyrus</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Theadelpheia (Arsinoites)</origPlace>
+                     <origDate notBefore="0300" notAfter="0312">
+                        ca. 300 - 312
+                        <precision match="../@notBefore" degree="0.5"/>
+                             </origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName n="1" type="ancient"
+                                   ref="https://www.trismegistos.org/place/2349 https://pleiades.stoa.org/places/737081">Theadelpheia</placeName>
+                        <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96851"/>
+                  <biblScope type="pp">65</biblScope>
+               </bibl>
+            </listBibl>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Abrechnung</term>
+               <term n="2">Steuer</term>
+               <term n="3">Geld</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2024-08-03" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">Tyche</title>
+                  <biblScope type="volume">36</biblScope>
+                  <biblScope type="fascicle">(2021)</biblScope>
+                  <biblScope type="pages">S. 65</biblScope>
+                  <biblScope type="number">Nr. 1</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">Tafel 6</bibl>
+            </p>
+         </div>
+         <div type="figure">
+            <p>
+               <figure n="1">
+                  <graphic url="https://www.penn.museum/collections/object/81564"/>
+               </figure>
+            </p>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV988/987076.xml
+++ b/HGV_meta_EpiDoc/HGV988/987076.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Lease of Goats</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">987076</idno>
+            <idno type="TM">987076</idno>
+            <idno type="ddb-filename">tyche.36.68_2</idno>
+            <idno type="ddb-hybrid">tyche;36;68_2</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>Philadelphia</settlement>
+                  </placeName>
+                  <collection>University of Pennsylvania Museum</collection>
+                  <idno type="invNo">E 16746</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Papyrus</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Theadelpheia (Arsinoites)</origPlace>
+                     <origDate notBefore="0318-03-27" notAfter="0318-04-25">27. März - 25. Apr. 318</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName n="1" type="ancient"
+                                   ref="https://www.trismegistos.org/place/2349 https://pleiades.stoa.org/places/737081">Theadelpheia</placeName>
+                        <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96851"/>
+                  <biblScope type="pp">68</biblScope>
+               </bibl>
+            </listBibl>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Mietvertrag</term>
+               <term n="2">Ziegen</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2024-08-03" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">Tyche</title>
+                  <biblScope type="volume">36</biblScope>
+                  <biblScope type="fascicle">(2021)</biblScope>
+                  <biblScope type="pages">S. 68</biblScope>
+                  <biblScope type="number">Nr. 2</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">Tafel 7</bibl>
+            </p>
+         </div>
+         <div type="figure">
+            <p>
+               <figure n="1">
+                  <graphic url="https://www.penn.museum/collections/object/151436"/>
+               </figure>
+            </p>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV988/987081.xml
+++ b/HGV_meta_EpiDoc/HGV988/987081.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>A Greek Receipt for the Payment of diagraphon from the Dossier of Ioulios</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">987081</idno>
+            <idno type="TM">987081</idno>
+            <idno type="ddb-filename">tyche.36.84</idno>
+            <idno type="ddb-hybrid">tyche;36;84</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>Vienna</settlement>
+                  </placeName>
+                  <collection>Nationalbibliothek</collection>
+                  <idno type="invNo">P.Vindob. G 31268</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Papyrus</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Arsinoiton Polis (Arsinoites)</origPlace>
+                     <origDate notBefore="0651" notAfter="0700" precision="low">2. Hälfte VII</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName n="1" type="ancient"
+                                   ref="https://www.trismegistos.org/place/327 https://pleiades.stoa.org/places/736948">Arsinoiton Polis</placeName>
+                        <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/182 https://pleiades.stoa.org/places/736888">Arsinoites</placeName>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96854"/>
+                  <biblScope type="pp">84</biblScope>
+               </bibl>
+            </listBibl>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Quittung</term>
+               <term n="2">Steuer (Kopfsteuer)</term>
+               <term n="3">diagraphon</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2024-08-03" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">Tyche</title>
+                  <biblScope type="volume">36</biblScope>
+                  <biblScope type="fascicle">(2021)</biblScope>
+                  <biblScope type="pages">S. 84</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">Tafel 11</bibl>
+            </p>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV988/987082.xml
+++ b/HGV_meta_EpiDoc/HGV988/987082.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Contratto di lavoro per un muratore salariato</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">987082</idno>
+            <idno type="TM">987082</idno>
+            <idno type="ddb-filename">tyche.36.111</idno>
+            <idno type="ddb-hybrid">tyche;36;111</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>Milan</settlement>
+                  </placeName>
+                  <collection>Università Statale</collection>
+                  <idno type="invNo">P.Mil.Vogl. inv. 1316</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Papyrus</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Antinoopolis</origPlace>
+                     <origDate notBefore="0586-10-17" notAfter="0586-10-26">17. - 26. Okt. 586</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName type="ancient"
+                                   ref="https://www.trismegistos.org/place/2774 https://pleiades.stoa.org/places/756518">Antinoopolis</placeName>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96857"/>
+                  <biblScope type="pp">111</biblScope>
+               </bibl>
+            </listBibl>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Vertrag</term>
+               <term n="2">Lohnarbeit</term>
+               <term n="3">Maurer</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2024-08-03" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">Tyche</title>
+                  <biblScope type="volume">36</biblScope>
+                  <biblScope type="fascicle">(2021)</biblScope>
+                  <biblScope type="pages">S. 111</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">Tafel 16, 17</bibl>
+            </p>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV988/987083.xml
+++ b/HGV_meta_EpiDoc/HGV988/987083.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Ein neuer Papyrus des Flavius Johannes,  comes consistorianus</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">987083</idno>
+            <idno type="TM">987083</idno>
+            <idno type="ddb-filename">tyche.36.139</idno>
+            <idno type="ddb-hybrid">tyche;36;139</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>Leipzig</settlement>
+                  </placeName>
+                  <collection>Universität</collection>
+                  <idno type="invNo">P.Lips. inv. 536</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Papyrus</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Oxyrhynchus (Oxyrhynchites)</origPlace>
+                     <origDate when="0466-12-23">23. Dez. 466</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName n="1" type="ancient"
+                                   ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchus</placeName>
+                        <placeName n="2" type="ancient" subtype="nome" ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+                  </p>
+                  </provenance>
+               </history>
+            </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96880"/>
+                  <biblScope type="pp">139</biblScope>
+               </bibl>
+            </listBibl>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Vertrag</term>
+               <term n="2">Darlehen (Vorauszahlung von Lohn, Prochreia)</term>
+               <term n="3">Arbeit</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2024-08-03" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">Tyche</title>
+                  <biblScope type="volume">36</biblScope>
+                  <biblScope type="fascicle">(2021)</biblScope>
+                  <biblScope type="pages">S. 139</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">Tafel 24, 25</bibl>
+            </p>
+         </div>
+         <div type="figure">
+            <p>
+               <figure n="1">
+                  <graphic url="https://www.papyrusportal.de/receive/UBLPapyri_schrift_00003280"/>
+               </figure>
+            </p>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV999/998117.xml
+++ b/HGV_meta_EpiDoc/HGV999/998117.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Model documents</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">998117</idno>
+            <idno type="TM">998117</idno>
+            <idno type="ddb-filename">tyche.37.205</idno>
+            <idno type="ddb-hybrid">tyche;37;205</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>Vienna</settlement>
+                  </placeName>
+                  <collection>Nationalbibliothek</collection>
+                  <idno type="invNo">P.Vindob. G 40454 R</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Papyrus</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>unbekannt</origPlace>
+                     <origDate notBefore="0001" notAfter="0100" precision="low">I</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/96897"/>
+                  <biblScope type="pp">205</biblScope>
+               </bibl>
+            </listBibl>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Modell</term>
+               <term n="2">Vertrag</term>
+               <term n="3">Synchoresis</term>
+               <term n="4">Übertragung eines Darlehens</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2024-08-03" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">Tyche</title>
+                  <biblScope type="volume">37</biblScope>
+                  <biblScope type="fascicle">(2022)</biblScope>
+                  <biblScope type="pages">S. 205</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">Tafel 23, 24</bibl>
+            </p>
+         </div>
+      </body>
+   </text>
+</TEI>


### PR DESCRIPTION
Added new files from Tyche 36 (2021) and 37 (2022) to HGV via XWalk, and updated the JournalEntryProgress spreadsheet to this effect.