### PR TITLE
P.Customs 4 and P.Mich. XV 689 disentangled

### DIFF
--- a/APIS/michigan/xml/michigan.apis.2633.xml
+++ b/APIS/michigan/xml/michigan.apis.2633.xml
@@ -13,10 +13,7 @@
             <idno type="controlNo">(MiU)2633</idno>
             <idno type="HGV">10651</idno>
             <idno type="TM">10651</idno>
-            <idno type="HGV">12319</idno>
-            <idno type="TM">12319</idno>
             <idno type="ddb-hybrid">p.customs;;4</idno>
-            <idno type="ddb-hybrid">p.mich;15;689</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>

--- a/HGV_meta_EpiDoc/HGV13/12319.xml
+++ b/HGV_meta_EpiDoc/HGV13/12319.xml
@@ -95,7 +95,7 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://quod.lib.umich.edu/a/apis/x-2633"/>
+                  <graphic url="http://quod.lib.umich.edu/a/apis/x-2632"/>
                </figure>
             </p>
          </div>


### PR DESCRIPTION
Disentangled P.Customs 4 and P.Mich. XV 689, wrongly merged in one APIS entry. Corrected link to digital image. Although they have the same inventory number, these are different papyri