### PR TITLE
updated image links for some BiPap papyri

### DIFF
--- a/HGV_meta_EpiDoc/HGV19/18403.xml
+++ b/HGV_meta_EpiDoc/HGV19/18403.xml
@@ -105,7 +105,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://quod.lib.umich.edu/a/apis/x-3017"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-3017"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/SB_XVIII_13320.jpg"/>
                </figure>
                <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/SB_XVIII_13320.html"/>

--- a/HGV_meta_EpiDoc/HGV19/18428.xml
+++ b/HGV_meta_EpiDoc/HGV19/18428.xml
@@ -99,6 +99,12 @@
          <div type="figure">
             <p>
                <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Cair_Masp_III_67301_r_.jpg"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Cair_Masp_III_67301_v_.jpg"/>
+               </figure>
+               <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Cair_Masp_III_67301.html"/>
                </figure>
             </p>

--- a/HGV_meta_EpiDoc/HGV19/18430.xml
+++ b/HGV_meta_EpiDoc/HGV19/18430.xml
@@ -100,6 +100,9 @@
                   <graphic url="http://ipap.csad.ox.ac.uk/4DLink4/4DACTION/IPAPwebquery?vPub=P.Cair.Masp.&amp;vVo3=1&amp;vNum=67303"/>
                </figure>
                <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Cair_Masp_III_67303.jpg"/>
+               </figure>
+               <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Cair_Masp_III_67303.html"/>
                </figure>
             </p>

--- a/HGV_meta_EpiDoc/HGV19/18875.xml
+++ b/HGV_meta_EpiDoc/HGV19/18875.xml
@@ -104,6 +104,12 @@
                   <graphic url="http://ipap.csad.ox.ac.uk/4DLink4/4DACTION/IPAPwebquery?vPub=P.Cair.Masp.&amp;vVol=2&amp;vNum=67128"/>
                </figure>
                <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Cair_Masp_II_67128_r_.jpg"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Cair_Masp_II_67128_v_.jpg"/>
+               </figure>
+               <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Cair_Masp_II_67128.html"/>
                </figure>
             </p>

--- a/HGV_meta_EpiDoc/HGV19/18976.xml
+++ b/HGV_meta_EpiDoc/HGV19/18976.xml
@@ -110,6 +110,12 @@
                   <graphic url="http://ipap.csad.ox.ac.uk/4DLink4/4DACTION/IPAPwebquery?vPub=P.Cair.Masp.&amp;vVol=1&amp;vNum=67001"/>
                </figure>
                <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Cair_Masp_I_67001_1_1_.jpg"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Cair_Masp_I_67001_1_2_.jpg"/>
+               </figure>
+               <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Cair_Masp_I_67001.html"/>
                </figure>
             </p>

--- a/HGV_meta_EpiDoc/HGV20/19033.xml
+++ b/HGV_meta_EpiDoc/HGV20/19033.xml
@@ -102,6 +102,9 @@
                   <graphic url="http://ipap.csad.ox.ac.uk/4DLink4/4DACTION/IPAPwebquery?vPub=P.Cair.Masp.&amp;vVol=1&amp;vNum=67104"/>
                </figure>
                <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Cair_Masp_I_67104.jpg"/>
+               </figure>
+               <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Cair_Masp_I_67104.html"/>
                </figure>
             </p>

--- a/HGV_meta_EpiDoc/HGV20/19342.xml
+++ b/HGV_meta_EpiDoc/HGV20/19342.xml
@@ -97,10 +97,13 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Flor_III_280.html"/>
+                  <graphic url="https://www.psi-online.it/documents/pflor;3;280"/>
                </figure>
                <figure>
-                  <graphic url="http://www.psi-online.it/documents/pflor;3;280"/>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Flor_III_280.jpg"/>
+               </figure>
+               <figure>
+                  <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Flor_III_280.html"/>
                </figure>
             </p>
          </div>

--- a/HGV_meta_EpiDoc/HGV20/19708.xml
+++ b/HGV_meta_EpiDoc/HGV20/19708.xml
@@ -97,6 +97,12 @@
          <div type="figure">
             <p>
                <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Lond_V_1691_r_.jpg"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Lond_V_1691_v_.jpg"/>
+               </figure>
+               <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Lond_V_1691.html"/>
                </figure>
                <figure>

--- a/HGV_meta_EpiDoc/HGV20/19712.xml
+++ b/HGV_meta_EpiDoc/HGV20/19712.xml
@@ -103,6 +103,12 @@
          <div type="figure">
             <p>
                <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Lond_V_1694_r_.jpg"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Lond_V_1694_v_.jpg"/>
+               </figure>
+               <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Lond_V_1694.html"/>
                </figure>
                <figure>

--- a/HGV_meta_EpiDoc/HGV22/21361.xml
+++ b/HGV_meta_EpiDoc/HGV22/21361.xml
@@ -98,7 +98,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://quod.lib.umich.edu/a/apis/x-2309"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-2309"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Mich_XI_607.jpg"/>
                </figure>
                <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Mich_XI_607.html"/>

--- a/HGV_meta_EpiDoc/HGV22/21375.xml
+++ b/HGV_meta_EpiDoc/HGV22/21375.xml
@@ -106,7 +106,19 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://quod.lib.umich.edu/a/apis/x-3014"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-3014"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Mich_XIII_662_l_01_04_.jpg"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Mich_XIII_662_l_06_31_.jpg"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Mich_XIII_662_l_32_57_.jpg"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Mich_XIII_662_l_58_78_.jpg"/>
                </figure>
                <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Mich_XIII_662.html"/>

--- a/HGV_meta_EpiDoc/HGV22/21376.xml
+++ b/HGV_meta_EpiDoc/HGV22/21376.xml
@@ -108,7 +108,10 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://quod.lib.umich.edu/a/apis/x-3016"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-3016"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Mich_XIII_664.jpg"/>
                </figure>
                <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Mich_XIII_664.html"/>

--- a/HGV_meta_EpiDoc/HGV22/21378.xml
+++ b/HGV_meta_EpiDoc/HGV22/21378.xml
@@ -110,7 +110,13 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://quod.lib.umich.edu/a/apis/x-3018"/>
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-3018"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Mich_XIII_666_l_01_20_.jpg"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Mich_XIII_666_l_19_41_.jpg"/>
                </figure>
                <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Mich_XIII_666.html"/>

--- a/HGV_meta_EpiDoc/HGV22/21422.xml
+++ b/HGV_meta_EpiDoc/HGV22/21422.xml
@@ -100,6 +100,9 @@
          <div type="figure">
             <p>
                <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Michael_46.jpg"/>
+               </figure>
+               <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Michael_46.html"/>
                </figure>
             </p>

--- a/HGV_meta_EpiDoc/HGV79/78091.xml
+++ b/HGV_meta_EpiDoc/HGV79/78091.xml
@@ -94,7 +94,13 @@
          <div type="figure">
             <p>
                <figure>
-                  <graphic url="http://berlpap.smb.museum/00220/"/>
+                  <graphic url="https://berlpap.smb.museum/00220/"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Bingen_132_r_.jpg"/>
+               </figure>
+               <figure>
+                  <graphic url="https://bipab.aphrodito.info/images/grandes_images/P_Bingen_132_v_.jpg"/>
                </figure>
                <figure>
                   <graphic url="http://www.misha.fr/papyrus_bipab/pages_html/P_Bingen_132.html"/>


### PR DESCRIPTION
The links to images from the website http://www.misha.fr are no longer working.

I have added links to https://bipab.aphrodito.info/ for a few papyri in grammateus.