### PR TITLE
Image links: new repository Milano Cattolica

### DIFF
--- a/HGV_meta_EpiDoc/HGV1/7.xml
+++ b/HGV_meta_EpiDoc/HGV1/7.xml
@@ -106,6 +106,13 @@
                <head xml:lang="de">Italienisch:</head>
                <bibl type="translations">A. Calderini, in: Recueil Champollion (1922), S. 677-678</bibl>
             </listBibl>
+            <div type="figure">
+            <p>
+               <figure>
+                  <graphic https://digitallibrary.unicatt.it/unicatt/0b02da82804d7ef7" />
+               </figure>
+            </p>
+         </div>
          </div>
       </body>
    </text>

--- a/HGV_meta_EpiDoc/HGV12/11885.xml
+++ b/HGV_meta_EpiDoc/HGV12/11885.xml
@@ -128,6 +128,13 @@
                <bibl type="illustration">Tavola XI</bibl>
             </p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://digitallibrary.unicatt.it/unicatt/0b02da82804db3a5" />
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV12/11889.xml
+++ b/HGV_meta_EpiDoc/HGV12/11889.xml
@@ -108,6 +108,13 @@
                <bibl type="illustration">Montevecchi, Papirologia, Tav. 32</bibl>
             </p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://digitallibrary.unicatt.it/unicatt/0b02da82804d7ef9"/>
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV12/11895.xml
+++ b/HGV_meta_EpiDoc/HGV12/11895.xml
@@ -104,6 +104,13 @@
                <bibl type="translations">Johnson, Roman Egypt (1936), S. 360, Nr. 198</bibl>
             </listBibl>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://digitallibrary.unicatt.it/unicatt/0b02da82804db3a2" />
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV12/11899.xml
+++ b/HGV_meta_EpiDoc/HGV12/11899.xml
@@ -96,6 +96,13 @@
                <bibl type="illustration">Tavola IX</bibl>
             </p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://digitallibrary.unicatt.it/unicatt/0b02da82804db3a3" />
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV12/11900.xml
+++ b/HGV_meta_EpiDoc/HGV12/11900.xml
@@ -144,6 +144,13 @@
                <bibl type="illustration">Tavola X</bibl>
             </p>
          </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://digitallibrary.unicatt.it/unicatt/0b02da82804db3a4" />
+               </figure>
+            </p>
+         </div>
       </body>
    </text>
 </TEI>


### PR DESCRIPTION
Added some links from Milano Cattolica repository (https://archivi-biblioteca.unicatt.it/patrimonio/af834bcb-2e1a-486c-a6b3-ce809e7f7a6e/baar-mi-pap-fondo-papiri-universita-cattolica)