### PR TITLE
Xwalk from Pylon 7

### DIFF
--- a/Biblio/98/97293.xml
+++ b/Biblio/98/97293.xml
@@ -1,52 +1,54 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97293" type="article" xml:lang="en" subtype="journal">
-  <title level="a" type="main">Three Homeric Descripta from Karanis</title>
-  <author n="1">
-    <forename>C. Michael</forename>
-    <surname>Sampson</surname>
-  </author>
-  <author n="2">
-    <forename>T. Mae</forename>
-    <surname>Sawatzky</surname>
-  </author>
-  <author n="3">
-    <forename>Colin</forename>
-    <surname>Shields</surname>
-  </author>
-  <date>2025</date>
-  <relatedItem type="appearsIn" n="1">
-    <bibl>
-      <ptr target="https://papyri.info/biblio/2374"/>
-      <!-- ignore - start, i.e. SoSOL users may not edit this  -->
-      <!-- ignore - stop -->
-    </bibl>
-  </relatedItem>
-  <relatedItem type="mentions" n="1">
-    <bibl>
-      <title level="s" type="short">P. Fay.</title>
-      <biblScope type="num">141</biblScope>
-      <biblScope type="generic">descr.</biblScope>
-      <idno type="dclp">60315</idno>
-    </bibl>
-  </relatedItem>
-  <relatedItem type="mentions" n="2">
-    <bibl>
-      <title level="s" type="short">Pylon</title>
-      <biblScope type="vol">7</biblScope>
-      <biblScope type="num">1</biblScope>
-      <idno type="dclp">60326</idno>
-      <idno type="invNo">P.Vindob. G 19768</idno>
-    </bibl>
-  </relatedItem>
-  <relatedItem type="mentions" n="3">
-    <bibl>
-      <title level="s" type="short">Pylon</title>
-      <biblScope type="vol">7</biblScope>
-      <biblScope type="num">1</biblScope>
-      <idno type="dclp">60366</idno>
-      <idno type="invNo">P.Vindob. G 19791+ 19794</idno>
-    </bibl>
-  </relatedItem>
-  <biblScope type="issue">7</biblScope>
-  <idno type="pi">97293</idno>
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0"
+      type="article"
+      subtype="journal"
+      xml:lang="en"
+      xml:id="b97293">
+   <title level="a" type="main">Three Homeric Descripta from Karanis</title>
+   <author n="1">
+      <forename>C. Michael</forename>
+      <surname>Sampson</surname>
+   </author>
+   <author n="2">
+      <forename>T. Mae</forename>
+      <surname>Sawatzky</surname>
+   </author>
+   <author n="3">
+      <forename>Colin</forename>
+      <surname>Shields</surname>
+   </author>
+   <date>2025</date>
+   <biblScope type="issue">7</biblScope>
+   <biblScope type="article" n="1">Article 1</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2025.7.112017"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">97293</idno>
+   <relatedItem type="mentions" n="1">
+      <bibl>
+         <title level="s" type="short">P. Fay.</title>
+         <biblScope type="num">141</biblScope>
+         <biblScope type="generic">descr.</biblScope>
+         <idno type="dclp">p.fay;;141</idno>
+      </bibl>
+   </relatedItem>
+   <relatedItem type="mentions" n="2">
+      <bibl>
+         <title level="s" type="short">Pylon</title>
+         <biblScope type="vol">7</biblScope>
+         <biblScope type="num">1</biblScope>
+         <idno type="dclp">pylon;7;1_2</idno>
+      </bibl>
+   </relatedItem>
+   <relatedItem type="mentions" n="3">
+      <bibl>
+         <title level="s" type="short">Pylon</title>
+         <biblScope type="vol">7</biblScope>
+         <biblScope type="num">1</biblScope>
+         <idno type="dclp">pylon;7;1_3</idno>
+      </bibl>
+   </relatedItem>
 </bibl>

--- a/Biblio/98/97397.xml
+++ b/Biblio/98/97397.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0"
+      type="article"
+      subtype="journal"
+      xml:lang="en"
+      xml:id="b97397">
+   <title level="a" type="main">An Arabic Private Letter from the Eighth Century</title>
+   <author n="1">
+      <forename>Lajos</forename>
+      <surname>Berkes</surname>
+   </author>
+   <date>2025</date>
+   <biblScope type="issue">7</biblScope>
+   <biblScope type="article" n="3">Article 3</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2025.7.112019"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">97397</idno>
+   <relatedItem type="mentions" n="1">
+      <bibl>
+         <title level="s" type="short">Pylon</title>
+         <biblScope type="vol">7</biblScope>
+         <biblScope type="num">3</biblScope>
+         <idno type="ddb">pylon;7;3</idno>
+         <idno type="tm">704976</idno>
+         <idno type="invNo">P.Heid. inv. Arab. 734</idno>
+      </bibl>
+   </relatedItem>
+</bibl>

--- a/Biblio/98/97398.xml
+++ b/Biblio/98/97398.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0"
+      type="article"
+      subtype="journal"
+      xml:lang="en"
+      xml:id="b97398">
+   <title level="a" type="main">An 8th-Century Heracleopolite compromissum from the Bodleian Library</title>
+   <author n="1">
+      <forename>Sophie</forename>
+      <surname>Kovarik</surname>
+   </author>
+   <date>2025</date>
+   <biblScope type="issue">7</biblScope>
+   <biblScope type="article" n="4">Article 4</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2025.7.112020"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">97398</idno>
+   <relatedItem type="mentions" n="1">
+      <bibl>
+         <title level="s" type="short">Pylon</title>
+         <biblScope type="vol">7</biblScope>
+         <biblScope type="num">4</biblScope>
+         <idno type="ddb">pylon;7;4</idno>
+         <idno type="tm">1000275</idno>
+         <idno type="invNo">MS. Gr. Class. e 135 (P)</idno>
+      </bibl>
+   </relatedItem>
+</bibl>

--- a/Biblio/98/97399.xml
+++ b/Biblio/98/97399.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0"
+      type="article"
+      subtype="journal"
+      xml:lang="en"
+      xml:id="b97399">
+   <title level="a" type="main">A Late Antique Receipt for Grain from the Hermopolite Nome </title>
+   <author n="1">
+      <forename>Lincoln H.</forename>
+      <surname>Blumell</surname>
+   </author>
+   <date>2025</date>
+   <biblScope type="issue">7</biblScope>
+   <biblScope type="article" n="5">Article 5</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2025.7.112021"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">97399</idno>
+   <relatedItem type="mentions" n="1">
+      <bibl>
+         <title level="s" type="short">Pylon</title>
+         <biblScope type="vol">7</biblScope>
+         <biblScope type="num">5</biblScope>
+         <idno type="ddb">pylon;7;5</idno>
+         <idno type="tm">1000277</idno>
+         <idno type="invNo">P. von Scherling g. 211</idno>
+      </bibl>
+   </relatedItem>
+</bibl>

--- a/Biblio/98/97400.xml
+++ b/Biblio/98/97400.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0"
+      type="article"
+      subtype="journal"
+      xml:lang="de"
+      xml:id="b97400">
+   <title level="a" type="main">Wohnen im spätantiken Arsinoe: ein neuer Mietvertrag</title>
+   <author n="1">
+      <forename>Micha</forename>
+      <surname>Teufel</surname>
+   </author>
+   <date>2025</date>
+   <biblScope type="issue">7</biblScope>
+   <biblScope type="article" n="6">Article 6</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2025.7.112022"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">97400</idno>
+   <relatedItem type="mentions" n="1">
+      <bibl>
+         <title level="s" type="short">Pylon</title>
+         <biblScope type="vol">7</biblScope>
+         <biblScope type="num">7</biblScope>
+         <idno type="ddb">pylon;7;7</idno>
+         <idno type="tm">1000278</idno>
+         <idno type="invNo">P.Vindob. G 20941</idno>
+      </bibl>
+   </relatedItem>
+</bibl>

--- a/Biblio/98/97401.xml
+++ b/Biblio/98/97401.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0"
+      type="article"
+      subtype="journal"
+      xml:lang="de"
+      xml:id="b97401">
+   <title level="a" type="main">Fragment eines Ehevertrages aus Oxyrhynchοs</title>
+   <author n="1">
+      <forename>Eleni</forename>
+      <surname>Avdoulou</surname>
+   </author>
+   <date>2025</date>
+   <biblScope type="issue">7</biblScope>
+   <biblScope type="article" n="7">Article 7</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2025.7.112023"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">97401</idno>
+   <relatedItem type="mentions" n="1">
+      <bibl>
+         <title level="s" type="short">Pylon</title>
+         <biblScope type="vol">7</biblScope>
+         <biblScope type="num">7</biblScope>
+         <idno type="ddb">pylon;7;7</idno>
+         <idno type="tm">1000279</idno>
+         <idno type="invNo">P.Hamb. Graec. inv. 489</idno>
+      </bibl>
+   </relatedItem>
+</bibl>

--- a/Biblio/98/97402.xml
+++ b/Biblio/98/97402.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0"
+      type="article"
+      subtype="journal"
+      xml:lang="de"
+      xml:id="b97402">
+   <title level="a" type="main">Ein mögliches Beispiel für das Kolumnenmaß in der antiken Stichometrie</title>
+   <author n="1">
+      <forename>Holger</forename>
+      <surname>Essler</surname>
+   </author>
+   <date>2025</date>
+   <biblScope type="issue">7</biblScope>
+   <biblScope type="article" n="8">Article 8</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2025.7.112024"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">97402</idno>
+</bibl>

--- a/Biblio/98/97403.xml
+++ b/Biblio/98/97403.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0"
+      type="article"
+      subtype="journal"
+      xml:lang="en"
+      xml:id="b97403">
+   <title level="a" type="main">Arabic Documents from the Staatsbibliothek in Hamburg I: Two Acknowledgements of Debt for Seed Advances (P.Hamb.Arab. Inv. 80-81)</title>
+   <author n="1">
+      <forename>Naïm</forename>
+      <surname>Vanthieghem</surname>
+   </author>
+   <date>2025</date>
+   <biblScope type="issue">7</biblScope>
+   <biblScope type="article" n="9">Article 9</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2025.7.112025"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">97403</idno>
+   <relatedItem type="mentions" n="1">
+      <bibl>
+         <title level="s" type="short">Pylon</title>
+         <biblScope type="vol">7</biblScope>
+         <biblScope type="num">9</biblScope>
+         <idno type="ddb">pylon;7;9_1</idno>
+         <idno type="tm">1000281</idno>
+         <idno type="invNo">P.Hamb.Arab. Inv. 80</idno>
+      </bibl>
+   </relatedItem>
+   <relatedItem type="mentions" n="2">
+      <bibl>
+         <title level="s" type="short">Pylon</title>
+         <biblScope type="vol">7</biblScope>
+         <biblScope type="num">9</biblScope>
+         <idno type="ddb">pylon;7;9_2</idno>
+         <idno type="tm">1000282</idno>
+         <idno type="invNo">P.Hamb.Arab. Inv. 81</idno>
+      </bibl>
+   </relatedItem>
+</bibl>

--- a/Biblio/98/97404.xml
+++ b/Biblio/98/97404.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0"
+      type="article"
+      subtype="journal"
+      xml:lang="en"
+      xml:id="b97404">
+   <title level="a" type="main">More on the Homeric Papyri from Karanis</title>
+   <author n="1">
+      <forename>C. Michael</forename>
+      <surname>Sampson</surname>
+   </author>
+   <date>2025</date>
+   <biblScope type="issue">7</biblScope>
+   <biblScope type="article" n="2">Article 2</biblScope>
+   <ptr target="https://doi.org/10.48631/pylon.2025.7.112018"/>
+   <relatedItem type="appearsIn" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/2374"/>
+      </bibl>
+   </relatedItem>
+   <idno type="pi">97404</idno>
+</bibl>

--- a/DCLP/61/60315.xml
+++ b/DCLP/61/60315.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.23/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="m60315" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="m60315">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -40,13 +40,15 @@
                <history>
                   <origin>
                      <origPlace>Found: Karanis (Arsinoites, Egypt); written: Egypt</origPlace>
-                     <origDate notBefore="0001" notAfter="0199">1 - 199</origDate>
+                     <origDate notBefore="0076" notAfter="0200" precision="low">Ende I - II</origDate>
                   </origin>
                   <provenance type="found">
                      <p>
                         <placeName type="ancient" subtype="nome">Arsinoites</placeName>
                         <placeName type="ancient" subtype="region">Egypt</placeName>
-                        <placeName type="ancient" ref="https://www.trismegistos.org/place/1008">Karanis</placeName>
+                        <placeName type="ancient"
+                                   ref="https://www.trismegistos.org/place/1008 https://pleiades.stoa.org/places/736932">Karanis</placeName>
+                        <placeName n="4" type="modern">Kom Aushim</placeName>
                      </p>
                   </provenance>
                   <provenance type="composed">
@@ -71,7 +73,6 @@
                <term>epic</term>
                <term type="culture">literature</term>
                <term type="religion">classical</term>
-               <term type="overview">Homerus; Ilias 01.273-362</term>
             </keywords>
          </textClass>
          <langUsage>
@@ -80,47 +81,249 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="DCLP">Xwalk from Pylon</change>
          <change when="2014-12-10" who="DCLP">Crosswalked to EpiDoc XML</change>
       </revisionDesc>
    </teiHeader>
    <text>
       <body>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
+
+<div n="vii" subtype="column" type="textpart">
+<ab>
+
+<lb n="1"/><supplied reason="lost">καὶ μ</supplied>έν <choice><reg>μεο</reg><orig>μυ</orig></choice> <unclear>βο</unclear>υλ<unclear>έ</unclear>ων ξύ<supplied reason="lost">νιεν πείθοντό τε μύθωι·</supplied>
+
+<lb n="2"/><supplied reason="lost">ἀλλὰ πίθεσθ</supplied><unclear>ε</unclear> <unclear>κ</unclear><supplied reason="lost">α</supplied><unclear>ὶ</unclear> ὔμμες, ἐ<supplied reason="lost">πεὶ πείθεσθαι ἄμεινον·</supplied>
+
+<lb n="3"/><supplied reason="lost">μήτε σὺ τόνδ’ ἀ</supplied><unclear>γ</unclear>αθός <unclear>περ</unclear> <supplied reason="lost">ἐὼν ἀποαίρεο κούρην,</supplied>
+
+<lb n="4"/><supplied reason="lost">ἀλλ’ ἔα, ὥς οἱ πρ</supplied><unclear>ῶτ</unclear><supplied reason="lost">α δ</supplied>ό<unclear>σ</unclear>αν γ<unclear>έ</unclear><supplied reason="lost">ρας υἷες Ἀχαιῶν·</supplied>
+
+<lb n="5"/><supplied reason="lost">μήτε σὺ</supplied> <app type="alternative"><lem><supplied reason="lost">Πηλεί</supplied>δ’<unclear><g type="apostrophe"/></unclear><note>δ’̣ papyrus</note> ἤθελ’</lem><rdg><supplied reason="lost">Πηλεί</supplied>δη θέλ’</rdg></app> ἐριζ<unclear>έ</unclear><supplied reason="lost">μεναι βασιλῆϊ</supplied>
+
+<lb n="6"/><supplied reason="lost">ἀντιβίην, ἐπεὶ ο</supplied>ὔ ποθ’ ὁμοί<supplied reason="lost">ης ἔμμορε τιμῆς</supplied>
+
+<lb n="7"/><supplied reason="lost">σκηπτοῦχος βασ</supplied>ιλεύς, ὧι τε <supplied reason="lost">Ζεὺς κῦδος ἔδ</supplied><unclear>ωκε</unclear>ν.
+
+<lb n="8"/><supplied reason="lost">εἰ δὲ σὺ καρτερός</supplied> <unclear>ἐ</unclear>σσι, θεὰ δέ <supplied reason="lost">σε γείνατο μήτη</supplied><unclear>ρ</unclear>,
+
+<lb n="9"/><supplied reason="lost">ἀλλ’ ὅδε φέρτερ</supplied><unclear>ός</unclear> <unclear>ἐστ</unclear><supplied reason="lost">ιν</supplied>, <unclear>ἐπε</unclear><supplied reason="lost">ὶ</supplied> <unclear>πλ</unclear>ε<supplied reason="lost">ό</supplied><unclear>ν</unclear><supplied reason="lost">εσ</supplied><unclear>σ</unclear>ιν <unclear>ἀ</unclear><supplied reason="lost">νά</supplied><unclear>σσει</unclear>.
+
+<lb n="10"/><supplied reason="lost">Ἀτρείδη, σὺ δὲ</supplied> παῦε τεὸν μένος· α<unclear>ὐ</unclear><supplied reason="lost">τ</supplied>ὰρ ἐγ<unclear>ώ</unclear> <unclear>γ</unclear>ε
+
+<lb n="11"/><supplied reason="lost">λίσσομ’ Ἀχιλλ</supplied><unclear>ῆ</unclear>ϊ μεθέμεν χόλον, ὃς <unclear>μ</unclear>έγα π<supplied reason="lost">ᾶ</supplied><unclear>σ</unclear>ιν
+
+<lb n="12"/><supplied reason="lost">ἕρκος Ἀχαιοῖσιν</supplied> <unclear>πέλ</unclear>εται πολέμοιο <unclear>κ</unclear><supplied reason="lost">α</supplied><unclear>κ</unclear>οῖο.
+
+<lb n="13"/><supplied reason="lost">τὸν δ’ ἀπαμειβ</supplied><unclear>ό</unclear>μενος προσέφη κρ<supplied reason="lost">ε</supplied><unclear>ί</unclear>ων <unclear>Ἀ</unclear>γαμέμ<unclear>ν</unclear><supplied reason="lost">ων·</supplied>
+
+<lb n="14"/><supplied reason="lost">ναὶ δὴ ταῦτά γε π</supplied><unclear>ά</unclear>ντα, γέρον, κατὰ <supplied reason="lost">μοῖ</supplied><unclear>ρ</unclear>αν ἔει<unclear>π</unclear>ες·
+
+<lb n="15"/><supplied reason="lost">ἀλλ’ ὅδ’ ἀνὴρ ἐθέλει περ</supplied><unclear>ὶ</unclear> <unclear>πάν</unclear><supplied reason="lost">των ἔμ</supplied><unclear>μ</unclear>ενα<unclear>ι</unclear> <supplied reason="lost">ἄ</supplied><unclear>λ</unclear>λων,
+
+<lb n="16"/><supplied reason="lost">πάντων μὲν κρατέειν ἐθέλ</supplied><unclear>ε</unclear><supplied reason="lost">ι</supplied>, <unclear>π</unclear><supplied reason="lost">άντεσσι δ’ ἀνά</supplied><unclear>σσ</unclear><supplied reason="lost">ε</supplied><unclear>ιν</unclear>,
+
+<lb n="17"/><supplied reason="lost">πᾶσι δὲ σημαίνειν, ἅ τ</supplied><unclear>ι</unclear>ν’ οὐ π<unclear>εί</unclear><supplied reason="lost">σ</supplied>ε<unclear>σ</unclear><supplied reason="lost">θαι</supplied> <unclear>ὀ</unclear>ΐ<supplied reason="lost">ω</supplied>.
+
+<lb n="18"/><supplied reason="lost">εἰ δέ μιν αἰχμητὴν</supplied> <unclear>ἔ</unclear>θεσαν θε<unclear>ο</unclear>ὶ <supplied reason="lost">αἰὲν</supplied> <unclear>ἐ</unclear>όντες
+
+<lb n="19"/><supplied reason="lost">τούνεκά οἱ προθέο</supplied><unclear>υ</unclear>σιν ὀνείδ<supplied reason="lost">εα μ</supplied><unclear>υθ</unclear>ήσα<unclear>σθ</unclear><supplied reason="lost">αι;</supplied>
+
+<lb n="20"/><supplied reason="lost">τὸν δ’ ἄρ’ ὑποβλήδη</supplied><unclear>ν</unclear> ἠμείβετο <supplied reason="lost">δῖος</supplied> Ἀχιλ<unclear>λ</unclear>εύς·
+
+<lb n="21"/><supplied reason="lost">ἦ γάρ κεν δειλός τε</supplied> <unclear>κα</unclear>ὶ οὐτιδαν<unclear>ὸ</unclear><supplied reason="lost">ς κα</supplied><unclear>λ</unclear>εοί<unclear>μ</unclear><supplied reason="lost">ην,</supplied>
+
+<lb n="22"/><supplied reason="lost">εἰ δὴ σοὶ πᾶν ἔρ</supplied><unclear>γ</unclear><supplied reason="lost">ο</supplied>ν <unclear>ὑ</unclear>πείξομα<unclear>ι</unclear> <unclear>ὅ</unclear><supplied reason="lost">ττί κε</supplied>ν εἴπῃς.
+
+<lb n="23"/><supplied reason="lost">ἄλλοισιν δὴ τα</supplied><unclear>ῦ</unclear>τ’ ἐπι<unclear>τ</unclear>έλλεο, μ<unclear>ὴ</unclear> <supplied reason="lost">γὰρ ἐ</supplied><unclear>μ</unclear>οί γε
+
+<lb n="24"/><supplied reason="lost">σήμαιν’· οὐ γὰρ ἐ</supplied>γώ γ’ <unclear>ἔ</unclear>τι σοὶ πείσ<supplied reason="lost">εσθα</supplied><unclear>ι</unclear> <unclear>ὀΐ</unclear>ω.
+
+<lb n="25"/><supplied reason="lost">ἄλλο δέ τοι ἐρέ</supplied>ω, σὺ <unclear>δ</unclear>’ <unclear>ἐ</unclear>νὶ φρεσὶ β<unclear>ά</unclear><supplied reason="lost">λλ</supplied>ε<unclear>ο</unclear> σῆισι·
+
+<lb n="26"/><supplied reason="lost">χερσὶ μὲν οὔ τ</supplied><unclear>ο</unclear>ι ἔ<unclear>γωγ</unclear>ε μαχέσσομ<supplied reason="lost">αι</supplied> <unclear>εἵνεκ</unclear>α κούρης,
+
+<lb n="27"/><supplied reason="lost">οὔτε σοὶ οὔτέ τωι ἄλ</supplied><unclear>λ</unclear>ωι, ἐπεί μ’ ἀφ<supplied reason="lost">έλεσθέ γε</supplied> <unclear>δ</unclear>όντες·
+
+<lb n="28"/><supplied reason="lost">τῶν δ’ ἄλλων ἅ μοί ἐ</supplied><unclear>στ</unclear>ι θοῆι παρὰ νηῒ <unclear>μελα</unclear>ίνηι,
+
+<lb n="29"/><supplied reason="lost">τῶν οὐκ ἄν τι φέροι</supplied><unclear>ς</unclear> ἀνελὼν ἀέκον<unclear>τ</unclear>ος ἐμεῖο.
+
+<lb n="30"/><supplied reason="lost">εἰ δ’ ἄγε μὴν πείρησαι ἵ</supplied><unclear>ν</unclear>α <unclear>γ</unclear>νώωσι καὶ <unclear>ο</unclear>ἵδε·
+
+<lb n="31"/><supplied reason="lost">αἶψά τοι αἷμα κελαινὸν</supplied> ἐρωήσει περὶ <unclear>δ</unclear><supplied reason="lost">ο</supplied><unclear>υ</unclear>ρί.
+
+<lb n="32"/><supplied reason="lost">ὣς τώ γ’ ἀντιβίοισι μαχ</supplied>εσσα<unclear>μ</unclear>ένω ἐπ<unclear>έε</unclear><supplied reason="lost">σσιν</supplied>
+
+<lb n="33"/><supplied reason="lost">ἀνστήτην, λῦσαν δ’ ἀγορὴ</supplied><unclear>ν</unclear> παρ<supplied reason="lost">ὰ</supplied> νηυσὶ<unclear>ν</unclear> Ἀχαιῶν.
+
+<lb n="34"/><supplied reason="lost">Πηλεΐδης μὲν ἐπὶ κλισί</supplied><unclear>α</unclear>ς κα<unclear>ὶ</unclear> νῆας ἐ<unclear>ΐσα</unclear><supplied reason="lost">ς</supplied>
+
+<lb n="35"/><supplied reason="lost">ἤϊε σύν τε Μενοιτιάδηι καὶ</supplied> <unclear>ο</unclear><supplied reason="lost">ἷ</supplied><unclear>ς</unclear> ἑτάροισιν·
+
+<lb n="36"/><supplied reason="lost">Ἀτρείδης δ’ ἄρα νῆα θοὴν ἅλαδε προέρυ</supplied><unclear>σσε</unclear>ν,
+
+<lb n="37"/><supplied reason="lost">ἐν δ’ ἐρέτας ἔκρινεν ἐείκοσιν, ἐς δ’ ἑκατ</supplied>όμβην
+
+<lb n="38"/><gap reason="lost" quantity="1" unit="line"/>
+
+<lb n="39"/><supplied reason="lost">εἷσεν ἄγων· ἐν δ’ ἀρχὸς ἔβη πολύμητις Ὀδυσσεύ</supplied><unclear>ς</unclear>.
+
+<lb n="40"/><supplied reason="lost">οἳ μὲν ἔπειτ’ ἀναβάντες ἐπέπλεον ὑγρὰ κέλευ</supplied><unclear>θα</unclear>,
+
+<lb n="41"/><supplied reason="lost">λαοὺς δ’ Ἀτρείδης ἀπολυμαίνε</supplied><unclear>σθα</unclear><supplied reason="lost">ι ἄνωγεν.</supplied>
+
+<lb n="42"/><supplied reason="lost">οἳ δ’ ἀπελυμαίνοντο καὶ εἰς</supplied> <unclear>ἅ</unclear>λα λύματ’ ἔ<supplied reason="lost">βα</supplied>λλον,
+
+<lb n="43"/><supplied reason="lost">ἔρδον δ’ Ἀπόλλωνι τεληέσσ</supplied><unclear>α</unclear>ς ἑκατόμβ<supplied reason="lost">ας</supplied>
+
+<lb n="44"/><supplied reason="lost">ταύρων ἠδ’ αἰγῶν παρὰ θῖν’ ἁ</supplied><unclear>λ</unclear>ὸς ἀτρυγ<unclear>έ</unclear><supplied reason="lost">τ</supplied><unclear>οι</unclear><supplied reason="lost">ο·</supplied>
+
+<lb n="45"/><supplied reason="lost">κνίση δ’ οὐρανὸν ἷκεν ἑλισσ</supplied>ομένη π<unclear>ε</unclear><supplied reason="lost">ρὶ</supplied> <unclear>κ</unclear>απνῶι.
+</ab></div>
+
+<div n="viii" subtype="column" type="textpart">
+<ab>
+
+<lb n="1"/>ὣς <unclear>ο</unclear><supplied reason="lost">ἳ μὲν τὰ πένοντο κατὰ στρατόν· οὐδ’ Ἀγαμέμνων</supplied>
+
+<lb n="2"/><unclear>λ</unclear>ῆγ’ <supplied reason="lost">ἔριδος, τὴν πρῶτον ἐπηπείλησ’ Ἀχιλῆϊ,</supplied>
+
+<lb n="3"/>ἀλλ’ <unclear>ὅ</unclear> <supplied reason="lost">γε Ταλθύβιόν τε καὶ Εὐρυβάτην προσέειπεν,</supplied>
+
+<lb n="4"/><unclear>τώ</unclear> <unclear>ο</unclear><supplied reason="lost">ἱ ἔσαν κήρυκε καὶ ὀτρηρὼ θεράποντε·</supplied>
+
+<lb n="5"/><gap reason="lost" quantity="1" unit="line"/>
+
+<lb n="6"/>χειρ<unclear>ὸ</unclear><supplied reason="lost">ς ἑλόντ’ ἀγέμεν Βρισηΐδα καλλιπάρηον.</supplied>
+
+<lb n="7"/>εἰ δέ <unclear>κ</unclear><supplied reason="lost">ε μὴ δώησιν, ἐγὼ δέ κεν αὐτὸς ἕλωμαι</supplied>
+
+<lb n="8"/>ἐλ<unclear>θὼν</unclear> <supplied reason="lost">σὺν πλεόνεσσι, τό οἱ καὶ ῥίγιον ἔσται.</supplied>
+
+<lb n="9"/>ὣ<supplied reason="lost">ς εἰπὼν προΐει, κρατερὸν δ’ ἐπὶ μῦθον ἔτελλεν.</supplied>
+
+<lb n="10"/>τ<unclear>ὼ</unclear> <supplied reason="lost">δ’ ἀέκοντε βάτην παρὰ θῖν’ ἁλὸς ἀτρυγέτοιο,</supplied>
+
+<lb n="11"/><unclear>Μ</unclear><supplied reason="lost">υρμιδόνων δ’ ἐπί τε κλισίας καὶ νῆας ἱκέσθην.</supplied>
+
+<lb n="12"/><unclear>τὸν</unclear> <unclear>δ</unclear>’ <unclear>ε</unclear><supplied reason="lost">ὗρον παρά τε κλισίηι καὶ νηῒ μελαίνηι</supplied>
+
+<lb n="13"/>ἥμεν<unclear>ο</unclear><supplied reason="lost">ν· οὐδ’ ἄρα τώ γε ἰδὼν γήθησεν Ἀχιλλεύς.</supplied>
+
+<lb n="14"/>τὼ μὲ<unclear>ν</unclear> <supplied reason="lost">ταρβήσαντε καὶ αἰδομένω βασιλῆα</supplied>
+
+<lb n="15"/>στήτη<supplied reason="lost">ν, οὐδέ τί μιν προσεφώνεον οὐδ’ ἐρέοντο·</supplied>
+
+<lb n="16"/>αὐτὰρ <unclear>ὃ</unclear> <supplied reason="lost">ἔγνω ἧισιν ἐνὶ φρεσὶ φώνησέν τε·</supplied>
+
+<lb n="17"/>χα<unclear>ίρετε</unclear> <supplied reason="lost">κήρυκες, Διὸς ἄγγελοι ἠδὲ καὶ ἀνδρῶν,</supplied>
+
+<lb n="18"/>ἆσσον <unclear>ἴτ</unclear>’· <supplied reason="lost">οὔ τί μοι ὔμμες ἐπαίτιοι, ἀλλ’ Ἀγαμέμνων,</supplied>
+
+<lb n="19"/>ὃ σφῶϊ <unclear>π</unclear><supplied reason="lost">ροΐει Βρισηΐδος εἵνεκα κούρης.</supplied>
+
+<lb n="20"/>ἀλ<unclear>λ</unclear>’ <unclear>ἄγε</unclear>, <unclear>δ</unclear><supplied reason="lost">ιογενὲς Πατρόκλεις, ἔξαγε κούρην</supplied>
+
+<lb n="21"/><gap reason="lost" quantity="1" unit="line"/>
+
+<lb n="22"/><unclear>πρ</unclear><supplied reason="lost">ός τε θεῶν μακάρων πρός τε θνητῶν ἀνθρώπων</supplied>
+
+<lb n="23"/>καὶ π<unclear>ρὸ</unclear><supplied reason="lost">ς</supplied> <unclear>το</unclear>ῦ βασι<supplied reason="lost">λῆος ἀπηνέος, εἴ ποτε δὴ αὖτε</supplied>
+
+<lb n="24"/>χρει<unclear>ὼ</unclear> <supplied reason="lost">ἐ</supplied><unclear>μεῖο</unclear> <unclear>γένητ</unclear><supplied reason="lost">αι ἀεικέα λοιγὸν ἀμῦναι</supplied>
+
+<lb n="25"/><unclear>τ</unclear>ο<unclear>ῖ</unclear><supplied reason="lost">ς ἄλλ</supplied>οις. ἦ <unclear>γ</unclear>ὰ<unclear>ρ</unclear> ὅ <unclear>γ</unclear>’ <unclear>ὀλ</unclear><supplied reason="lost">οιῆισι φρεσὶ θυίει,</supplied>
+
+<lb n="26"/>ο<supplied reason="lost">ὐδέ τι</supplied> <unclear>ο</unclear>ἶδε <supplied reason="lost">ν</supplied><unclear>οῆσαι</unclear> <supplied reason="lost">ἅμα πρόσσω καὶ ὀπίσσω,</supplied>
+
+<lb n="27"/>ὅ<unclear>ππ</unclear>ως οἱ παρὰ νη<unclear>υ</unclear><supplied reason="lost">σὶ σόοι μαχεοίατ’ Ἀχαιοί.</supplied>
+
+<lb n="28"/>ὣ<unclear>ς</unclear> <supplied reason="lost">φ</supplied>άτο, Πάτροκλος <supplied reason="lost">δὲ φίλωι ἐπεπείθεθ’ ἑταίρωι,</supplied>
+
+<lb n="29"/>ἐκ <unclear>δ</unclear>’ ἄγαγε κλισίης Β<unclear>ρ</unclear><supplied reason="lost">ισηΐδα καλλιπάρηον,</supplied>
+
+<lb n="30"/><supplied reason="lost">δῶκ</supplied><unclear>ε</unclear> <supplied reason="lost">δ’ ἄγειν. τὼ δ’ αὖτις ἴτην παρὰ νῆας Ἀχαιῶν,</supplied>
+
+<lb n="31"/><supplied reason="lost">ἣ δ’ ἀέκο</supplied><unclear>υ</unclear>σ’ ἅμα <unclear>τοῖσι</unclear> <supplied reason="lost">γυνὴ κίεν. αὐτὰρ Ἀχιλλεὺς</supplied>
+
+<lb n="32"/><supplied reason="lost">δακρύσ</supplied>ας ἑτάρων ἄ<supplied reason="lost">φαρ ἕζετο νόσφι λιασθείς</supplied>
+
+<lb n="33"/><supplied reason="lost">θῖν’ ἔφ’ ἁ</supplied>λὸς πολιῆς, <supplied reason="lost">ὁρόων ἐπὶ οἴνοπα πόντον·</supplied>
+
+<lb n="34"/><supplied reason="lost">πολλὰ δ</supplied><unclear>ὲ</unclear> μητρὶ φίλη<unclear>ι</unclear> <supplied reason="lost">ἠρήσατο χεῖρας ὀρεγνύς·</supplied>
+
+<lb n="35"/><supplied reason="lost">μῆτερ, ἐ</supplied>πεί μ’ <unclear>ἔτε</unclear>κ<unclear>ές</unclear> <supplied reason="lost">γε μινυνθάδιόν περ ἐόντα,</supplied>
+
+<lb n="36"/><supplied reason="lost">τιμήν π</supplied>έρ μοι ὄφελλ<supplied reason="lost">εν Ὀλύμπιος ἐγγυαλίξαι</supplied>
+
+<lb n="37"/><supplied reason="lost">Ζεὺς ὑ</supplied>ψιβρεμέτης· <supplied reason="lost">νῦν δ’ οὐδέ με τυτθὸν ἔτισεν.</supplied>
+
+<lb n="38"/><supplied reason="lost">ἦ γάρ μ’ Ἀτ</supplied>ρείδης <unclear>εὐρὺ</unclear> <supplied reason="lost">κρείων Ἀγαμέμνων</supplied>
+
+<lb n="39"/><supplied reason="lost">ἠτίμη</supplied>σε<unclear>ν</unclear>, <unclear>ἑλὼ</unclear><supplied reason="lost">ν γὰρ ἔχει γέρας αὐτὸς ἀπούρας.</supplied>
+
+<lb n="40"/><unclear>ὣ</unclear><supplied reason="lost">ς</supplied> φ<unclear>άτ</unclear><supplied reason="lost">ο δά</supplied><unclear>κρυ</unclear> <unclear>χ</unclear><supplied reason="lost">έων, τοῦ δ’ ἔκλυε πότνια μήτηρ</supplied>
+
+<lb n="41"/><unclear>ἡ</unclear><supplied reason="lost">μένη</supplied> <unclear>ἐν</unclear> <unclear>βέ</unclear>νθ<unclear>εσ</unclear><supplied reason="lost">σιν ἁλὸς παρὰ πατρὶ γέροντι.</supplied>
+
+<lb n="42"/><supplied reason="lost">κα</supplied><unclear>ρπαλίμ</unclear>ως δ’ <unclear>ἀ</unclear>νέ<unclear>δ</unclear><supplied reason="lost">υ πολιῆς ἁλὸς ἠΰτ’ ὀμίχλη,</supplied>
+
+<lb n="43"/>κ<unclear>αί</unclear> ῥα πάροιθ’ αὐτοῖο <unclear>κ</unclear><supplied reason="lost">αθέζετο δάκρυ χέοντος,</supplied>
+
+<lb n="44"/>χειρί τέ <unclear>μ</unclear>ιν κατέρεξ<supplied reason="lost">εν, ἔπος τ’ ἔφατ’ ἔκ τ’ ὀνόμαζε·</supplied>
+
+<lb n="45"/>τέκνον, <unclear>τ</unclear>ί κλαίεις; τί δ<supplied reason="lost">έ σε φρένας ἵκετο πένθος;</supplied>
+</ab></div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
                <bibl type="publication" subtype="principal">
+                  <ptr target="http://papyri.info/biblio/97293"/>
+                  <biblScope unit="number">1</biblScope>
+               </bibl>
+               <bibl type="reference" subtype="previous">
                   <ptr target="http://papyri.info/biblio/95143"/>
                   <biblScope unit="number">141</biblScope>
-                  <!--ignore - start, i.e. SoSOL users may not edit this-->
+                  <biblScope unit="generic">descr.</biblScope>
                   <title level="s" type="abbreviated">P. Fay.</title>
-                  <!--ignore - stop-->
                </bibl>
                <bibl type="reference" subtype="catalogue">
-                  <!-- ignore - start, i.e. SoSOL users may not edit this -->
                   <title level="m" type="main">Studies in the Text and Transmission of the Iliad.</title>
                   <author>
                      <surname>West</surname>
                      <forename>Martin L.</forename>
                   </author>
-                  <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/16711"/>
                   <biblScope unit="number">125</biblScope>
+               </bibl>
+               <bibl type="reference" subtype="catalogue">
+                  <ptr target="http://papyri.info/biblio/95104"/>
+                  <biblScope unit="number">10217</biblScope>
+                  <biblScope unit="generic">descr.</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <listBibl>
+               <bibl type="printed">Liège</bibl>
+               <bibl type="online">
+                  <ptr target="https://doi.org/10.48631/pylon.2025.7.112017"/>
                </bibl>
             </listBibl>
          </div>
          <div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0012">Homerus</author>
+                  <author xml:lang="grc"
+                          ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0012 http://cwkb.org/author/id/927/rdf">Homerus</author>
                   <title type="main"
                          level="m"
-                         ref="http://www.trismegistos.org/authorwork/511">Ilias</title>
+                         xml:lang="grc"
+                         ref="http://www.trismegistos.org/authorwork/511 http://cwkb.org/work/id/2815/rdf">Ilias</title>
+                  <biblScope n="1" unit="book">1</biblScope>
+                  <biblScope n="2" unit="line" from="273" to="362">273-362</biblScope>
                </bibl>
-            </listBibl>
-         </div>
-         <div type="edition" xml:space="preserve" xml:lang="grc"/>
-         <div type="bibliography" subtype="illustrations">
-            <listBibl>
-               <bibl type="printed">Liège</bibl>
             </listBibl>
          </div>
       </body>

--- a/DCLP/61/60326.xml
+++ b/DCLP/61/60326.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.23/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="m60326" xml:lang="en">
-  <teiHeader>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="m60326">
+   <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Fragments of Iliad 8 in Florence and Oxford</title>
+            <title>Fragments of Iliad 8 in Florence, Oxford, and Vienna</title>
          </titleStmt>
          <publicationStmt>
             <authority>Digital Corpus of Literary Papyri</authority>
@@ -12,7 +12,7 @@
             <idno type="TM">60326</idno>
             <idno type="LDAB">1447</idno>
             <idno type="filename">60326</idno>
-            <idno type="dclp-hybrid">tm;;60326</idno>
+            <idno type="dclp-hybrid">pylon;7;1_2</idno>
             <idno type="MP3">00821.000</idno>
             <availability>
                <p>
@@ -28,6 +28,7 @@
                   <idno>
                      <idno type="invNo" n="1">Florence, Biblioteca Medicea Laurenziana P. Flor. 109</idno>
                      <idno type="invNo" n="2">Oxford, Bodleian Library MS. Gr. class. d. 20 (P)</idno>
+                     <idno type="invNo" n="3">Vienna, Nationalbibliothek G 19768</idno>
                   </idno>
                </msIdentifier>
                <physDesc>
@@ -39,26 +40,26 @@
                      </supportDesc>
                      <layoutDesc>
                         <layout columns="1">
-                           <p>papyrus roll (columns: 2, pagination: 0)</p>
+                           <p>papyrus roll (columns: 1, pagination: 0)</p>
                         </layout>
                      </layoutDesc>
                   </objectDesc>
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Fundort: Arsinoites, Egypt; Schreibort: Egypt</origPlace>
-                     <origDate notBefore="0001" notAfter="0199">1 - 199</origDate>
+                     <origPlace>Found: Karanis (Arsinoites, Egypt); written: Egypt</origPlace>
+                     <origDate notBefore="0001" notAfter="0100" precision="low">I</origDate>
                   </origin>
-                  <provenance n="1" type="found">
+                  <provenance type="found">
                      <p>
-                        <placeName n="1"
-                                   type="ancient"
-                                   subtype="nome"
-                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
-                        <placeName n="2" type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient" subtype="nome">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Egypt</placeName>
+                        <placeName type="ancient"
+                                   ref="https://www.trismegistos.org/place/1008 https://pleiades.stoa.org/places/736932">Karanis</placeName>
+                        <placeName n="4" type="modern">Kom Aushim</placeName>
                      </p>
                   </provenance>
-                  <provenance n="2" type="composed">
+                  <provenance type="composed">
                      <p>
                         <placeName type="ancient" subtype="region">Egypt</placeName>
                      </p>
@@ -76,7 +77,7 @@
       <profileDesc>
          <textClass>
             <keywords>
-               <term n="1" type="description">epic</term>
+               <term n="1">epic</term>
                <term n="2" type="religion">classical</term>
                <term n="3" type="culture">literature</term>
                <term n="4">poetry</term>
@@ -88,6 +89,7 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="DCLP">Xwalk from Pylon</change>
          <change when="2022-06-05T21:16:57-04:00"
                  who="http://papyri.info/editor/users/Mike%20Sampson">Finalized - This is good to go </change>
          <change when="2022-06-05T21:15:22-04:00"
@@ -108,66 +110,199 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Submit - Initial entry, from Gallazzi 1988.</change>
          <change when="2014-12-10" who="DCLP">Crosswalked to EpiDoc XML</change>
       </revisionDesc>
-  </teiHeader>
-  <text>
+   </teiHeader>
+   <text>
       <body>
          <div xml:lang="grc" type="edition" xml:space="preserve">
-<div n="i" subtype="column" type="textpart"><ab>
+
+<div n="P-Grenf-I-2+P-Flor-II-109" type="textpart">
+<div n="i" subtype="column" type="textpart">
+<ab>
+
 <lb n="1"/><gap reason="lost" extent="unknown" unit="line"/>
+
 <lb n="1"/><supplied reason="lost">χαλκεοθωρήκων· ἀτὰρ ἀσπίδες ὀμ</supplied>φαλόε<unclear>σ</unclear><supplied reason="lost">σαι</supplied>
+
 <lb n="2"/><supplied reason="lost">ἔπληντ’ ἀλλήλῃσι, πολὺς δ’ ὀρυμαγδὸς</supplied> ὀρώρ<unclear>ε</unclear><supplied reason="lost">ι.</supplied>
+
 <lb n="3"/><supplied reason="lost">ἔνθα δ’ ἅμ’ οἰμωγή τε καὶ εὐχωλὴ</supplied> πέλεν ἀνδρῶν
+
 <lb n="4"/><supplied reason="lost">ὀλλύντων τε καὶ ὀλλυμένων, ῥέε δ’ αἵ</supplied><unclear>μ</unclear>ατι γα<unclear>ῖ</unclear>α.
+
 <lb n="5"/><supplied reason="lost">ὄφρα μὲν ἠὼς ἦν καὶ ἀέξετο</supplied> ἱερὸ<unclear>ν</unclear> ἦμαρ,
+
 <lb n="5a"/> <add place="interlinear"><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="2" unit="character"/></add>
+
 <lb n="6"/><supplied reason="lost">τόφρα μάλ’ ἀμφοτέρων βέλε’ ἥπ</supplied><unclear>τε</unclear>το, <subst><add place="inline">πῖπτε</add><del rend="corrected">πεῖπτε</del></subst> δὲ λαό<unclear>ς</unclear>.
+
 <lb n="7"/><supplied reason="lost">ἦμος δ’ Ἠέλιος μέσον οὐρανὸν ἀμ</supplied><unclear>φ</unclear>ιβεβήκει,
+
 <lb n="8"/><supplied reason="lost">καὶ τότε δὴ χρύσεια πατὴρ ἐτίταινε</supplied> τάλαντ<unclear>α</unclear>.
+
 <lb n="9"/><supplied reason="lost">ἐν δ’ ἐτίθει <num value="2">δύο</num> κῆρε τανηλεγέος θ</supplied><unclear>α</unclear>νάτο<supplied reason="lost">ι</supplied>ο
+
 <lb n="10"/><supplied reason="lost">Τρώων θ’ ἱπποδάμων καὶ Ἀχαιῶ</supplied>ν χαλκο<unclear>χι</unclear>τ<unclear>ώνω</unclear>ν,
+
 <lb n="11"/><supplied reason="lost">ἕλκε δὲ μέσσα λαβών· ῥέπε δ’ αἴσι</supplied><add place="above">μ</add>ο<supplied reason="lost">ν ἦ</supplied>μαρ Ἀχ<unclear>α</unclear>ιῶν.
+
 <lb n="12"/><supplied reason="lost">αἳ μὲν Ἀχαιῶν κῆρες ἐπὶ χθονὶ</supplied> <subst><add place="inline">πουλυβοτείρῃ</add><del rend="corrected">πουλυποτείρῃ</del></subst>
+
 <lb n="13"/><supplied reason="lost">ἑζέσθην, Τρώων δὲ πρὸς οὐρανὸν εὐ</supplied>ρὺν ἄ<unclear>ε</unclear>ρθεν.
+
 <lb n="14"/><supplied reason="lost">αὐτὸς δ’ ἐξ Ἴδης μεγάλ’ ἔκτυπε, δαιόμε</supplied><unclear>νο</unclear><supplied reason="lost">ν δ</supplied><unclear>ὲ</unclear>
+
 <lb n="14"/><gap reason="lost" extent="unknown" unit="line"/>
 </ab></div>
-<div n="ii" subtype="column" type="textpart"><ab>
+</div>
+<div n="P-Grenf-I-2" type="textpart">
+<div n="ii" subtype="column" type="textpart">
+<ab>
+
 <lb n="1"/>ἀλλὰ μέν’ ὄφρα γ<unclear>έ</unclear>ροντος ἀπώσομεν ἄ<supplied reason="lost">γριον ἄνδρα.</supplied>
+
 <lb n="2"/><add place="left"><expan>πο<ex>ιητής</ex></expan></add> ὣς ἔφατ’, οὐδ’ ἐσάκουσε πολύτλας δῖος Ὀ<unclear>δ</unclear><supplied reason="lost">υσσεύς,</supplied>
+
 <lb n="3"/>ἀλλὰ παρή<hi rend="diaeresis">ϊ</hi>ξε<unclear>ν</unclear> <unclear>κ</unclear>οίλας ἐ<unclear>π</unclear>ὶ νῆας Ἀχα<unclear>ι</unclear><supplied reason="lost">ῶν.</supplied>
+
 <lb n="4"/>Τυδεΐδης δ’ αὐτός περ ἐὼν προμάχοισιν <subst><add place="inline">ἐμίχθη</add><del rend="corrected">ἐμείχθη</del></subst>,
+
 <lb n="5"/>στῆ δὲ πρόσθ’ ἵππων Νηλη<hi rend="diaeresis">ϊ</hi>άδαο γέροντος,
+
 <lb n="6"/>καί μιν φωνήσας ἔπεα πτερόεντα <subst><add place="inline">προσηύδα</add><del rend="corrected">προσεύδα</del></subst>·
+
 <lb n="7"/><add place="left"><gap reason="illegible" quantity="4" unit="character"/> <unclear>Α</unclear> <gap reason="illegible" quantity="1" unit="character"/></add> ὦ γέρον ἦ μάλα <unclear>δή</unclear> σε νέοι τείρουσι μαχηταί,
+
 <lb n="8"/><add place="left"><expan>Δι<unclear>ομ</unclear><ex>ήδης</ex></expan> <expan><unclear>πρ</unclear><ex>ὸς</ex></expan> <expan><unclear>Νέ</unclear>σ<ex>τορα</ex></expan></add> σὴ δὲ βίη λέλυται, χαλεπὸν δέ σε γῆρας ὀπάζει,
+
 <lb n="9"/>ἠπεδανὸς δέ νύ <unclear>τ</unclear>οι θεράπων, βραδέε<unclear>ς</unclear> δέ τοι ἵππο<supplied reason="lost">ι</supplied>.
+
 <lb n="10"/><unclear>ἀ</unclear>λλ’ ἄγ’ ἐμῶν ὀχέων ἐπιβήσεο, ὄφ<unclear>ρ</unclear>α <hi rend="diaeresis">ἴ</hi>δηαι 
+
 <lb n="11"/><unclear>οἷ</unclear>οι <unclear>Τ</unclear>ρώϊοι ἵππο<supplied reason="lost">ι</supplied> ἐπιστάμενοι πεδίοι<supplied reason="omitted">ο</supplied>
+
 <lb n="12"/>κ<supplied reason="lost">ραι</supplied><unclear>πνὰ</unclear> μάλ’ ἔνθα καὶ ἔνθα διωκέμεν ἠδὲ φέβ<supplied reason="lost">εσθαι</supplied>,
+
 <lb n="13"/>οὕ<supplied reason="lost">ς π</supplied>οτ’ ἀπ’ Αἰνείαν ἑλόμ<supplied reason="lost">ην</supplied> <unclear>μ</unclear>ή<unclear>στ</unclear>ωρε φ<unclear>ό</unclear><supplied reason="lost">β</supplied><unclear>οιο</unclear>.
+
 <lb n="14"/><choice><reg><supplied reason="lost">τού</supplied>τω</reg><orig><supplied reason="lost">τού</supplied><unclear>τ</unclear>ωι</orig></choice> μὲν θεράποντ<unclear>ε</unclear> <supplied reason="lost">κο</supplied>μείτων, τώιδε <supplied reason="lost">δὲ νῶϊ</supplied>
+
 <lb n="15"/><supplied reason="lost">Τρωσ</supplied>ὶν ἐφ’ ἱπποδάμοις ἰ<supplied reason="lost">θύνομεν, ὄ</supplied>φρα <supplied reason="lost">καὶ Ἕκτωρ</supplied>
+
 <lb n="16"/><supplied reason="lost">εἴσετ</supplied>αι <choice><reg>εἰ</reg><orig>ἠ</orig></choice> καὶ ἐμὸ<unclear>ν</unclear> δόρυ μ<supplied reason="lost">αίνεται ἐν παλάμῃσιν.</supplied>
+
 <lb n="17"/><supplied reason="lost">ὣς ἔφ</supplied>ατ’, οὐδ’ ἀπίθησε Γε<supplied reason="lost">ρήνιος ἱππότα Νέστωρ.</supplied>
+
 <lb n="18"/><supplied reason="lost">Νεστ</supplied>ορέας μὲν ἔπειθ’ ἵ<supplied reason="lost">ππους θεράποντε κομείτην</supplied>
+
 <lb n="19"/><supplied reason="lost">ἴφθιμ</supplied>ος Σθένελ<unclear>ό</unclear>ς τε κ<unclear>α</unclear><supplied reason="lost">ὶ Εὐρυμέδων ἀγαπήνωρ.</supplied>
+
 <lb n="20"/><supplied reason="lost">τὼ δ’ εἰς ἀμφοτέρ</supplied>ωι Διομ<unclear>ή</unclear><supplied reason="lost">δεος ἅρματα βήτην·</supplied>
+
 <lb n="21"/><supplied reason="lost">Νέστωρ δ’ ἐν χείρεσ</supplied><unclear>σι</unclear> <unclear>λ</unclear>άβ’ <unclear>ἡ</unclear><supplied reason="lost">νία σιγαλόεντα,</supplied>
+
 <lb n="21"/><gap reason="lost" extent="unknown" unit="line"/>
 </ab></div></div>
-         <div type="bibliography" subtype="ancientEdition">
+         <div n="P-Vindob-G-19768" type="textpart">
+
+<ab>
+
+<lb n="1"/><gap reason="lost" extent="unknown" unit="line"/>
+
+<lb n="1"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="6" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
+
+<lb n="2"/><supplied reason="lost">μίγδ’</supplied> <unclear>ἄ</unclear>λλοι<unclear>σ</unclear><supplied reason="lost">ι θεοῖσι, φίλον τετιημέναι ἦτορ.</supplied>
+
+<lb n="3"/><supplied reason="lost">Ζεὺς δ</supplied><unclear>ὲ</unclear> πατὴ<supplied reason="lost">ρ Ἴδηθεν ἐΰτροχον ἅρμα καὶ ἵππους</supplied>
+
+<lb n="4"/><supplied reason="lost">Οὔλυμ</supplied><unclear>π</unclear>όνδ’ ἐδ<supplied reason="lost">ίωκε, θεῶν δ’ ἐξίκετο θώκους.</supplied>
+
+<lb n="5"/><supplied reason="lost">τῶι δ</supplied><unclear>ὲ</unclear> καὶ ἵππ<supplied reason="lost">ους μὲν λῦσε κλυτὸς Ἐννοσίγαιος,</supplied>
+
+<lb n="6"/><supplied reason="lost">ἅρματ</supplied>α δ’ ἂμ β<supplied reason="lost">ωμοῖσι τίθει, κατὰ λῖτα πετάσσας.</supplied>
+
+<lb n="7"/><supplied reason="lost">αὐτὸς</supplied> <unclear>δ</unclear>ὲ χρύσε<supplied reason="lost">ιον ἐπὶ θρόνον εὐρύοπα Ζεύς</supplied>
+
+<lb n="8"/><supplied reason="lost">ἕζετ</supplied><unclear>ο</unclear>, τῶι δ’ ὑ<unclear>π</unclear><supplied reason="lost">ὸ ποσσὶ μέγας πελεμίζετ’ Ὄλυμπος.</supplied>
+
+<lb n="9"/><supplied reason="lost">αἳ δ’ οἶ</supplied><unclear>α</unclear>ι Διὸς ἀμ<supplied reason="lost">φὶς Ἀθηναίη τε καὶ Ἥρη</supplied>
+
+<lb n="10"/><supplied reason="lost">ἥσθην,</supplied> <unclear>ο</unclear>ὐδέ <app type="editorial"><lem resp="papyrus">τέ</lem><rdg resp="mss.">τί</rdg></app> <unclear>μ</unclear><supplied reason="lost">ιν προσεφώνεον οὐδ’ ἐρέοντο.</supplied>
+
+<lb n="11"/><supplied reason="lost">αὐτὰρ ὃ</supplied> <unclear>ἔ</unclear>γνω ἧ<supplied reason="lost">ισιν ἐνὶ φρεσὶ φώνησέν τε·</supplied>
+
+<lb n="12"/><supplied reason="lost">τίφθ’</supplied> <app type="editorial"><lem resp="papyrus"><supplied reason="lost">οὕ</supplied>θω</lem><rdg resp="mss.">οὕτω</rdg></app> τετ<supplied reason="lost">ίησθον, Ἀθηναίη τε καὶ Ἥρη;</supplied>
+
+<lb n="13"/><supplied reason="lost">οὐ μέν</supplied> θην κά<unclear>μ</unclear><supplied reason="lost">ετόν γε μάχηι ἔνι κυδιανείρηι</supplied>
+
+<lb n="14"/><supplied reason="lost">ὀλλῦσ</supplied><unclear>αι</unclear> <unclear>Τ</unclear>ρῶ<unclear>α</unclear><supplied reason="lost">ς, τοῖσιν κότον αἰνὸν ἔθεσθε.</supplied>
+
+<lb n="15"/><supplied reason="lost">πάντ</supplied><unclear>ω</unclear>ς, <unclear>οἷ</unclear><supplied reason="lost">ο</supplied><unclear>ν</unclear> <supplied reason="lost">ἐμόν γε μένος καὶ χεῖρες ἄαπτοι,</supplied>
+
+<lb n="16"/><supplied reason="lost">οὐκ ἄν</supplied> με <unclear>τ</unclear>ρέ<supplied reason="lost">ψειαν, ὅσοι θεοί εἰσ’ ἐν Ὀλύμπωι.</supplied>
+
+<lb n="17"/><supplied reason="lost">σφῶϊν</supplied> δὲ πρίν π<unclear>ε</unclear><supplied reason="lost">ρ τρόμος ἔλλαβε φαίδιμα γυῖα,</supplied>
+
+<lb n="18"/><supplied reason="lost">πρὶν πό</supplied>λεμόν τ<supplied reason="omitted">ε</supplied> ἰ<unclear>δ</unclear><supplied reason="lost">εῖν πολέμοιό τε μέρμερα ἔργα.</supplied>
+
+<lb n="19"/><supplied reason="lost">ὧδε γὰρ</supplied> ἐξερέω, <unclear>τ</unclear><supplied reason="lost">ὸ δέ κεν τετελεσμένον ἦεν·</supplied>
+
+<lb n="20"/><supplied reason="lost">οὐκ ἂν ἐ</supplied>φ’ ὑμε<unclear>τέρ</unclear><supplied reason="lost">ων ὀχέων πληγέντε κεραυνῶι</supplied>
+
+<lb n="21"/><supplied reason="lost">ἂψ ἐς Ὄλ</supplied><unclear>υ</unclear>μπον <unclear>ἵκ</unclear><supplied reason="lost">εσθον, ἵν’ ἀθανάτων ἕδος ἐστίν.</supplied>
+
+<lb n="22"/><supplied reason="lost">ὣς ἔφαθ’·</supplied> <unclear>αἳ</unclear> <unclear>δ</unclear>’ <unclear>ἐπέ</unclear><supplied reason="lost">μυξαν Ἀθηναίη τε καὶ Ἥρη.</supplied>
+
+<lb n="23"/><supplied reason="lost">ἤτοι Ἀθ</supplied>ην<unclear>α</unclear>ίη ἀ<supplied reason="lost">κέων ἦν οὐδέ τι εἶπεν,</supplied>
+
+<lb n="24"/><supplied reason="lost">σκυζομ</supplied>ένη Δ<unclear>ιὶ</unclear> <unclear>π</unclear><supplied reason="lost">ατρί, χόλος δέ μιν ἄγριος ἥιρει·</supplied>
+
+<lb n="25"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="2" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
+
+<lb n="25"/><gap reason="lost" extent="unknown" unit="line"/>
+</ab></div></div>
+         <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl type="publication" subtype="ancient">
-                  <author xml:lang="grc"
-                          ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0012 http://cwkb.org/author/id/927/rdf">Homerus</author>
-                  <title type="main"
-                         level="m"
-                         ref="http://www.trismegistos.org/authorwork/511 http://cwkb.org/work/id/2815/rdf">Ilias</title>
-                  <biblScope n="1" unit="book">8</biblScope>
-                  <biblScope n="2" unit="line" from="62" to="75">62-75</biblScope>
-                  <biblScope n="3" unit="generic">and</biblScope>
-                  <biblScope n="4" unit="book">8</biblScope>
-                  <biblScope n="5" unit="line" from="96" to="116">96-116</biblScope>
+               <bibl n="1" type="reference" subtype="catalogue">
+                  <title level="m" type="main">Studies in the Text and Transmission of the Iliad.</title>
+                  <ptr target="http://papyri.info/biblio/16711"/>
+                  <biblScope n="1" unit="number">20</biblScope>
+                  <biblScope n="2" unit="book"/>
+                  <biblScope n="3" unit="book"/>
+               </bibl>
+               <bibl n="2" type="reference" subtype="catalogue">
+                  <title level="m" type="main">Studies in the Text and Transmission of the Iliad.</title>
+                  <ptr target="http://papyri.info/biblio/16711"/>
+                  <biblScope n="1" unit="number">55</biblScope>
+                  <biblScope n="2" unit="book"/>
+                  <biblScope n="3" unit="book"/>
+               </bibl>
+               <bibl n="3" type="reference" subtype="partial">
+                  <ptr target="http://papyri.info/biblio/95161"/>
+                  <biblScope n="1" unit="number">2</biblScope>
+                  <biblScope n="2" unit="chapter"/>
+                  <biblScope n="3" unit="page"/>
+               </bibl>
+               <bibl n="4" type="reference" subtype="partial">
+                  <ptr target="http://papyri.info/biblio/95146"/>
+                  <biblScope n="1" unit="number">109</biblScope>
+                  <biblScope n="2" unit="chapter"/>
+                  <biblScope n="3" unit="page"/>
+               </bibl>
+               <bibl n="5" type="reference" subtype="partial">
+                  <ptr target="http://papyri.info/biblio/97293"/>
+                  <biblScope n="1" unit="number">2</biblScope>
+               </bibl>
+               <bibl n="6" type="reference" subtype="partial">
+                  <ptr target="http://papyri.info/biblio/59143"/>
+                  <biblScope n="1" unit="number">2</biblScope>
+                  <biblScope n="2" unit="chapter"/>
+                  <biblScope n="3" unit="page" from="60" to="66">60-66</biblScope>
+               </bibl>
+               <bibl n="7" type="reference" subtype="study">
+                  <ptr target="http://papyri.info/biblio/76872"/>
+                  <biblScope n="1" unit="volume"/>
+                  <biblScope n="2" unit="chapter"/>
+                  <biblScope n="3" unit="page">35</biblScope>
                </bibl>
             </listBibl>
          </div>
@@ -189,62 +324,30 @@
                <bibl type="online">
                   <ptr target="http://www.psi-online.it/documents/pflor;2;109"/>
                </bibl>
+               <bibl type="online">
+                  <ptr target="https://doi.org/10.48631/pylon.2025.7.112017"/>
+               </bibl>
             </listBibl>
          </div>
-         <div type="bibliography" subtype="principalEdition">
+         <div type="bibliography" subtype="ancientEdition">
             <listBibl>
-               <bibl n="1" type="reference" subtype="catalogue">
-                  <title level="m" type="main">Studies in the Text and Transmission of the Iliad.</title>
-                  <!-- ignore - start, i.e. SoSOL users may not edit this -->
-                  <!-- ignore - stop -->
-                  <ptr target="http://papyri.info/biblio/16711"/>
-                  <biblScope n="1" unit="number">20</biblScope>
-                  <biblScope n="2" unit="book"/>
-                  <biblScope n="3" unit="book"/>
-               </bibl>
-               <bibl n="2" type="reference" subtype="catalogue">
-                  <title level="m" type="main">Studies in the Text and Transmission of the Iliad.</title>
-                  <!-- ignore - start, i.e. SoSOL users may not edit this -->
-                  <!-- ignore - stop -->
-                  <ptr target="http://papyri.info/biblio/16711"/>
-                  <biblScope n="1" unit="number">55</biblScope>
-                  <biblScope n="2" unit="book"/>
-                  <biblScope n="3" unit="book"/>
-               </bibl>
-               <bibl n="3" type="reference" subtype="partial">
-            <!-- ignore - start, i.e. SoSOL users may not edit this -->
-            <!-- ignore - stop -->
-                  <ptr target="http://papyri.info/biblio/95161"/>
-                  <biblScope n="1" unit="number">2</biblScope>
-                  <biblScope n="2" unit="chapter"/>
-                  <biblScope n="3" unit="page"/>
-               </bibl>
-               <bibl n="4" type="reference" subtype="partial">
-            <!-- ignore - start, i.e. SoSOL users may not edit this -->
-            <!-- ignore - stop -->
-                  <ptr target="http://papyri.info/biblio/95146"/>
-                  <biblScope n="1" unit="number">109</biblScope>
-                  <biblScope n="2" unit="chapter"/>
-                  <biblScope n="3" unit="page"/>
-               </bibl>
-               <bibl n="5" type="publication" subtype="principal">
-            <!-- ignore - start, i.e. SoSOL users may not edit this -->
-            <!-- ignore - stop -->
-                  <ptr target="http://papyri.info/biblio/59143"/>
-                  <biblScope n="1" unit="number">2</biblScope>
-                  <biblScope n="2" unit="chapter"/>
-                  <biblScope n="3" unit="page" from="60" to="66">60-66</biblScope>
-               </bibl>
-               <bibl n="6" type="reference" subtype="study">
-            <!-- ignore - start, i.e. SoSOL users may not edit this -->
-            <!-- ignore - stop -->
-                  <ptr target="http://papyri.info/biblio/76872"/>
-                  <biblScope n="1" unit="volume"/>
-                  <biblScope n="2" unit="chapter"/>
-                  <biblScope n="3" unit="page">35</biblScope>
+               <bibl type="publication" subtype="ancient">
+                  <author xml:lang="grc"
+                          ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0012 http://cwkb.org/author/id/927/rdf">Homerus</author>
+                  <title type="main"
+                         level="m"
+                         ref="http://www.trismegistos.org/authorwork/511 http://cwkb.org/work/id/2815/rdf">Ilias</title>
+                  <biblScope n="1" unit="book">8</biblScope>
+                  <biblScope n="2" unit="line" from="62" to="75">62-75</biblScope>
+                  <biblScope n="3" unit="generic">and</biblScope>
+                  <biblScope n="4" unit="book">8</biblScope>
+                  <biblScope n="5" unit="line" from="96" to="116">96-116</biblScope>
+                  <biblScope n="6" unit="generic">and</biblScope>
+                  <biblScope n="7" unit="book">8</biblScope>
+                  <biblScope n="8" unit="line" from="436" to="461">436-461</biblScope>
                </bibl>
             </listBibl>
          </div>
       </body>
-  </text>
+   </text>
 </TEI>

--- a/DCLP/61/60366.xml
+++ b/DCLP/61/60366.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.23/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="m60366" xml:lang="en">
-  <teiHeader>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" xml:id="m60366">
+   <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A school text of Iliad 10</title>
+            <title>Fragments of Iliad 10</title>
          </titleStmt>
          <publicationStmt>
             <authority>Digital Corpus of Literary Papyri</authority>
@@ -12,7 +12,7 @@
             <idno type="TM">60366</idno>
             <idno type="LDAB">1487</idno>
             <idno type="filename">60366</idno>
-            <idno type="dclp-hybrid">mper.ns;1;3</idno>
+            <idno type="dclp-hybrid">pylon;7;1_3</idno>
             <idno type="MP3">00853.000</idno>
             <availability>
                <p>
@@ -93,6 +93,7 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="DCLP">Xwalk from Pylon</change>
          <change when="2021-12-16T11:50:33-05:00"
                  who="http://papyri.info/editor/users/Mike%20Sampson">Finalized - This is good to go.</change>
          <change when="2021-12-16T11:44:15-05:00"
@@ -101,15 +102,136 @@
                  who="http://papyri.info/editor/users/Mike%20Sampson">Submit - Updated meta and provided image link</change>
          <change when="2014-12-10" who="DCLP">Crosswalked to EpiDoc XML</change>
       </revisionDesc>
-  </teiHeader>
-  <text>
+   </teiHeader>
+   <text>
       <body>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
+
+<div n="G19791" type="textpart">
+
+<div n="ii" subtype="column" type="textpart">
+
+<ab>
+
+<lb n="1"/><gap reason="lost" extent="unknown" unit="line"/>
+
+<lb n="1"/><supplied reason="lost">νύκτα δι’ ἀμβροσίη</supplied>ν· μάλα τις <unclear>θρ</unclear><supplied reason="lost">ασυκάρδιος ἔσται.</supplied>
+
+<lb n="2"/><supplied reason="lost">τὸν δ’ ἀπαμειβόμε</supplied><unclear>ν</unclear>ος προσέφη κρ<unclear>ε</unclear><supplied reason="lost">ίων Ἀγαμέμνων·</supplied>
+
+<lb n="3"/><supplied reason="lost">χρεὼ βουλῆς ἐμὲ κ</supplied><unclear>α</unclear>ὶ σέ, διοτρεφὲς ὦ <supplied reason="lost">Μ</supplied><unclear>ε</unclear>ν<supplied reason="lost">έλαε,</supplied>
+
+<lb n="4"/><supplied reason="lost">κερδαλέης, ἥ τίς κ</supplied><unclear>ε</unclear>ν ἐρύσσεται ἠδὲ <supplied reason="lost">σα</supplied><unclear>ώ</unclear>σ<supplied reason="lost">ει</supplied>
+
+<lb n="5"/><supplied reason="lost">Ἀργείους καὶ νῆα</supplied>ς, ἐπεὶ Διὸς ἐτρά<unclear>π</unclear>ετ<unclear>ο</unclear> φ<supplied reason="lost">ρήν.</supplied>
+
+<lb n="6"/><supplied reason="lost">Ἑκτορέοις ἄρα μ</supplied><unclear>ᾶ</unclear>λλον ἐπὶ φρένα θῆχ’<g type="apostrophe"/> ἱερ<supplied reason="lost">οῖσιν.</supplied>
+
+<lb n="7"/><supplied reason="lost">οὐ γάρ πω ἰδόμ</supplied><unclear>η</unclear>ν, οὐδ’ ἔκλυον αὐδήσα<unclear>ν</unclear><supplied reason="lost">τος,</supplied>
+
+<lb n="8"/><supplied reason="lost">ἄνδρ’ <num value="1">ἕνα</num> τοσσά</supplied><unclear>δ</unclear>ε μέρμερ’ <subst><add place="inline">ἐπ’</add><del rend="corrected">απ</del></subst> ἤματι μ<unclear>η</unclear><supplied reason="lost">τίσασθαι,</supplied>
+
+<lb n="9"/><supplied reason="lost">ὅσσ’ Ἕκτωρ ἔρρεξε</supplied> <unclear>δ</unclear>ιίφ<unclear>ιλ</unclear>ος υἷας Ἀχαιῶν<g type="middot"/>
+
+<lb n="10"/><supplied reason="lost">αὔτως, οὔτε θεᾶς</supplied> υἱὸς φίλος οὔτε θεοῖο.<g type="middot"/>
+
+<lb n="11"/><supplied reason="lost">ἔργα δ’ ἔρεξ’ ὅσα φη</supplied>μὶ μελη<unclear>σ</unclear>έμεν <choice><reg>Ἀργείοισι</reg><orig>Ἀργίοισι</orig></choice>
+
+<lb n="12"/><supplied reason="lost">δηθά τε καὶ δολι</supplied><unclear>χ</unclear>όν· <subst><add place="inline">τόσα</add><del rend="corrected">τ<gap reason="illegible" quantity="1" unit="character"/>σα</del></subst> γὰρ κ<unclear>ακ</unclear>ὰ μήσατ’ <supplied reason="lost">Ἀχαιούς.</supplied>
+
+<lb n="13"/><supplied reason="lost">ἀλλ’ ἴθι νῦν Αἴαντ</supplied><unclear>α</unclear> καὶ Ἰδομεν<unclear>ῆα</unclear> <unclear>κάλεσ</unclear><supplied reason="lost">σον</supplied>
+
+<lb n="14"/><supplied reason="lost">ῥίμφα θέων παρὰ</supplied> νῆας· ἐγὼ <unclear>δ</unclear>’ ἐπὶ <unclear>Νέσ</unclear>τορα <supplied reason="lost">δῖον</supplied>
+
+<lb n="15"/><supplied reason="lost">εἶμι καὶ ὀτρυνέω</supplied> ἀνστήμεναι, αἴ <unclear>κ</unclear>’ ἐθέληι<supplied reason="lost">σιν</supplied>
+
+<lb n="16"/><supplied reason="lost">ἐλθεῖν ἐς φυλάκ</supplied>ων ἱερὸν τέλος <unclear>ἠδ</unclear>’ <unclear>ἐ</unclear>πιτ<supplied reason="lost">εῖλαι.</supplied>
+
+<lb n="17"/><supplied reason="lost">κείνου γάρ κε μάλι</supplied><unclear>στα</unclear> <unclear>π</unclear><supplied reason="lost">ιθο</supplied><unclear>ί</unclear>ατ<supplied reason="lost">ο· τοῖο γὰρ υἱὸς</supplied>
+</ab></div></div>
+
+<div n="G19794" type="textpart">
+
+<div n="iii" subtype="column" type="textpart">
+
+<ab>
+
+<lb n="1"/><supplied reason="lost">ἀσ</supplied><unclear>π</unclear>ὶς καὶ <num value="2">δύο</num> <unclear>δ</unclear><supplied reason="lost">ο</supplied><unclear>ῦρ</unclear>ε φαεινή <unclear>τ</unclear><supplied reason="lost">ε τρυ</supplied><unclear>φάλεια</unclear>·
+
+<lb n="2"/><supplied reason="lost">π</supplied>ὰρ δὲ ζωστὴρ κεῖτο παναί<supplied reason="lost">ολος, ὧι</supplied> <unclear>ῥ</unclear>’ <unclear>ὁ</unclear> γεραιός
+
+<lb n="3"/><supplied reason="lost">ζ</supplied><unclear>ώ</unclear>ννυθ’, ὅτ’ ἐ<unclear>ς</unclear> πόλεμον φθ<supplied reason="lost">εισήνο</supplied><unclear>ρ</unclear><supplied reason="lost">α</supplied> <choice><reg>θωρή<supplied reason="lost">σσοιτο</supplied></reg><orig>θωρί<supplied reason="lost">σσοιτο</supplied></orig></choice>
+
+<lb n="4"/><supplied reason="lost">λ</supplied><unclear>α</unclear>ὸν ἄγων, ἐπ<unclear>εὶ</unclear> οὐ μὲ<unclear>ν</unclear> ἐπέ<supplied reason="lost">τρεπε γ</supplied><unclear>ήρ</unclear>α<supplied reason="lost">ϊ λυγρῶι.</supplied>
+
+<lb n="5"/><supplied reason="lost">ὀρ</supplied>θωθεὶς δ’ ἄ<supplied reason="lost">ρ</supplied>’ ἐπ’ ἀγκῶνος, <supplied reason="lost">κεφαλ</supplied><unclear>ὴ</unclear>ν ἐ<supplied reason="lost">παείρας,</supplied>
+
+<lb n="6"/><supplied reason="lost">Ἀτ</supplied>ρείδην π<unclear>ρ</unclear>οσέε<unclear>ι</unclear>πε καὶ <unclear>ἐ</unclear><supplied reason="lost">ξερεε</supplied><unclear>ί</unclear><supplied reason="lost">ν</supplied>ετ<supplied reason="lost">ο μύθωι·</supplied>
+
+<lb n="7"/><supplied reason="lost">τί</supplied>ς δ’ οὗτος κα<unclear>τὰ</unclear> ν<unclear>ῆ</unclear>ας ἀνὰ <unclear>σ</unclear><supplied reason="lost">τρατ</supplied>ὸν ἔρ<unclear>χ</unclear><supplied reason="lost">εαι οἶος</supplied>
+
+<lb n="8"/><supplied reason="lost">νύ</supplied><unclear>κ</unclear>τα δι’ ὀρ<supplied reason="lost">φναίη</supplied>ν, ὅτε θ’ ε<unclear>ὕ</unclear><supplied reason="lost">δουσι</supplied> <unclear>β</unclear>ρο<unclear>τ</unclear><supplied reason="lost">οὶ ἄλλοι,</supplied>
+
+<lb n="9"/><supplied reason="lost">ἠέ</supplied> <unclear>τ</unclear>ιν’ οὐρήω<supplied reason="lost">ν διζ</supplied><unclear>ή</unclear>μενο<supplied reason="lost">ς, ἤ τιν’ ἑ</supplied>ταί<supplied reason="lost">ρων;</supplied>
+
+<lb n="10"/><supplied reason="lost">φθέ</supplied>γγεο, μηδ’<g type="apostrophe"/> <supplied reason="lost">ἀκέω</supplied>ν ἐπ’ ἔ<supplied reason="lost">μ’ ἔρ</supplied><unclear>χε</unclear><supplied reason="lost">ο. τ</supplied><unclear>ί</unclear>πτ<supplied reason="lost">ε δέ σε χρεώ;</supplied>
+
+<lb n="11"/><supplied reason="lost">τὸ</supplied><unclear>ν</unclear> δ’ ἠμεί<unclear>βε</unclear><supplied reason="lost">τ’ ἔπε</supplied>ιτα ἄ<supplied reason="lost">ναξ ἀ</supplied><unclear>νδρ</unclear>ῶν <supplied reason="lost">Ἀγαμέμνων·</supplied>
+
+<lb n="12"/><supplied reason="lost">ὦ Νέ</supplied><unclear>στ</unclear>ο<supplied reason="lost">ρ</supplied> Νηλ<supplied reason="lost">ηϊάδη, μέγα κῦδος Ἀχαιῶν,</supplied>
+
+<lb n="13"/><supplied reason="lost">γνώσε</supplied><unclear>α</unclear>ι Ἀτ<supplied reason="lost">ρείδη</supplied><unclear>ν</unclear> Ἀγ<supplied reason="lost">αμέμνονα, τὸν περὶ πάντων</supplied>
+
+<lb n="14"/><supplied reason="lost">Ζεὺς ἐνέ</supplied>ηκε <supplied reason="lost">πόνοισ</supplied>ι δι<supplied reason="lost">αμπερές, εἰς ὅ κ’ ἀϋτμή</supplied>
+
+<lb n="15"/><supplied reason="lost">ἐν στήθ</supplied><unclear>ε</unclear>σσ<unclear>ι</unclear> <supplied reason="lost">μένηι</supplied> καί μ<supplied reason="lost">οι φίλα γούνατ’ ὀρώρηι.</supplied>
+
+<lb n="16"/><supplied reason="lost">πλάζομαι ὧ</supplied><unclear>δ</unclear>’, <supplied reason="lost">ἐπεὶ οὔ</supplied> <unclear>μο</unclear>ι <supplied reason="lost">ἐ</supplied>π’ <unclear>ὄμ</unclear><supplied reason="lost">μασι νήδυμος ὕπνος</supplied>
+
+<lb n="17"/><supplied reason="lost">ἱζάνει, ἀλλὰ μέλει πό</supplied>λεμο<unclear>ς</unclear> <unclear>κ</unclear>αὶ <supplied reason="lost">κήδε’ Ἀχαιῶν.</supplied>
+
+<lb n="18"/><supplied reason="lost">αἰνῶς γὰρ Δαναῶν</supplied> <unclear>π</unclear>ε<unclear>ρ</unclear><supplied reason="lost">ι</supplied>δ<supplied reason="lost">ε</supplied>ίδ<supplied reason="lost">ια, οὐδέ μοι ἦτορ</supplied>
+
+<lb n="19"/><supplied reason="lost">ἔμπεδον, ἀλλ’ ἀλαλ</supplied><unclear>ύκ</unclear>τη<unclear>μαι</unclear>, <unclear>κ</unclear><supplied reason="lost">ραδίη δέ μοι ἔξω</supplied>
+
+<lb n="20"/><supplied reason="lost">στηθέων ἐκθρώισκει,</supplied> <unclear>τρ</unclear>ο<unclear>μέ</unclear><supplied reason="lost">ει δ’ ὑπὸ φαίδιμα γυῖα.</supplied>
+
+<lb n="21"/><supplied reason="lost">ἀλλ’ εἴ τι δραίνεις, ἐπεὶ</supplied> <unclear>ο</unclear>ὐδ<supplied reason="lost">ὲ σέ γ’ ὕπνος ἱκάνει,</supplied>
+
+<lb n="22"/><supplied reason="lost">δεῦρ’ ἐς τοὺς φύλακας</supplied> <unclear>κ</unclear>α<unclear>τ</unclear><supplied reason="lost">αβείομεν, ὄφρα ἴδωμεν,</supplied>
+
+<lb n="23"/><supplied reason="lost">μὴ τοὶ μὲν καμάτωι ἀδ</supplied><unclear>ηκό</unclear><supplied reason="lost">τες ἠδὲ καὶ ὕπνωι</supplied>
+
+<lb n="24"/><supplied reason="lost">κοιμήσωνται, ἀτὰρ φ</supplied>υλ<unclear>α</unclear><supplied reason="lost">κῆς ἐπὶ πάγχυ λάθωνται·</supplied>
+
+<lb n="25"/><supplied reason="lost">δυσμενέες δ’ ἄνδρες σ</supplied>χεδ<supplied reason="lost">ὸν εἵαται, οὐδέ τι ἴδμεν,</supplied>
+
+<lb n="26"/><gap reason="lost" quantity="2" unit="line"/>
+
+<lb n="28"/><supplied reason="lost">Ἀτρείδη</supplied> <unclear>κύ</unclear><supplied reason="lost">διστε, ἄν</supplied><unclear>αξ</unclear> <unclear>ἀν</unclear><supplied reason="lost">δρ</supplied><unclear>ῶ</unclear><supplied reason="lost">ν Ἀγάμεμνον,</supplied>
+
+<lb n="29"/><supplied reason="lost">οὔ θην Ἕκτο</supplied><unclear>ρι</unclear> <supplied reason="lost">πάντα</supplied> <unclear>νο</unclear><supplied reason="lost">ήμ</supplied><unclear>ατα</unclear> <unclear>μη</unclear><supplied reason="lost">τίετα Ζεύς</supplied>
+
+<lb n="30"/><supplied reason="lost">ἐκτελέει, ὅσ</supplied><unclear>α</unclear> <unclear>π</unclear>ο<supplied reason="lost">ύ</supplied> ν<unclear>υν</unclear> <supplied reason="lost">ἐ</supplied><unclear>έλπε</unclear>ται· ἀ<supplied reason="lost">λλά μιν οἴω</supplied>
+
+<lb n="31"/><supplied reason="lost">κήδεσι μοχ</supplied><unclear>θή</unclear><supplied reason="lost">σειν</supplied> καὶ πλ<supplied reason="lost">ε<supplied reason="omitted">ί</supplied></supplied>ο<supplied reason="lost">σ</supplied><unclear>ι</unclear>ν, εἴ κ<unclear>ε</unclear><supplied reason="lost">ν Ἀχιλλεύς</supplied>
+
+<lb n="32"/><supplied reason="lost">ἐκ χόλου ἀργα</supplied><unclear>λέ</unclear>οιο με<unclear>τ</unclear>ασ<supplied reason="lost">τ</supplied><unclear>ρ</unclear>έ<unclear>ψη</unclear><supplied reason="lost">ι</supplied> φ<unclear>ί</unclear><supplied reason="lost">λον ἦτορ.</supplied>
+
+<lb n="33"/><supplied reason="lost">σοὶ δὲ μάλ’ ἕ</supplied><unclear>ψ</unclear>ομ’ ἐγώ· πρ<unclear>ο</unclear><supplied reason="lost">τὶ</supplied> δ’ αὖ καὶ ἐ<supplied reason="lost">γείρομεν ἄλλους,</supplied>
+
+<lb n="34"/><supplied reason="lost">ἠμὲν Τυδείδ</supplied><unclear>ην</unclear> <unclear>δ</unclear>ου<unclear>ρικλυτ</unclear>ὸ<unclear>ν</unclear> <choice><reg>ἠ<supplied reason="lost">δ’</supplied></reg><orig>εἰ<supplied reason="lost">δ’</supplied></orig></choice> Ὀ<unclear>δυ</unclear><supplied reason="lost">σῆα</supplied>
+
+<lb n="35"/><supplied reason="lost">ἠδ’ Αἴαντα ταχ</supplied><unclear>ὺ</unclear>ν καὶ Φ<unclear>υ</unclear><supplied reason="lost">λ</supplied><unclear>έο</unclear>ς ἄλκι<supplied reason="lost">μον υἱόν.</supplied>
+
+<lb n="36"/><supplied reason="lost">ἀλλ’ εἴ τις καὶ</supplied> τ<unclear>ο</unclear>ύσδε μετ<unclear>οι</unclear>χόμε<supplied reason="lost">ν</supplied><unclear>ο</unclear>ς <supplied reason="lost">καλέσειεν,</supplied>
+
+<lb n="37"/><supplied reason="lost">ἀντίθεόν τ’ Αἴ</supplied><unclear>α</unclear>ντα καὶ Ἰδο<unclear>με</unclear><supplied reason="lost">ν</supplied><unclear>ῆα</unclear> <unclear>ἄ</unclear>ν<supplied reason="lost">ακτα·</supplied>
+</ab></div></div></div>
          <div type="bibliography" subtype="principalEdition">
             <listBibl>
-               <bibl n="1" type="reference" subtype="partial">
+               <bibl n="1" type="reference" subtype="previous">
                   <title level="s" type="abbreviated">MPER N.S.</title>
-                  <!-- ignore - start, i.e. SoSOL users may not edit this -->
-                  <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/3034"/>
                   <biblScope n="1" unit="number">3</biblScope>
                   <biblScope n="2" unit="generic">(= 2-3 b)</biblScope>
@@ -117,8 +239,6 @@
                </bibl>
                <bibl n="2" type="reference" subtype="catalogue">
                   <title level="m" type="main">Studies in the Text and Transmission of the Iliad.</title>
-                  <!-- ignore - start, i.e. SoSOL users may not edit this -->
-                  <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/16711"/>
                   <biblScope n="1" unit="number">288</biblScope>
                   <biblScope n="2" unit="book"/>
@@ -126,20 +246,31 @@
                </bibl>
                <bibl n="3" type="reference" subtype="catalogue">
                   <title level="m" type="main">Studies in the Text and Transmission of the Iliad.</title>
-                  <!-- ignore - start, i.e. SoSOL users may not edit this -->
-                  <!-- ignore - stop -->
                   <ptr target="http://papyri.info/biblio/16711"/>
                   <biblScope n="1" unit="number">367</biblScope>
                   <biblScope n="2" unit="book"/>
                   <biblScope n="3" unit="book"/>
                </bibl>
-               <bibl n="4" type="reference" subtype="partial">
-            <!-- ignore - start, i.e. SoSOL users may not edit this -->
-            <!-- ignore - stop -->
+               <bibl n="4" type="reference" subtype="previous">
                   <ptr target="http://papyri.info/biblio/3889"/>
                   <biblScope n="1" unit="number">1</biblScope>
                   <biblScope n="2" unit="chapter"/>
                   <biblScope n="3" unit="page"/>
+               </bibl>
+               <bibl n="5" type="publication" subtype="principal">
+                  <ptr target="https://papyri.info/biblio/97293"/>
+                  <biblScope n="1" unit="number">3</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <listBibl>
+               <bibl type="printed">Liège</bibl>
+               <bibl type="online">
+                  <ptr target="http://data.onb.ac.at/rec/RZ00003953"/>
+               </bibl>
+               <bibl type="online">
+                  <ptr target="https://doi.org/10.48631/pylon.2025.7.112017"/>
                </bibl>
             </listBibl>
          </div>
@@ -162,15 +293,6 @@
                </bibl>
             </listBibl>
          </div>
-         <div type="edition" xml:space="preserve" xml:lang="grc"/>
-         <div type="bibliography" subtype="illustrations">
-            <listBibl>
-               <bibl type="printed">Liège</bibl>
-               <bibl type="online">
-                  <ptr target="http://data.onb.ac.at/rec/RZ00003953"/>
-               </bibl>
-            </listBibl>
-         </div>
       </body>
-  </text>
+   </text>
 </TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.2_1.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.2_1.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title>Letter concerning a sum of money</title>
-            </titleStmt>
-            <publicationStmt>
-                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-                <idno type="filename">pylon.4.2_1</idno>
-                <idno type="ddb-hybrid">pylon;4;2_1</idno>
-                <idno type="HGV">987697</idno>
-                <idno type="TM">987697</idno>
-                <availability>
-                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>pylon.4.2_1</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.4.2_1</idno>
+            <idno type="ddb-hybrid">pylon;4;2_1</idno>
+            <idno type="HGV">987697</idno>
+            <idno type="TM">987697</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
                         <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
                             Commons Attribution 3.0 License</ref>.</p>
-                </availability>
-            </publicationStmt>
-            <sourceDesc>
-                <p/>
-            </sourceDesc>
-        </fileDesc>
-        <profileDesc>
-            <langUsage>
-                <language ident="en">English</language>
-                <language ident="grc">Greek</language>
-                <language ident="la">Latin</language>
-            </langUsage>
-        </profileDesc>
-        <revisionDesc>
-          <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
-        </revisionDesc>
-    </teiHeader>
-    <text>
-        <body>
-            <head/>
-            <div xml:lang="grc" type="edition" xml:space="preserve">
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <head/>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
 <div n="r" type="textpart"><ab>
 <lb n="1"/><g type="stauros"/>
 <lb n="2"/><supplied reason="lost"><g type="stauros"/> καθὼς καὶ κα</supplied>τὰ <subst><add place="inline">πρόσω<add place="above">πον</add></add><del rend="corrected">προ<gap reason="illegible" quantity="2" unit="character"/></del></subst> παρεκάλεσα <subst><add place="inline">τὴν</add><del rend="corrected"><gap reason="illegible" quantity="1" unit="character"/>ην</del></subst><subst><add place="inline">πάνσοφον</add><del rend="corrected">σοφ<gap reason="illegible" quantity="7" unit="character"/></del></subst> καὶ περίβλεπτον
@@ -51,6 +51,6 @@
 <div n="v" type="textpart"><ab>
 <lb n="10"/><g type="stauros"/> <expan>δεσπό<ex>τῃ</ex></expan> ἐμῷ τὰ <expan>π<ex>ά</ex>ντ<ex>α</ex></expan> <expan>σοφωτά<ex>τῳ</ex></expan> <expan>γνη<ex>σίῳ</ex></expan> <expan>φίλ<ex>ῳ</ex></expan> <expan><ex>καὶ</ex></expan> <expan>ἀδ<supplied reason="lost">ε</supplied><unclear>λ</unclear>φ<ex>ῷ</ex></expan> <expan>κυρ<ex>ίῳ</ex></expan> Ἰω<gap reason="lost" extent="unknown" unit="character"/>
 </ab></div></div>
-        </body>
-    </text>
+      </body>
+   </text>
 </TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.2_2.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.2_2.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title/>
-            </titleStmt>
-            <publicationStmt>
-                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-                <idno type="filename">pylon.4.2_2</idno>
-                <idno type="ddb-hybrid">pylon;4;2_2</idno>
-                <idno type="TM">989102</idno>
-                <idno type="HGV">989102</idno>
-                <availability>
-                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>pylon.4.2_2</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.4.2_2</idno>
+            <idno type="ddb-hybrid">pylon;4;2_2</idno>
+            <idno type="TM">989102</idno>
+            <idno type="HGV">989102</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
                         <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
                             Commons Attribution 3.0 License</ref>.</p>
-                </availability>
-            </publicationStmt>
-            <sourceDesc>
-                <p/>
-            </sourceDesc>
-        </fileDesc>
-        <profileDesc>
-            <langUsage>
-                <language ident="en">English</language>
-                <language ident="grc">Greek</language>
-                <language ident="la">Latin</language>
-            </langUsage>
-        </profileDesc>
-        <revisionDesc>
-          <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
-        </revisionDesc>
-    </teiHeader>
-    <text>
-        <body>
-            <head xml:lang="en"/>
-            <div xml:lang="grc" type="edition" xml:space="preserve">
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <head xml:lang="en"/>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
 <lb n="1"/><supplied reason="lost" cert="low">Ἐπεὶ</supplied>φ <num value="23">κγ</num> σίτου ϡοα <num value="1/2">𐅵</num> <num value="1/3" rend="tick"><unclear>γ</unclear></num> <supplied reason="lost"><num value="1/4" rend="tick">δ</num></supplied> <gap reason="lost" extent="unknown" unit="character"/> 
 <lb n="2"/><expan><ex>ὑπὲρ</ex></expan> <expan>Θεοδοσιουπόλ<ex>εως</ex></expan> σίτου α <num value="1/4" rend="tick">δ</num> <num value="1/24" rend="tick"><unclear>κ</unclear>δ</num>
@@ -59,6 +59,6 @@
 <lb n="17"/><expan><ex>ὑπὲρ</ex></expan> <expan>λοιπάδ<ex>ος</ex></expan> ἐμβ<unclear>ολ</unclear><supplied reason="lost">ῆ</supplied><unclear>ς</unclear> Ἀντινόου <expan><ex>ἀρτάβη</ex></expan> <num value="1">α</num> <expan>κ<ex>εράτιον</ex></expan> <num value="1">α</num>
 <lb n="18"/><expan><ex>ὑπὲρ</ex></expan> <expan>ἀναλωματ<ex>- </ex></expan> <gap reason="lost" extent="unknown" unit="character"/> <expan><unclear>ὁμ</unclear><ex>οῦ</ex></expan> <expan>κ<ex>εράτια</ex></expan> <num value="8"><unclear>η</unclear></num>
 </ab></div>
-        </body>
-    </text>
+      </body>
+   </text>
 </TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.2_3.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.2_3.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title>Letter to Kyriakos requesting the intervention of a bishop</title>
-            </titleStmt>
-            <publicationStmt>
-                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-                <idno type="filename">pylon.4.2_3</idno>
-                <idno type="ddb-hybrid">pylon;4;2_3</idno>
-                <idno type="HGV">987698</idno>
-                <idno type="TM">987698</idno>
-                <availability>
-                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>pylon.4.2_3</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.4.2_3</idno>
+            <idno type="ddb-hybrid">pylon;4;2_3</idno>
+            <idno type="HGV">987698</idno>
+            <idno type="TM">987698</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
                         <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
                             Commons Attribution 3.0 License</ref>.</p>
-                </availability>
-            </publicationStmt>
-            <sourceDesc>
-                <p/>
-            </sourceDesc>
-        </fileDesc>
-        <profileDesc>
-            <langUsage>
-                <language ident="en">English</language>
-                <language ident="grc">Greek</language>
-                <language ident="la">Latin</language>
-            </langUsage>
-        </profileDesc>
-        <revisionDesc>
-           <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
-        </revisionDesc>
-    </teiHeader>
-    <text>
-        <body>
-            <head xml:lang="en"/>
-            <div xml:lang="grc" type="edition" xml:space="preserve">
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <head xml:lang="en"/>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
 <div n="r" type="textpart"><ab>
 <lb n="1"/><unclear><g type="stauros"/></unclear> 
 <lb n="2"/><g type="stauros"/> καθὼς <unclear>τὸ</unclear> <choice><reg>πρῶτον</reg><orig>προ͂των</orig></choice> ἔγραψα τῇ σου <choice><reg>δεσποτείᾳ</reg><orig>δεσποτίᾳ</orig></choice> <choice><reg>ἕνεκεν</reg><orig>ἕνεγκεν</orig></choice> <choice><reg><app type="alternative"><lem>τῶν μικρῶν κλήρων</lem><rdg>τοῦ μικροῦ κλήρου</rdg></app></reg><orig>τῶ μικρον κληρον</orig></choice> <choice><reg>καταξιώσῃ</reg><orig>καταξιόσι</orig></choice>
@@ -50,6 +50,6 @@
 <lb n="8"/>κυρίῳ <choice><reg>κόμητι</reg><orig><expan>κόμιτ<ex>ι</ex></expan></orig></choice> Κυριακῷ 
 <lb n="9"/><supplied reason="lost"><g type="stauros"/></supplied> <gap reason="lost" extent="unknown" unit="character"/><unclear>ς</unclear> <unclear>ὑ</unclear>μέτε<unclear>ρος</unclear> δοῦλος <unclear>καὶ</unclear> <unclear>ἀδελ</unclear>φός <unclear><g type="stauros"/></unclear> <gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="3" unit="character"/>
 </ab></div></div>
-        </body>
-    </text>
+      </body>
+   </text>
 </TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.3_1.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.3_1.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title>Receipt for payment of apomoira into bank of Herakleides</title>
-            </titleStmt>
-            <publicationStmt>
-                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-                <idno type="filename">pylon.4.3_1</idno>
-                <idno type="ddb-hybrid">pylon;4;3_1</idno>
-                <idno type="HGV">987699</idno>
-                <idno type="TM">987699</idno>
-                <availability>
-                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>pylon.4.3_1</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.4.3_1</idno>
+            <idno type="ddb-hybrid">pylon;4;3_1</idno>
+            <idno type="HGV">987699</idno>
+            <idno type="TM">987699</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
                         <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
                             Commons Attribution 3.0 License</ref>.</p>
-                </availability>
-            </publicationStmt>
-            <sourceDesc>
-                <p/>
-            </sourceDesc>
-        </fileDesc>
-        <profileDesc>
-            <langUsage>
-                <language ident="en">English</language>
-                <language ident="grc">Greek</language>
-                <language ident="la">Latin</language>
-            </langUsage>
-        </profileDesc>
-        <revisionDesc>
-           <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
-        </revisionDesc>
-    </teiHeader>
-    <text>
-        <body>
-            <head/>
-            <div xml:lang="grc" type="edition" xml:space="preserve">
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <head/>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
 <lb n="1"/><supplied reason="lost">ἔτους</supplied> <gap reason="lost" extent="unknown" unit="character"/><num value="5"><hi rend="supraline">ε</hi></num> <expan>τέ<ex>τακται</ex></expan> ἐπὶ τὴν
 <lb n="2"/><supplied reason="lost">ἐν Διὸς πόλει τῆ</supplied>ι <expan>με<ex>γάληι</ex></expan> <expan>τρά<ex>πεζαν</ex></expan> ἐφ’ ἧς Ἡρακλε<unclear>ίδη</unclear><add place="above"><unclear>ς</unclear></add>
@@ -44,7 +44,7 @@
 <lb n="4"/><gap reason="lost" quantity="3" unit="character" precision="low"><certainty match=".." locus="name"/></gap><gap reason="illegible" quantity="1" unit="character"/>ς <num value="4550">τετρακισχιλ<unclear>ί</unclear>ας 
 <lb n="5"/><supplied reason="lost">πεντακοσ</supplied>ίας πεντήκ<unclear>ο</unclear>ντα</num>
 <lb n="6"/><supplied reason="lost"><expan><ex>γίνονται</ex></expan></supplied> <num value="4550"><supplied reason="lost">Δ</supplied>φν</num> <space extent="unknown" unit="character"/> <expan>Ἡρακλ<ex>είδης</ex></expan> <expan>τρα<ex>πεζίτης</ex></expan> 
-<lb n="7" rend="indent"/> <num value="4800">Δω</num></ab></div>   
-        </body>
-    </text>
+<lb n="7" rend="indent"/> <num value="4800">Δω</num></ab></div>
+      </body>
+   </text>
 </TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.3_2.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.3_2.xml
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title>Receipt for payment of epigraphe by Ptolemaios, son of Pyrrhos, who is probably a known infantry commander</title>
-            </titleStmt>
-            <publicationStmt>
-                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-                <idno type="filename">pylon.4.3_2</idno>
-                <idno type="ddb-hybrid">pylon;4;3_2</idno>
-                <idno type="HGV">987700</idno>
-                <idno type="TM">987700</idno>
-                <availability>
-                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>pylon.4.3_2</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.4.3_2</idno>
+            <idno type="ddb-hybrid">pylon;4;3_2</idno>
+            <idno type="HGV">987700</idno>
+            <idno type="TM">987700</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
                         <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
                             Commons Attribution 3.0 License</ref>.</p>
-                </availability>
-            </publicationStmt>
-            <sourceDesc>
-                <p/>
-            </sourceDesc>
-        </fileDesc>
-        <profileDesc>
-            <langUsage>
-                <language ident="en">English</language>
-                <language ident="grc">Greek</language>
-                <language ident="la">Latin</language>
-            </langUsage>
-        </profileDesc>
-        <revisionDesc>
-           <change when="2023-12-22T09:13:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
-        </revisionDesc>
-    </teiHeader>
-    <text>
-        <body>
-            <head/>
-            <div xml:lang="grc" type="edition" xml:space="preserve">
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-12-22T09:13:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <head/>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
 <lb n="1" xml:id="ed2ln1"/>ἔτους <num value="50">ν</num> Μεσορη <num value="20"><hi rend="supraline"><unclear>κ</unclear></hi></num> <expan>με<ex>μέτρηκεν</ex></expan> εἰς τὸν
 <lb n="2" xml:id="ed2ln2"/>ἐν Διὸς <expan>πόλ<ex>ει</ex></expan> τῆι <expan>με<ex>γάληι</ex></expan> <expan>θη<ex>σαυρὸν</ex></expan> <num value="50">ν</num> <expan><ex>ἔτους</ex></expan> ὑπὲρ <unclear>το</unclear>ῦ <expan>τόπ<ex>ου</ex></expan>
 <lb n="3" xml:id="ed2ln3"/>Πτολεμαῖος Πύρρου <expan><ex>πυροῦ</ex></expan> <num value="16">δέκα ἓξ</num>
 <milestone rend="paragraphos" unit="undefined"/>
 <lb n="4" rend="indent" xml:id="ed2ln4"/> <expan><ex>γίνονται</ex></expan> <expan><ex>πυροῦ</ex></expan> <num value="16">ιϛ</num> <space extent="unknown" unit="character"/> <expan>Ἀντ<ex>ιγένης</ex></expan></ab></div>
-        </body>
-    </text>
+      </body>
+   </text>
 </TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.5_1.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.5_1.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Receipt Addressed to a Beneficiarius</title>
+            <title>pylon.4.5_1</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.5_2.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.5_2.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title>Document with a Subscription by a Curator</title>
-            </titleStmt>
-            <publicationStmt>
-                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-                <idno type="filename">pylon.4.5_2</idno>
-                <idno type="ddb-hybrid">pylon;4;5_2</idno>
-                <idno type="HGV">987702</idno>
-                <idno type="TM">987702</idno>
-                <availability>
-                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>pylon.4.5_2</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.4.5_2</idno>
+            <idno type="ddb-hybrid">pylon;4;5_2</idno>
+            <idno type="HGV">987702</idno>
+            <idno type="TM">987702</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
                         <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
                             Commons Attribution 3.0 License</ref>.</p>
-                </availability>
-            </publicationStmt>
-            <sourceDesc>
-                <p/>
-            </sourceDesc>
-        </fileDesc>
-        <profileDesc>
-            <langUsage>
-                <language ident="en">English</language>
-                <language ident="grc">Greek</language>
-                <language ident="la">Latin</language>
-            </langUsage>
-        </profileDesc>
-        <revisionDesc>
-           <change when="2023-12-22T09:13:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
-        </revisionDesc>
-    </teiHeader>
-    <text>
-        <body>
-            <head xml:lang="en">Document with a Subscription by a Curator</head>
-            <div xml:lang="grc" type="edition" xml:space="preserve">
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-12-22T09:13:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <head xml:lang="en">Document with a Subscription by a Curator</head>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
 <lb n="1"/><gap reason="lost" extent="unknown" unit="line"/>     
 <lb n="1" xml:id="ed2ln1"/><supplied reason="lost"><expan><ex>ἔτους</ex></expan> <app type="alternative"><lem><num value="1">α</num></lem><rdg><num value="2">β</num></rdg></app> Αὐτοκράτορος Καίσαρος Μάρκου Κλωδίου Πουπιηνοῦ</supplied>
@@ -47,6 +47,6 @@
 <lb n="6" xml:id="ed2ln6"/><handShift new="m3"/><expan>Αὐρήλ<ex>ιος</ex></expan> Μῶρος ὁ καὶ Λεωνίδης <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="7" xml:id="ed2ln7"/><handShift new="m4"/>ὁ καὶ Ἀσκληπιάδης κουράτωρ ἐπηκολο<unclear>ύ</unclear><supplied reason="lost">θηκα</supplied><gap reason="lost" extent="unknown" unit="character"/>
 </ab></div>
-        </body>
-    </text>
+      </body>
+   </text>
 </TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.7.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.7.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title>A Local Will with a “Codicillary” Clause</title>
-            </titleStmt>
-            <publicationStmt>
-                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-                <idno type="filename">pylon.4.7</idno>
-                <idno type="ddb-hybrid">pylon;4;7</idno>
-                <idno type="HGV">987703</idno>
-                <idno type="TM">987703</idno>
-                <availability>
-                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>pylon.4.7</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.4.7</idno>
+            <idno type="ddb-hybrid">pylon;4;7</idno>
+            <idno type="HGV">987703</idno>
+            <idno type="TM">987703</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
                         <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
                             Commons Attribution 3.0 License</ref>.</p>
-                </availability>
-            </publicationStmt>
-            <sourceDesc>
-                <p/>
-            </sourceDesc>
-        </fileDesc>
-        <profileDesc>
-            <langUsage>
-                <language ident="en">English</language>
-                <language ident="grc">Greek</language>
-                <language ident="la">Latin</language>
-            </langUsage>
-        </profileDesc>
-        <revisionDesc>
-           <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
-        </revisionDesc>
-    </teiHeader>
-    <text>
-        <body>
-            <head/>
-            <div xml:lang="grc" type="edition" xml:space="preserve">
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <head/>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
 <ab>
 <lb n="1"/><gap reason="lost" extent="unknown" unit="line"/>     
 <lb n="1"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" quantity="3" unit="character"/>ης σκευῶν ἢ ἄλλων <gap reason="lost" quantity="3" unit="character"/><gap reason="illegible" quantity="4" unit="character"/><gap reason="lost" quantity="3" unit="character"/><gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>
@@ -52,7 +52,7 @@
 <lb n="11"/><gap reason="lost" extent="unknown" unit="character"/> <subst><add place="inline"><choice><reg><supplied reason="lost">δ</supplied>ιαδεξάμενοι</reg><orig><supplied reason="lost">δ</supplied>ιαδεξόμενοι</orig></choice></add><del rend="corrected"><app type="alternative"><lem><supplied reason="lost">δ</supplied>ιαδελόμενοι</lem><rdg><supplied reason="lost">δ</supplied>ιαδεχόμενοι</rdg></app></del></subst> δὲ αὐτὴν ὁμοίως χορηγή<unclear>σ</unclear><supplied reason="lost">ουσι</supplied> <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="12"/><gap reason="lost" extent="unknown" unit="character"/><gap reason="illegible" quantity="1" unit="character"/><unclear>σ</unclear>θαι τῷ αὐτῷ <unclear>υ</unclear>ἱῷ μο<unclear>υ</unclear> <gap reason="illegible" quantity="9" unit="character"/>ωκ<gap reason="lost" extent="unknown" unit="character"/>
 <lb n="13"/><gap reason="lost" extent="unknown" unit="character"/> <supplied reason="lost">ἡ δι</supplied><unclear>α</unclear>θ<unclear>ήκη</unclear> κυρία. <space extent="unknown" unit="character"/>
-</ab></div>             
-        </body>
-    </text>
+</ab></div>
+      </body>
+   </text>
 </TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.8_1.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.8_1.xml
@@ -4,29 +4,29 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title/>
+            <title>pylon.4.8_1</title>
          </titleStmt>
-            <publicationStmt>
-               <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-               <idno type="filename">pylon.4.8_1</idno>
-               <idno type="ddb-hybrid">pylon;4;8_1</idno>
-               <idno type="HGV">369456</idno>
-               <idno type="TM">369456</idno>
-               <availability>
-                  <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.4.8_1</idno>
+            <idno type="ddb-hybrid">pylon;4;8_1</idno>
+            <idno type="HGV">369456</idno>
+            <idno type="TM">369456</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
                      <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 License</ref>.</p>
-               </availability>
-            </publicationStmt>
-            <sourceDesc>
-               <p/>
-            </sourceDesc>
-        </fileDesc>
-        <profileDesc>
-           <langUsage>
-              <language ident="en">English</language>
-              <language ident="grc">Greek</language>
-              <language ident="la">Latin</language>
-        </langUsage>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
       </profileDesc>
       <revisionDesc>
          <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
@@ -35,7 +35,7 @@
    <text>
       <body>
          <head xml:lang="en"/>
-            <div xml:lang="grc" type="edition" xml:space="preserve"><ab>
+         <div xml:lang="grc" type="edition" xml:space="preserve"><ab>
 <lb n="1"/><handShift new="m2"/><gap reason="lost" quantity="12" unit="character" precision="low"/> ἐπιτρόπ<unclear>ῳ</unclear> τοῦ κυρίου Καίσαρος
 <lb n="2"/><supplied reason="lost">παρὰ Στεφάνου</supplied> <unclear>Ἀ</unclear>πολλωνίου ἀπὸ Ἀλαβαστρίνης τῆς Ἀντινόου νομαρχίας
 <lb n="3"/><handShift new="m1"/><gap reason="lost" quantity="10" unit="character" precision="low"/> <expan><supplied reason="lost">νομάρ</supplied>χ<ex>ῃ</ex></expan> Ἀντινόου πόλεως <space extent="unknown" unit="character"/> παρὰ Στεφάνου Ἀπολλωνίου ἀπὸ Ἀλαβαστρίνης νομαρχίας Ἀντινόου

--- a/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.8_2.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.8_2.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title/>
-            </titleStmt>
-            <publicationStmt>
-                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-                <idno type="filename">pylon.4.8_2</idno>
-                <idno type="ddb-hybrid">pylon;4;8_2</idno>
-                <idno type="HGV">987704</idno>
-                <idno type="TM">987704</idno>
-                <availability>
-                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>pylon.4.8_2</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.4.8_2</idno>
+            <idno type="ddb-hybrid">pylon;4;8_2</idno>
+            <idno type="HGV">987704</idno>
+            <idno type="TM">987704</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
                         <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
                             Commons Attribution 3.0 License</ref>.</p>
-                </availability>
-            </publicationStmt>
-            <sourceDesc>
-                <p/>
-            </sourceDesc>
-        </fileDesc>
-        <profileDesc>
-            <langUsage>
-                <language ident="en">English</language>
-                <language ident="grc">Greek</language>
-                <language ident="la">Latin</language>
-            </langUsage>
-        </profileDesc>
-        <revisionDesc>
-           <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
-        </revisionDesc>
-    </teiHeader>
-    <text>
-        <body>
-            <head xml:lang="en"/>
-            <div xml:lang="grc" type="edition" xml:space="preserve"><ab>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-12-22T09:56:20-04:00" who="http://papyri.info/editor">Automated creation from template</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <head xml:lang="en"/>
+         <div xml:lang="grc" type="edition" xml:space="preserve"><ab>
 <lb n="1"/><gap reason="lost" extent="unknown" unit="character"/> <space extent="unknown" unit="character"/> Σαραπίωνι <space extent="unknown" unit="character"/> <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="2"/><gap reason="lost" extent="unknown" unit="character"/>λίων Μαξίμου το<unclear>ῦ</unclear> <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="3"/><gap reason="lost" extent="unknown" unit="character"/> <supplied reason="lost">ἐ</supplied>ν Ἀλαβαστρίνῃ ἔτι <gap reason="lost" extent="unknown" unit="character"/>
@@ -49,6 +49,6 @@
 <lb n="10"/><gap reason="lost" extent="unknown" unit="character"/> <supplied reason="lost">πρ</supplied>οστάγματ<gap reason="lost" extent="unknown" unit="character"/>
 <lb n="11"/><gap reason="lost" extent="unknown" unit="character"/><unclear>λι</unclear><gap reason="illegible" quantity="2" unit="character"/>ας <num value="580"><unclear>φ</unclear>π<certainty match="../@value" locus="value"/></num> <gap reason="lost" extent="unknown" unit="character"/>
 <lb n="12"/><gap reason="lost" extent="unknown" unit="line"/> </ab></div>
-        </body>
-    </text>
+      </body>
+   </text>
 </TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.9.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.4/pylon.4.9.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title>A Document in the Bodleian Addressed to the Governor of Arcadia </title>
-            </titleStmt>
-            <publicationStmt>
-                <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
-                <idno type="filename">pylon.4.9</idno>
-                <idno type="ddb-hybrid">pylon;4;9</idno>
-                <idno type="HGV">987705</idno>
-                <idno type="TM">987705</idno>
-                <availability>
-                    <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>pylon.4.9</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.4.9</idno>
+            <idno type="ddb-hybrid">pylon;4;9</idno>
+            <idno type="HGV">987705</idno>
+            <idno type="TM">987705</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
                         <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
                             Commons Attribution 3.0 License</ref>.</p>
-                </availability>
-            </publicationStmt>
-            <sourceDesc>
-                <p/>
-            </sourceDesc>
-        </fileDesc>
-        <profileDesc>
-            <langUsage>
-                <language ident="en">English</language>
-                <language ident="grc">Greek</language>
-                <language ident="la">Latin</language>
-            </langUsage>
-        </profileDesc>
-        <revisionDesc>
-            <change when="2023-12-15T11:29:08-04:00" who="http://papyri.info/editor">Automated creation from template</change>
-        </revisionDesc>
-    </teiHeader>
-    <text>
-        <body>
-            <head xml:lang="en"/>
-            <div xml:lang="grc" type="edition" xml:space="preserve"><ab>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-12-15T11:29:08-04:00" who="http://papyri.info/editor">Automated creation from template</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <head xml:lang="en"/>
+         <div xml:lang="grc" type="edition" xml:space="preserve"><ab>
     <lb n="1"/>τῇ τάξει τῆς ἐξουσίας τοῦ <unclear>κ</unclear><supplied reason="lost">υρίου</supplied> <supplied reason="lost">μου τοῦ λαμπροτάτου ἡγεμόνος</supplied>
 
     <lb n="2"/>ἐπαρχίας Ἀρκαδίας <supplied reason="lost"><space extent="unknown" unit="character"/></supplied>
@@ -77,6 +77,6 @@
 
     <lb n="5"/><gap reason="lost" extent="unknown" unit="line"/></ab>
 </div>	</div>
-        </body>
-    </text>
+      </body>
+   </text>
 </TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.5/pylon.5.2.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.5/pylon.5.2.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Dialysis </title>
+            <title>pylon.5.2</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
@@ -28,7 +28,8 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
-         <change when="2024-07-11T11:00:48-05:00" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon</change>
+         <change when="2024-07-11T11:00:48-05:00"
+                 who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon</change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/DDB_EpiDoc_XML/pylon/pylon.5/pylon.5.5.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.5/pylon.5.5.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Receipt for the poll tax from Elephantine </title>
+            <title>pylon.5.5</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
@@ -28,7 +28,8 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
-         <change when="2024-07-11T11:00:48-05:00" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon</change>
+         <change when="2024-07-11T11:00:48-05:00"
+                 who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon</change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/DDB_EpiDoc_XML/pylon/pylon.5/pylon.5.6.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.5/pylon.5.6.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>An Inscription from the Reign of Probus</title>
+            <title>pylon.5.6</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
@@ -28,7 +28,8 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
-         <change when="2024-07-12T11:00:48-05:00" who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon</change>
+         <change when="2024-07-12T11:00:48-05:00"
+                 who="https://papyri.info/editor/users/Mike%20Sampson">Xwalk from Pylon</change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/DDB_EpiDoc_XML/pylon/pylon.6/pylon.6.5.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.6/pylon.6.5.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Macedonia and other toponoyms from the Panopolite nome </title>
+            <title>pylon.6.5</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/DDB_EpiDoc_XML/pylon/pylon.6/pylon.6.7.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.6/pylon.6.7.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A property declaration from Theadelphia</title>
+            <title>pylon.6.7</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/DDB_EpiDoc_XML/pylon/pylon.6/pylon.6.8_1.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.6/pylon.6.8_1.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title/>
+            <title>pylon.6.8_1</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/DDB_EpiDoc_XML/pylon/pylon.6/pylon.6.8_2.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.6/pylon.6.8_2.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Gelasios to Papnouthes</title>
+            <title>pylon.6.8_2</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/DDB_EpiDoc_XML/pylon/pylon.6/pylon.6.8_3.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.6/pylon.6.8_3.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title/>
+            <title>pylon.6.8_3</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.3.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.3.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>An Arabic Private Letter from the Eighth Century</title>
+            <title>pylon.7.3</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.3.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.3.xml
@@ -10,8 +10,8 @@
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
             <idno type="filename">pylon.7.3</idno>
             <idno type="ddb-hybrid">pylon;7;3</idno>
-            <idno type="HGV">704976</idno>
-            <idno type="TM">704976</idno>
+            <idno type="HGV">999672</idno>
+            <idno type="TM">999672</idno>
             <availability>
                <p>© Duke Databank of Documentary Papyri. This work is licensed under a
                             <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.3.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.3.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>An Arabic Private Letter from the Eighth Century</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.7.3</idno>
+            <idno type="ddb-hybrid">pylon;7;3</idno>
+            <idno type="HGV">704976</idno>
+            <idno type="TM">704976</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+                            <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+                                Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="DDbDP">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="ar" type="edition" xml:space="preserve">
+
+<div n="r" type="textpart">
+<ab>
+
+<lb n="1"/><supplied reason="lost">بسم اللـه الرحمن الرحيم</supplied>
+
+
+<lb n="2"/><supplied reason="lost">من عمر بن مسلم الى</supplied><gap reason="lost" quantity="13" unit="char"/>ــد واحمد وفاطمة ابني عمر
+
+
+<lb n="3"/><supplied reason="lost">سلم عليكم فانــي احمــد اليكم الـ</supplied>ـله الذي لا اله الا هو
+
+
+<lb n="4"/><supplied reason="lost">اما بعد عافنا اللّه واياكم باحـ</supplied>ـسن عافيته فاتمها في الدنيا
+    
+
+<lb n="5"/><supplied reason="lost">والآخرة</supplied> <gap reason="lost" quantity="15" unit="char"/> والله محمود لم يحدث علي بعدكم
+
+
+<lb n="6"/><supplied reason="lost">الا خير</supplied> <gap reason="lost" quantity="15" unit="char"/> مع عامل اشمون وكتبت<gap reason="lost" extent="unknown" unit="char"/>ـعه
+    
+
+<lb n="7"/><gap reason="lost" quantity="20" unit="char"/>ــ<gap reason="lost" quantity="1" unit="char"/>ـو قد كتبت الي بخـ<supplied reason="lost">ـبـ</supplied>ـر من حالك
+    
+
+<lb n="8"/><gap reason="lost" quantity="15" unit="char"/> ىــحـه العامل يستوصي به
+    
+
+<lb n="9"/><gap reason="lost" quantity="20" unit="char"/> <gap reason="illegible" quantity="2" unit="char"/>ـشـ<gap reason="illegible" quantity="3" unit="char"/>
+    
+
+<lb n="9"/><gap reason="lost" extent="unknown" unit="line"/>
+</ab></div>
+
+<div n="v" type="textpart">
+<ab>
+
+<lb n="10"/>من عمر بن مسلم الى <gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> <gap reason="lost" extent="unknown" unit="char"/>
+</ab></div>
+                </div>
+      </body>
+   </text>
+</TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.4.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.4.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Compromissum</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.7.4</idno>
+            <idno type="ddb-hybrid">pylon;7;4</idno>
+            <idno type="HGV">1000275</idno>
+            <idno type="TM">1000275</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+                <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+                  Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="DDbDP">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
+
+<ab> 
+
+<lb n="1"/><g type="stauros">†</g> τὸ παρὸν κομ<unclear>π</unclear>ρόμισσον ποιοῦνται πρὸς ἀλλήλους ἑκου<unclear>σ</unclear>ίᾳ
+
+<lb n="2"/><unclear>γν</unclear>ώμῃ ἐκ μ<supplied reason="lost">ὲ</supplied><unclear>ν</unclear> τοῦ ἑνὸς <choice><reg>μέρους</reg><orig>μέρος</orig></choice> <expan>Πεκύ<ex>σιος</ex></expan> <expan>πρε<ex>σβύτερος</ex></expan> <unclear>υ</unclear><hi rend="diaeresis">ἱ</hi><unclear>ὸ</unclear>ς <unclear>Ν</unclear>ααραoυ
+
+<lb n="3"/>ἐκ δὲ τοῦ δευτ<unclear>έ</unclear>ρου μέρους Αμπα <choice><reg>υἱὸς</reg><orig>υ<hi rend="diaeresis">ἱ</hi>ῷ</orig></choice> <expan>Νααρ<ex>αo</ex>υ</expan> Πκανεε ἀμφ
+
+<lb n="4" break="no"/>ότεροι ἀπὸ κώμης Λευκογίο<supplied reason="lost">υ</supplied> τοῦ <expan>Ἡρ<ex>ακλεο</ex>π<ex>ολίτου</ex></expan> <subst><add place="inline"><unclear>ν</unclear>ομοῦ</add><del rend="corrected">πομου</del></subst>. <choice><reg>ἀμφιβολία<supplied reason="lost">ν</supplied></reg><orig>ἀμφιβο<unclear>λ</unclear>εί<unclear>α</unclear><supplied reason="lost">ν</supplied></orig></choice>
+
+<lb n="5"/><unclear>ἔ</unclear><supplied reason="lost">χ</supplied><unclear>ον</unclear>τ<unclear>ε</unclear><supplied reason="lost">ς</supplied> μετ’ ἀλλήλ<unclear>ω</unclear><supplied reason="lost">ν π</supplied><unclear>ε</unclear><supplied reason="lost">ρί τ</supplied><unclear>ιν</unclear>ων <supplied reason="lost">αὐτῶν κ</supplied><unclear>ε</unclear>
+
+<lb n="6" break="no"/><supplied reason="lost">φ</supplied>αλαίων καὶ μὴ δ<unclear>υ</unclear><supplied reason="lost">νηθέντ</supplied>ες <supplied reason="lost">δι’ ἑαυτῶν</supplied>
+
+<lb n="7"/><supplied reason="lost">ἀ</supplied>πα<unclear>λ</unclear>λ<unclear>α</unclear>γῆναι <unclear>ᾑ</unclear><supplied reason="lost">ρέσαν</supplied><unclear>τ</unclear>ο ἑ<supplied reason="lost">κουσίας</supplied>
+
+<lb n="8"/>αὐτῶν γνώμης <choice><reg>Κοσμᾶν</reg><orig>Κοσμᾶ</orig></choice> υἱὸν Παπᾶ κ<unclear>α</unclear>ὶ <choice><reg>Μηνᾶν</reg><orig>Μην<unclear>ᾶ</unclear></orig></choice>
+
+<lb n="9"/>υἱὸν Ἀντ<unclear>ω</unclear>νίου ὥστε αὐτοὺς δικαιολογήσασθαι
+
+<lb n="10"/>αὐτοῖς. τὸ δὲ παραβαῖνον μέρος τὴν διδομένη<unclear>ν</unclear>
+
+<lb n="11"/>π<unclear>α</unclear>ρ’ αὐτ<unclear>ῶ</unclear>ν δίκην παράσχῃ τῷ ἐμμέν<supplied reason="lost">ο</supplied>ντι ὑπ<unclear>ὲ</unclear>ρ
+
+<lb n="12"/>προστίμου <expan>χρυ<ex>σοῦ</ex></expan> <expan>νο<ex>μισμάτια</ex></expan> <num value="4">δ</num>. <expan>ἐγρ<ex>άφη</ex></expan> <expan>μ<ex>ηνὶ</ex></expan> <expan>Φαμ<ex>ενω</ex>θ</expan> <num value="21">κα</num> <expan>ἰνδ<ex>ικτίωνος</ex></expan> <num value="11">ια</num>. <g type="stauros">†</g>
+
+<lb n="13"/><handShift new="m2"/><foreign xml:lang="cop"><g type="stauros">†</g> ⲡⲓϭⲱϣ ⲡⲣⲉⲥⲃⲏⲧⲉⲣⲟⲥ<note><emph rend="italics">i.e.</emph> Greek πρεσβύτερος</note> ⲥⲧⲓⲭⲓⲛ<note><emph rend="italics">i.e.</emph> Greek στοιχεῖν</note> ⲉⲡⲉⲓⲕⲟⲩ<add place="above">ⲛ</add>
+
+<lb n="14" break="no"/>ⲡⲣⲱⲙⲓⲥⲥⲟⲛ<note>or ⲕⲟⲩⲛ|ⲡⲣⲱⲙⲓⲥⲱⲛ, <emph rend="italics">i.e.</emph> Greek κομπρόμισσον</note></foreign>  
+
+<lb n="15" rend="indent"/> <app type="alternative"><lem><handShift new="m1"/></lem><rdg><handShift new="m3"/></rdg></app> <g type="stauros">†</g> δι’ ἐμοῦ Ἰωάννου υἱοῦ Φιβ ἐγράφη <g type="stauros">†</g> <g type="stauros">†</g>
+</ab></div>
+      </body>
+   </text>
+</TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.4.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.4.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Compromissum</title>
+            <title>pylon.7.4</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.5.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.5.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A Late Antique Receipt for Grain from the Hermopolite Nome</title>
+            <title>pylon.7.5</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.5.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.5.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>A Late Antique Receipt for Grain from the Hermopolite Nome</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.7.5</idno>
+            <idno type="ddb-hybrid">pylon;7;5</idno>
+            <idno type="HGV">1000277</idno>
+            <idno type="TM">1000277</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+                            <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+                                Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="DDbDP">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
+
+<ab>
+    
+<lb n="1"/><g type="rho-cross">⳨</g> τῷ ἁγίῳ <choice><reg>μοναστηρίῳ</reg><orig>μοναστηρίου</orig></choice> ἄπα Δωροθέ<unclear>ο</unclear><supplied reason="lost">υ</supplied> <gap reason="lost" extent="unknown" unit="character"/>      
+    
+<lb n="2"/><gap reason="illegible" quantity="4" unit="character"/><gap reason="lost" quantity="1" unit="character"/><gap reason="illegible" quantity="2" unit="character"/>η<gap reason="illegible" quantity="1" unit="character"/>ω ἀπὸ <choice><reg>ἐποικίου</reg><orig>ἐποικείου</orig></choice> <choice><reg>Νειλάμμωνος</reg><orig>Νιλάμμωνος</orig></choice> <expan>π<ex>αρὰ</ex></expan> <gap reason="lost" extent="unknown" unit="character"/> 
+    
+<lb n="3"/>καὶ <hi rend="diaeresis">Ἰ</hi>ωσῆφις Ἰερεμίου <expan>ἀμφ<unclear>ο</unclear>τέ<unclear>ρ</unclear><ex>ων</ex></expan> κωμαρχ<unclear>ῶ</unclear><supplied reason="lost">ν κώμης</supplied> <gap reason="lost" extent="unknown" unit="character"/> <supplied reason="lost">τοῦ Ἑρμοπολίτου</supplied>
+    
+<lb n="4"/>νομοῦ <expan>χ<ex>αίρειν</ex></expan>. <choice><reg><app type="alternative"><lem>πεπληρώμεθα</lem><rdg>ἐπληρώθημεν</rdg></app></reg><orig>πεπληρώθην</orig></choice> παρὰ σοῦ ὑπὲρ σίτ<supplied reason="lost">ου</supplied> <gap reason="lost" quantity="5" unit="character"/><gap reason="illegible" quantity="1" unit="character"/>επι<gap reason="illegible" quantity="1" unit="character"/><gap reason="lost" extent="unknown" unit="character"/>  
+    
+<lb n="5"/>τετάρτου μέτρῳ Ἀθηναίῳ καὶ χρυσοῦ <expan><unclear>νο</unclear><ex>μίσματα</ex></expan> <num value="4"><unclear>τ</unclear>έσσαρ<supplied reason="lost">α</supplied></num> <gap reason="lost" extent="unknown" unit="character"/>
+    
+<lb n="6"/>καὶ πρὸς σὴν ἀσφάλειαν <choice><reg>ἐξεδώκαμεν</reg><orig>ἐξέδοκά</orig></choice> σοι τήν<unclear>δε</unclear> <supplied reason="lost">τ</supplied><unclear>ὴν</unclear> <unclear>π</unclear><supplied reason="lost">ληρωτικὴν ἀποχὴν</supplied> <gap reason="lost" extent="unknown" unit="character"/>
+    
+<lb n="7"/>ηνως. <expan><unclear>ἐ</unclear>γράφ<ex>η</ex></expan> Μεσορὴ <num value="9">θ</num>, <num value="9">θ</num> <expan>ἰνδ<ex>ικτίωνος</ex></expan>. <gap reason="lost" extent="unknown" unit="character"/>
+</ab></div>
+      </body>
+   </text>
+</TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.7.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.7.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Fragment eines Ehevertrages aus Oxyrhynchοs</title>
+            <title>pylon.7.7</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.7.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.7.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Fragment eines Ehevertrages aus Oxyrhynchοs</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.7.7</idno>
+            <idno type="ddb-hybrid">pylon;7;7</idno>
+            <idno type="HGV">1000279</idno>
+            <idno type="TM">1000279</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+                            <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+                                Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="DDbDP">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="grc" type="edition" xml:space="preserve">
+
+<ab>
+
+<lb n="1"/>ἀ<unclear>γα</unclear>θῇ τύχῃ. Πολυκράτης Ἀθη<unclear>ν</unclear><gap reason="lost" extent="unknown" unit="character"/>
+
+<lb n="2"/>Πολυκράτους τῶν ἀπ’ Ὀξυρύ<supplied reason="lost">γχων πόλεως</supplied> <gap reason="lost" extent="unknown" unit="character"/>
+
+<lb n="3"/>ἀπ<unclear>ὸ</unclear> κώμης Σερύφεως <gap reason="illegible" quantity="1" unit="character"/><unclear>ο</unclear><gap reason="lost" extent="unknown" unit="character"/>
+
+<lb n="4"/><gap reason="lost" quantity="4" unit="character"/><unclear>ο</unclear>υ διὰ χειρὸς ἀργυρί<unclear>ο</unclear><supplied reason="lost">υ δραχμὰς</supplied> <gap reason="lost" extent="unknown" unit="character"/>
+
+<lb n="5"/><gap reason="lost" quantity="4" unit="character"/><unclear>κ</unclear>οσίας ὑπὲρ <choice><reg>προικὸς</reg><orig>πρυκὸς</orig></choice> λ<unclear>ό</unclear><supplied reason="lost">γου</supplied> <gap reason="lost" extent="unknown" unit="character"/>
+
+<lb n="6"/><gap reason="lost" quantity="8" unit="character"/><unclear>ς</unclear> γάμου <choice><reg>κοινω<supplied reason="lost">νίαν</supplied></reg><orig>κυνω<supplied reason="lost">νίαν</supplied></orig></choice> <gap reason="lost" extent="unknown" unit="character"/>
+
+<lb n="7"/><gap reason="illegible" extent="unknown" unit="character"><desc>vestiges</desc></gap> 
+
+<lb n="8"/><gap reason="lost" extent="unknown" unit="line"/> 
+</ab></div>
+      </body>
+   </text>
+</TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.9_1.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.9_1.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Acknowledgements of Debt for Seed Advance</title>
+            <title>pylon.7.9_1</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.9_1.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.9_1.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Acknowledgements of Debt for Seed Advance</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.7.9_1</idno>
+            <idno type="ddb-hybrid">pylon;7;9_1</idno>
+            <idno type="HGV">1000281</idno>
+            <idno type="TM">1000281</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+                <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+                  Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:32-05:00" who="DDbDP">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="ar" type="edition" xml:space="preserve">
+
+<ab>
+   
+<lb n="1"/> <handShift new="m1"/> بسم اللـه  الرحمن الرحيم
+   
+<lb n="2"/> اقر  حرير بن محمد واشهد على نفسه طوعا في صحة عقله
+   
+<lb n="3"/> وبدنه  وجواز امره غير مكره ولا مجبر ان عليه وعنده وقبله
+   
+<lb n="4"/> وفي خالص ماله وذمته لمحمد بن ايوب من البرسيم
+   
+<lb n="5"/> المغربل  المهرب ثلثي اردب دينا ثابتا
+   
+<lb n="6"/> وحقا واجبا لازما اعترف له بذلك عند شهود
+   
+<lb n="7"/> هذه الوثيقة لا يدافع بذلك ولا يحتج فيه بحجة
+   
+<lb n="8"/> ولا يعتل فيه بعلة عن الخروج من الدين
+   
+<lb n="9"/> المذكور ذلك بضمان  عمر بن احمد
+   
+<lb n="10"/> وبذلك اشهد على نفسه في شوال سنة احدى
+   
+<lb n="11"/> واربعين واربعماية 
+   
+<lb n="12"/> <handShift new="m2"/> شهد حفاظ بن كناني بجميع ما فيه
+   
+<lb n="13"/> وكتب عنه باذنه ومحضره
+   
+<lb n="14"/> شهد شهادته جماعة على اقرار المقر بما فيه
+   
+<lb n="15"/> وكتب بيد<supplied reason="omitted">ه</supplied> في تاريخه
+</ab></div>
+      </body>
+   </text>
+</TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.9_2.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.9_2.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.16/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Acknowledgements of Debt for Seed Advance</title>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Duke Collaboratory for Classics Computing (DC3)</authority>
+            <idno type="filename">pylon.7.9_2</idno>
+            <idno type="ddb-hybrid">pylon;7;9_2</idno>
+            <idno type="HGV">1000282</idno>
+            <idno type="TM">1000282</idno>
+            <availability>
+               <p>© Duke Databank of Documentary Papyri. This work is licensed under a
+                <ref type="license" target="http://creativecommons.org/licenses/by/3.0/">Creative 
+                  Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:32-05:00" who="DDbDP">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="ar" type="edition" xml:space="preserve">
+
+<ab>
+    
+<lb n="1"/> <handShift new="m1"/> بسم اللـه الرحمن الرحيم 
+    
+<lb n="2"/> اقر حرير بن محمد واشهد على نفسه طوعا في صحة <supplied reason="lost">عقله وبدنه</supplied> 
+    
+<lb n="3"/> وجواز امره غير مكره ولا مجبر ان عليه وعنده وقبله
+    
+<lb n="4"/> وفي خالص ماله وذمته  لمحمد بن ايوب من الجلبان النقي 
+    
+<lb n="5"/> من العلث والقصل  وجميع ذلك اردب
+    
+<lb n="6"/> واحد وثلث اردب دينا ثابتا وحقا واجبا
+    
+<lb n="7"/> لازما اعترف له بذلك عند شهود هذه الوثيقة
+    
+<lb n="8"/> لا يدافع بذلك ولا بشي فيه عن الخروج من الدين المذكور
+    
+<lb n="9"/> وذلك بضمان  عمر بن احمد وبذلك اشهد على
+    
+<lb n="10"/>  نفسه في شوال من سنة احدى واربعين واربع ماية 
+    
+<lb n="11"/> <handShift new="m2"/> شهد شهادته جماعة
+    
+<lb n="12"/> الخطيب بططون على اقرار المقر بما فيه وكتب بيده في تاريخه
+    
+<lb n="13"/> شهد حفاظ بن كناني؟ بجميع ما فيه وكتب عنه بامره ومحضره
+</ab></div>
+      </body>
+   </text>
+</TEI>

--- a/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.9_2.xml
+++ b/DDB_EpiDoc_XML/pylon/pylon.7/pylon.7.9_2.xml
@@ -4,7 +4,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Acknowledgements of Debt for Seed Advance</title>
+            <title>pylon.7.9_2</title>
          </titleStmt>
          <publicationStmt>
             <authority>Duke Collaboratory for Classics Computing (DC3)</authority>

--- a/HGV_meta_EpiDoc/HGV1000/999672.xml
+++ b/HGV_meta_EpiDoc/HGV1000/999672.xml
@@ -16,9 +16,9 @@
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>P.Heid. inv. Arab. 734</settlement>
+                     <settlement>Heidelberg</settlement>
                   </placeName>
-                  <collection/>
+                  <collection>Insitut für Papyrologie</collection>
                   <idno type="invNo">P.Heid. inv. Arab. 734</idno>
                </msIdentifier>
                <physDesc>
@@ -63,6 +63,7 @@
             <language ident="es">Spanisch</language>
             <language ident="la">Latein</language>
             <language ident="el">Griechisch</language>
+            <language ident="ar">Arabisch</language>
          </langUsage>
          <textClass>
             <keywords scheme="hgv">

--- a/HGV_meta_EpiDoc/HGV1000/999672.xml
+++ b/HGV_meta_EpiDoc/HGV1000/999672.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv704976">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>An Arabic Private Letter from the Eighth Century</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="TM">999672</idno>
+            <idno type="filename">999672</idno>
+            <idno type="ddb-filename">pylon.7.3</idno>
+            <idno type="ddb-hybrid">pylon;7;3</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>P.Heid. inv. Arab. 734</settlement>
+                  </placeName>
+                  <collection/>
+                  <idno type="invNo">P.Heid. inv. Arab. 734</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Papyrus</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Arsinoites</origPlace>
+                     <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName type="ancient"
+                                   subtype="nome"
+                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+            <listBibl>
+               <bibl type="SB">
+                  <ptr target="https://papyri.info/biblio/97397"/>
+               </bibl>
+            </listBibl>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Brief (privat)</term>
+               <term n="2">Gesundheit</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21" who="HGV">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">Pylon</title>
+                  <biblScope n="1" type="volume">7</biblScope>
+                  <biblScope n="2" type="fascicle">(2025)</biblScope>
+                  <biblScope n="3" type="generic">Art. 3</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_meta_EpiDoc/HGV1001/1000275.xml
+++ b/HGV_meta_EpiDoc/HGV1001/1000275.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv704976">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv1000275">
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>An Arabic Private Letter from the Eighth Century</title>
+            <title>Compromissum</title>
          </titleStmt>
          <publicationStmt>
-            <idno type="TM">704976</idno>
-            <idno type="filename">704976</idno>
-            <idno type="ddb-filename">pylon.7.3</idno>
-            <idno type="ddb-hybrid">pylon;7;3</idno>
+            <idno type="TM">1000275</idno>
+            <idno type="filename">1000275</idno>
+            <idno type="ddb-filename">pylon.7.4</idno>
+            <idno type="ddb-hybrid">pylon;7;4</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>P.Heid. inv. Arab. 734</settlement>
+                     <settlement>Heidelberg</settlement>
                   </placeName>
-                  <collection/>
-                  <idno type="invNo">P.Heid. inv. Arab. 734</idno>
+                  <collection>Institut für Papyrologie</collection>
+                  <idno type="invNo">MS. Gr. Class. e 135 (P)</idno>
                </msIdentifier>
                <physDesc>
                   <objectDesc>
@@ -32,21 +32,27 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites</origPlace>
-                     <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+                     <origPlace>Leukogion (Herakleopolites)</origPlace>
+                     <origDate xml:id="dateAlternativeX" when="0713-03-17">
+                        <certainty locus="value" match="../year-from-date(@when)"/>17. März 713 (Jahr unsicher)</origDate>
+                     <origDate xml:id="dateAlternativeY" when="0728-03-17">
+                        <certainty locus="value" match="../year-from-date(@when)"/>17. März 728 (Jahr unsicher)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
+                                   ref="https://pleiades.stoa.org/places/741509 https://www.trismegistos.org/place/1248">Leukogion</placeName>
+                        <placeName type="ancient"
                                    subtype="nome"
-                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                                   ref="https://www.trismegistos.org/place/2713 https://pleiades.stoa.org/places/736921">Herakleopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>
             </msDesc>
             <listBibl>
                <bibl type="SB">
-                  <ptr target="https://papyri.info/biblio/97397"/>
+                  <ptr target="https://papyri.info/biblio/97398"/>
                </bibl>
             </listBibl>
          </sourceDesc>
@@ -66,8 +72,9 @@
          </langUsage>
          <textClass>
             <keywords scheme="hgv">
-               <term n="1">Brief (privat)</term>
-               <term n="2">Gesundheit</term>
+               <term>Kompromiß</term>
+               <term>Urteil</term>
+               <term>Bußgeld</term>
             </keywords>
          </textClass>
       </profileDesc>
@@ -83,7 +90,7 @@
                   <title level="s" type="abbreviated">Pylon</title>
                   <biblScope n="1" type="volume">7</biblScope>
                   <biblScope n="2" type="fascicle">(2025)</biblScope>
-                  <biblScope n="3" type="generic">Art. 3</biblScope>
+                  <biblScope n="3" type="generic">Art. 4</biblScope>
                </bibl>
             </listBibl>
          </div>

--- a/HGV_meta_EpiDoc/HGV1001/1000277.xml
+++ b/HGV_meta_EpiDoc/HGV1001/1000277.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv704976">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv1000277">
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>An Arabic Private Letter from the Eighth Century</title>
+            <title>A Late Antique Receipt for Grain from the Hermopolite Nome</title>
          </titleStmt>
          <publicationStmt>
-            <idno type="TM">704976</idno>
-            <idno type="filename">704976</idno>
-            <idno type="ddb-filename">pylon.7.3</idno>
-            <idno type="ddb-hybrid">pylon;7;3</idno>
+            <idno type="TM">1000277</idno>
+            <idno type="filename">1000277</idno>
+            <idno type="ddb-filename">pylon.7.5</idno>
+            <idno type="ddb-hybrid">pylon;7;5</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>P.Heid. inv. Arab. 734</settlement>
+                     <settlement/>
                   </placeName>
                   <collection/>
-                  <idno type="invNo">P.Heid. inv. Arab. 734</idno>
+                  <idno type="invNo">P. von Scherling g. 211</idno>
                </msIdentifier>
                <physDesc>
                   <objectDesc>
@@ -32,21 +32,22 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites</origPlace>
-                     <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+                     <origPlace>Hermopolites</origPlace>
+                     <origDate when="0207-05-22">22. Mai 207</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
                                    subtype="nome"
-                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                                   ref="https://www.trismegistos.org/place/2720">Hermopolites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>
             </msDesc>
             <listBibl>
                <bibl type="SB">
-                  <ptr target="https://papyri.info/biblio/97397"/>
+                  <ptr target="https://papyri.info/biblio/97399"/>
                </bibl>
             </listBibl>
          </sourceDesc>
@@ -64,12 +65,6 @@
             <language ident="la">Latein</language>
             <language ident="el">Griechisch</language>
          </langUsage>
-         <textClass>
-            <keywords scheme="hgv">
-               <term n="1">Brief (privat)</term>
-               <term n="2">Gesundheit</term>
-            </keywords>
-         </textClass>
       </profileDesc>
       <revisionDesc>
          <change when="2025-07-21" who="HGV">Xwalk from Pylon</change>
@@ -83,7 +78,7 @@
                   <title level="s" type="abbreviated">Pylon</title>
                   <biblScope n="1" type="volume">7</biblScope>
                   <biblScope n="2" type="fascicle">(2025)</biblScope>
-                  <biblScope n="3" type="generic">Art. 3</biblScope>
+                  <biblScope n="3" type="generic">Art. 5</biblScope>
                </bibl>
             </listBibl>
          </div>

--- a/HGV_meta_EpiDoc/HGV1001/1000278.xml
+++ b/HGV_meta_EpiDoc/HGV1001/1000278.xml
@@ -1,52 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv704976">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv1000278">
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>An Arabic Private Letter from the Eighth Century</title>
+            <title>Wohnen im spätantiken Arsinoe: ein neuer Mietvertrag</title>
          </titleStmt>
          <publicationStmt>
-            <idno type="TM">704976</idno>
-            <idno type="filename">704976</idno>
-            <idno type="ddb-filename">pylon.7.3</idno>
-            <idno type="ddb-hybrid">pylon;7;3</idno>
+            <idno type="TM">1000278</idno>
+            <idno type="filename">1000278</idno>
+            <idno type="ddb-filename">pylon.7.7</idno>
+            <idno type="ddb-hybrid">pylon;7;7</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>P.Heid. inv. Arab. 734</settlement>
+                     <settlement>Vienna</settlement>
                   </placeName>
-                  <collection/>
-                  <idno type="invNo">P.Heid. inv. Arab. 734</idno>
+                  <collection>Nationalbibliothek</collection>
+                  <idno type="invNo">P.Vindob. G 20941</idno>
                </msIdentifier>
                <physDesc>
                   <objectDesc>
                      <supportDesc>
-                        <support>
-                           <material>Papyrus</material>
-                        </support>
+                        <support/>
                      </supportDesc>
                   </objectDesc>
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites</origPlace>
-                     <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+                     <origPlace>Arsinoiton Polis</origPlace>
+                     <origDate notBefore="0501" notAfter="0600" precision="low">VI</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
                         <placeName type="ancient"
+                                   ref="https://pleiades.stoa.org/places/736948 https://www.trismegistos.org/place/327">Arsinoiton Polis</placeName>
+                        <placeName type="ancient"
                                    subtype="nome"
                                    ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>
             </msDesc>
             <listBibl>
                <bibl type="SB">
-                  <ptr target="https://papyri.info/biblio/97397"/>
+                  <ptr target="https://papyri.info/biblio/97400"/>
                </bibl>
             </listBibl>
          </sourceDesc>
@@ -66,8 +67,9 @@
          </langUsage>
          <textClass>
             <keywords scheme="hgv">
-               <term n="1">Brief (privat)</term>
-               <term n="2">Gesundheit</term>
+               <term>Vertrag</term>
+               <term>Miete</term>
+               <term>Haus</term>
             </keywords>
          </textClass>
       </profileDesc>
@@ -83,7 +85,7 @@
                   <title level="s" type="abbreviated">Pylon</title>
                   <biblScope n="1" type="volume">7</biblScope>
                   <biblScope n="2" type="fascicle">(2025)</biblScope>
-                  <biblScope n="3" type="generic">Art. 3</biblScope>
+                  <biblScope n="3" type="generic">Art. 6</biblScope>
                </bibl>
             </listBibl>
          </div>

--- a/HGV_meta_EpiDoc/HGV1001/1000279.xml
+++ b/HGV_meta_EpiDoc/HGV1001/1000279.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv704976">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv1000279">
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>An Arabic Private Letter from the Eighth Century</title>
+            <title>Fragment eines Ehevertrages aus Oxyrhynchοs</title>
          </titleStmt>
          <publicationStmt>
-            <idno type="TM">704976</idno>
-            <idno type="filename">704976</idno>
-            <idno type="ddb-filename">pylon.7.3</idno>
-            <idno type="ddb-hybrid">pylon;7;3</idno>
+            <idno type="TM">1000279</idno>
+            <idno type="filename">1000279</idno>
+            <idno type="ddb-filename">pylon.7.7</idno>
+            <idno type="ddb-hybrid">pylon;7;7</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>P.Heid. inv. Arab. 734</settlement>
+                     <settlement>Hamburg</settlement>
                   </placeName>
-                  <collection/>
-                  <idno type="invNo">P.Heid. inv. Arab. 734</idno>
+                  <collection>Staats- und Universitätsbibliothek</collection>
+                  <idno type="invNo">P.Hamb. Graec. inv. 489</idno>
                </msIdentifier>
                <physDesc>
                   <objectDesc>
@@ -32,21 +32,26 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites</origPlace>
-                     <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+                     <origPlace>Oxyrhynchos (Oxyrhynchites, Ägypten)</origPlace>
+                     <origDate notBefore="0101" notAfter="0200" precision="low">II</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
-                        <placeName type="ancient"
+                        <placeName n="1"
+                                   type="ancient"
+                                   ref="https://www.trismegistos.org/place/1524 https://pleiades.stoa.org/places/736983">Oxyrhynchos</placeName>
+                        <placeName n="2"
+                                   type="ancient"
                                    subtype="nome"
-                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                                   ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
+                        <placeName n="3" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>
             </msDesc>
             <listBibl>
                <bibl type="SB">
-                  <ptr target="https://papyri.info/biblio/97397"/>
+                  <ptr target="https://papyri.info/biblio/97401"/>
                </bibl>
             </listBibl>
          </sourceDesc>
@@ -66,8 +71,8 @@
          </langUsage>
          <textClass>
             <keywords scheme="hgv">
-               <term n="1">Brief (privat)</term>
-               <term n="2">Gesundheit</term>
+               <term n="1">Vertrag</term>
+               <term n="2">Ehe</term>
             </keywords>
          </textClass>
       </profileDesc>
@@ -83,7 +88,7 @@
                   <title level="s" type="abbreviated">Pylon</title>
                   <biblScope n="1" type="volume">7</biblScope>
                   <biblScope n="2" type="fascicle">(2025)</biblScope>
-                  <biblScope n="3" type="generic">Art. 3</biblScope>
+                  <biblScope n="3" type="generic">Art. 7</biblScope>
                </bibl>
             </listBibl>
          </div>

--- a/HGV_meta_EpiDoc/HGV1001/1000281.xml
+++ b/HGV_meta_EpiDoc/HGV1001/1000281.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv704976">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv1000281">
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>An Arabic Private Letter from the Eighth Century</title>
+            <title>Acknowledgements of Debt for Seed Advance</title>
          </titleStmt>
          <publicationStmt>
-            <idno type="TM">704976</idno>
-            <idno type="filename">704976</idno>
-            <idno type="ddb-filename">pylon.7.3</idno>
-            <idno type="ddb-hybrid">pylon;7;3</idno>
+            <idno type="TM">1000281</idno>
+            <idno type="filename">1000281</idno>
+            <idno type="ddb-filename">pylon.7.9_1</idno>
+            <idno type="ddb-hybrid">pylon;7;9_1</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>P.Heid. inv. Arab. 734</settlement>
+                     <settlement>Hamburg</settlement>
                   </placeName>
-                  <collection/>
-                  <idno type="invNo">P.Heid. inv. Arab. 734</idno>
+                  <collection>Staats- und Universitätsbibliothek</collection>
+                  <idno type="invNo">P.Hamb.Arab. Inv. 80</idno>
                </msIdentifier>
                <physDesc>
                   <objectDesc>
@@ -32,21 +32,23 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites</origPlace>
-                     <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+                     <origPlace>Ṭuṭūn</origPlace>
+                     <origDate notBefore="1050-02" notAfter="1050-05">Febr. - März 1050</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
+                        <placeName n="1"/>
+                     </p>
+                     <p>
                         <placeName type="ancient"
-                                   subtype="nome"
-                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                                   ref="https://pleiades.stoa.org/places/737072 https://www.trismegistos.org/place/2287">Ṭuṭūn</placeName>
                      </p>
                   </provenance>
                </history>
             </msDesc>
             <listBibl>
                <bibl type="SB">
-                  <ptr target="https://papyri.info/biblio/97397"/>
+                  <ptr target="https://papyri.info/biblio/97403"/>
                </bibl>
             </listBibl>
          </sourceDesc>
@@ -66,8 +68,9 @@
          </langUsage>
          <textClass>
             <keywords scheme="hgv">
-               <term n="1">Brief (privat)</term>
-               <term n="2">Gesundheit</term>
+               <term n="1">Vertrag</term>
+               <term n="2">Darlehen</term>
+               <term n="3">Saatgut</term>
             </keywords>
          </textClass>
       </profileDesc>
@@ -83,7 +86,8 @@
                   <title level="s" type="abbreviated">Pylon</title>
                   <biblScope n="1" type="volume">7</biblScope>
                   <biblScope n="2" type="fascicle">(2025)</biblScope>
-                  <biblScope n="3" type="generic">Art. 3</biblScope>
+                  <biblScope n="3" type="generic">Art. 9</biblScope>
+                  <biblScope n="4" type="number">Nr. 1</biblScope>
                </bibl>
             </listBibl>
          </div>

--- a/HGV_meta_EpiDoc/HGV1001/1000281.xml
+++ b/HGV_meta_EpiDoc/HGV1001/1000281.xml
@@ -65,6 +65,7 @@
             <language ident="es">Spanisch</language>
             <language ident="la">Latein</language>
             <language ident="el">Griechisch</language>
+            <language ident="ar">Arabisch</language>
          </langUsage>
          <textClass>
             <keywords scheme="hgv">

--- a/HGV_meta_EpiDoc/HGV1001/1000282.xml
+++ b/HGV_meta_EpiDoc/HGV1001/1000282.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv704976">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv1000282">
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>An Arabic Private Letter from the Eighth Century</title>
+            <title>Acknowledgements of Debt for Seed Advance</title>
          </titleStmt>
          <publicationStmt>
-            <idno type="TM">704976</idno>
-            <idno type="filename">704976</idno>
-            <idno type="ddb-filename">pylon.7.3</idno>
-            <idno type="ddb-hybrid">pylon;7;3</idno>
+            <idno type="TM">1000282</idno>
+            <idno type="filename">1000282</idno>
+            <idno type="ddb-filename">pylon.7.9_2</idno>
+            <idno type="ddb-hybrid">pylon;7;9_2</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>P.Heid. inv. Arab. 734</settlement>
+                     <settlement>Hamburg</settlement>
                   </placeName>
-                  <collection/>
-                  <idno type="invNo">P.Heid. inv. Arab. 734</idno>
+                  <collection>Staats- und Universitätsbibliothek</collection>
+                  <idno type="invNo">P.Hamb.Arab. Inv. 81</idno>
                </msIdentifier>
                <physDesc>
                   <objectDesc>
@@ -32,21 +32,23 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites</origPlace>
-                     <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+                     <origPlace>Ṭuṭūn</origPlace>
+                     <origDate notBefore="1050-02" notAfter="1050-05">Febr. - März 1050</origDate>
                   </origin>
                   <provenance type="located">
                      <p>
+                        <placeName n="1"/>
+                     </p>
+                     <p>
                         <placeName type="ancient"
-                                   subtype="nome"
-                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                                   ref="https://pleiades.stoa.org/places/737072 https://www.trismegistos.org/place/2287">Ṭuṭūn</placeName>
                      </p>
                   </provenance>
                </history>
             </msDesc>
             <listBibl>
                <bibl type="SB">
-                  <ptr target="https://papyri.info/biblio/97397"/>
+                  <ptr target="https://papyri.info/biblio/97403"/>
                </bibl>
             </listBibl>
          </sourceDesc>
@@ -66,8 +68,9 @@
          </langUsage>
          <textClass>
             <keywords scheme="hgv">
-               <term n="1">Brief (privat)</term>
-               <term n="2">Gesundheit</term>
+               <term n="1">Vertrag</term>
+               <term n="2">Darlehen</term>
+               <term n="3">Saatgut</term>
             </keywords>
          </textClass>
       </profileDesc>
@@ -83,7 +86,8 @@
                   <title level="s" type="abbreviated">Pylon</title>
                   <biblScope n="1" type="volume">7</biblScope>
                   <biblScope n="2" type="fascicle">(2025)</biblScope>
-                  <biblScope n="3" type="generic">Art. 3</biblScope>
+                  <biblScope n="3" type="generic">Art. 9</biblScope>
+                  <biblScope n="4" type="number">Nr. 2</biblScope>
                </bibl>
             </listBibl>
          </div>

--- a/HGV_meta_EpiDoc/HGV1001/1000282.xml
+++ b/HGV_meta_EpiDoc/HGV1001/1000282.xml
@@ -65,6 +65,7 @@
             <language ident="es">Spanisch</language>
             <language ident="la">Latein</language>
             <language ident="el">Griechisch</language>
+            <language ident="ar">Arabisch</language>
          </langUsage>
          <textClass>
             <keywords scheme="hgv">

--- a/HGV_meta_EpiDoc/HGV705/704976.xml
+++ b/HGV_meta_EpiDoc/HGV705/704976.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="hgv704976">
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>An Arabic Private Letter from the Eighth Century</title>
+            <title>A Karanis penthemeros certificate completed</title>
          </titleStmt>
          <publicationStmt>
-            <idno type="TM">704976</idno>
             <idno type="filename">704976</idno>
-            <idno type="ddb-filename">pylon.7.3</idno>
-            <idno type="ddb-hybrid">pylon;7;3</idno>
+            <idno type="TM">704976</idno>
+            <idno type="ddb-filename">pylon.2.11</idno>
+            <idno type="ddb-hybrid">pylon;2;11</idno>
          </publicationStmt>
          <sourceDesc>
             <msDesc>
                <msIdentifier>
                   <placeName>
-                     <settlement>P.Heid. inv. Arab. 734</settlement>
+                     <settlement>Ann Arbor</settlement>
                   </placeName>
-                  <collection/>
-                  <idno type="invNo">P.Heid. inv. Arab. 734</idno>
+                  <collection>University of Michigan</collection>
+                  <idno type="invNo">P.Mich. inv. 2409</idno>
                </msIdentifier>
                <physDesc>
                   <objectDesc>
@@ -32,21 +32,26 @@
                </physDesc>
                <history>
                   <origin>
-                     <origPlace>Arsinoites</origPlace>
-                     <origDate notBefore="0701" notAfter="0800" precision="low">VIII</origDate>
+                     <origPlace>Karanis (Arsinoites, Ägypten)</origPlace>
+                     <origDate when="0140-06-19">19. Juni 140</origDate>
                   </origin>
                   <provenance type="located">
-                     <p>
-                        <placeName type="ancient"
-                                   subtype="nome"
-                                   ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                     <p xml:id="geoIA8HJC">
+                        <placeName n="1"
+                           type="ancient"
+                           ref="https://www.trismegistos.org/place/1008 https://pleiades.stoa.org/places/736932">Karanis</placeName>
+                        <placeName n="2"
+                           type="ancient"
+                           subtype="nome"
+                           ref="https://www.trismegistos.org/place/332 https://pleiades.stoa.org/places/736893">Arsinoites</placeName>
+                        <placeName n="3" type="ancient" subtype="region">Ägypten</placeName>
                      </p>
                   </provenance>
                </history>
             </msDesc>
             <listBibl>
                <bibl type="SB">
-                  <ptr target="https://papyri.info/biblio/97397"/>
+                  <ptr target="https://papyri.info/biblio/96296"/>
                </bibl>
             </listBibl>
          </sourceDesc>
@@ -66,13 +71,25 @@
          </langUsage>
          <textClass>
             <keywords scheme="hgv">
-               <term n="1">Brief (privat)</term>
-               <term n="2">Gesundheit</term>
+               <term n="1">Quittung</term>
+               <term n="2">Penthemeros</term>
             </keywords>
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change when="2025-07-21" who="HGV">Xwalk from Pylon</change>
+         <change when="2022-12-22T09:24:41-05:00"
+            who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
+         <change when="2022-12-22T09:08:15-05:00"
+            who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Update</change>
+         <change when="2022-12-22T08:48:16-05:00"
+            who="http://papyri.info/editor/users/james.cowey">Submit - Update to Pylon 2 (2022) Nr. 11</change>
+         <change when="2022-05-23T15:42:24-04:00"
+            who="http://papyri.info/editor/users/james.cowey">Finalized - Ready.</change>
+         <change when="2021-06-15T07:27:38-04:00"
+            who="http://papyri.info/editor/users/james.cowey">Vote - HGVAccept - Fine</change>
+         <change when="2021-06-14T12:55:22-04:00"
+            who="http://papyri.info/editor/users/gclaytor">Submit - entered text and metadata of basp;54;92 (TM 704976)</change>
+         <change when="2021-06-14T12:46:16-04:00" who="http://papyri.info/editor">Automated creation from template</change>
       </revisionDesc>
    </teiHeader>
    <text>
@@ -81,10 +98,30 @@
             <listBibl>
                <bibl type="publication" subtype="principal">
                   <title level="s" type="abbreviated">Pylon</title>
-                  <biblScope n="1" type="volume">7</biblScope>
-                  <biblScope n="2" type="fascicle">(2025)</biblScope>
-                  <biblScope n="3" type="generic">Art. 3</biblScope>
+                  <biblScope n="1" type="volume">2</biblScope>
+                  <biblScope n="2" type="fascicle">(2022)</biblScope>
+                  <biblScope n="3" type="generic">Art. 11</biblScope>
                </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">BASP 54 (2017) S. 93</bibl>
+            </p>
+         </div>
+         <div type="figure">
+            <p>
+               <figure n="1">
+                  <graphic url="https://quod.lib.umich.edu/a/apis/x-9086/2409R.TIF"/>
+               </figure>
+               <figure n="2">
+                  <graphic url="https://journals.ub.uni-heidelberg.de/index.php/pylon/article/view/92977/87729#fig1"/>
+               </figure>
+            </p>
+         </div>
+         <div type="bibliography" subtype="otherPublications">
+            <listBibl>
+               <bibl type="publication" subtype="other">BASP 54 (2017) S. 92 Nr. 5</bibl>
             </listBibl>
          </div>
       </body>

--- a/HGV_trans_EpiDoc/1000275.xml
+++ b/HGV_trans_EpiDoc/1000275.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title type="main">Compromissum</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">1000275</idno>
+            <idno type="TM">1000275</idno>
+            <idno type="HGV">1000275</idno>
+            <idno type="ddb-hybrid">pylon;7;4</idno>
+            <availability>
+               <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p>The contents of this document are generated from SOSOL.</p>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="HGV">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="en" type="translation" xml:space="preserve">
+<p>
+† On the one side Pekysios, priest, son of Naaraous, and on the other side Sambas (?), son of Naaraous Pkanee, both from the village Leukogion of the Heracleopolite nome, make the present <emph rend="italics">compromissum</emph> with each other of their own free will. Because they have a disagreement with each other about some matters between them and they could not agree among themselves, they chose of their own free will Kosmas, son of Papas, and Menas, son of Antonios, that they should make a judgement for them; the party that does not abide by the judgement they deliver, should hand over as fine to the complying party 4 gold solidi. Written on the 21st of the month of Phamenoth, 11th indiction †. (Coptic) I, Pikosh, priest, I agree with the <emph rend="italics">compromissum</emph>. † Written by me, Ioannes, son of Phib † †.
+</p></div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_trans_EpiDoc/1000277.xml
+++ b/HGV_trans_EpiDoc/1000277.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title type="main">A Late Antique Receipt for Grain from the Hermopolite Nome</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">1000277</idno>
+            <idno type="TM">1000277</idno>
+            <idno type="HGV">1000277</idno>
+            <idno type="ddb-hybrid">pylon;7;5</idno>
+            <availability>
+               <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p>The contents of this document are generated from SOSOL.</p>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="HGV">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="en" type="translation" xml:space="preserve">
+
+<p>
+To the Holy Monastery of apa Dorotheus [to N.N. ...] ... from the epoikion of Neilammon from [N.N. son of N.N.] and Josephis son of Jeremiah, both Komarchs [of the village of ... of the Hermopolite] nome, greeting. We have been paid in full by you for the levy of grain ... one quarter on the Athenian measure and four nomismata of gold ... and for your security, we have issued to you this [receipt for full payment ...]. Written Mesore 9, 9th indiction.
+</p>
+</div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_trans_EpiDoc/1000278.xml
+++ b/HGV_trans_EpiDoc/1000278.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title type="main"/>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">1000278</idno>
+            <idno type="TM">1000278</idno>
+            <idno type="HGV">1000278</idno>
+            <idno type="ddb-hybrid">pylon;7;7</idno>
+            <availability>
+               <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p>The contents of this document are generated from SOSOL.</p>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="HGV">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="de" type="translation" xml:space="preserve">
+<p>
+„[– – –] aus derselben Stadt, unten mit eigener Hand unterschreibend, Grüße. Ich stimme zu, dass ich von dir Teile des dir gehörigen Hauses, das ,des Psaeios‘ genannt wird, gemietet habe, das sich in der eben genannten Stadt, im Stadtviertel Dionysiu Topon, auch genannt Dionysiu Sebastes, befindet, mit zwei Türen, die Haupttür geöffnet nach Norden, die Nebentür geöffnet nach Westen, einen Raum geöffnet nach Westen [– – –] eines anderen Raums mit dem dir gehörenden und passenden [– – –] Zubehör [– – –]“.
+</p></div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_trans_EpiDoc/1000279.xml
+++ b/HGV_trans_EpiDoc/1000279.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title type="main">Fragment eines Ehevertrages aus Oxyrhynchοs</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">1000279</idno>
+            <idno type="TM">1000279</idno>
+            <idno type="HGV">1000279</idno>
+            <idno type="ddb-hybrid">pylon;7;7</idno>
+            <availability>
+               <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p>The contents of this document are generated from SOSOL.</p>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="HGV">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="de" type="translation" xml:space="preserve">
+
+<p>
+Zu gutem Geschick. Polykrates Sohn des Athen- … [Tochter] des Polykrates, eine von denen aus der Stadt Oxyrhynchοs, … aus dem Dorf Seryphis … in bar [Drachmen] aus Silber … als Mitgift … [für] Ehepartnerschaft …
+</p>
+</div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_trans_EpiDoc/1000281.xml
+++ b/HGV_trans_EpiDoc/1000281.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title type="main">Acknowledgements of Debt for Seed Advance</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">1000281</idno>
+            <idno type="TM">1000281</idno>
+            <idno type="HGV">1000281</idno>
+            <idno type="ddb-hybrid"/>
+            <availability>
+               <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p>The contents of this document are generated from SOSOL.</p>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:32-05:00" who="HGV">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="en" type="translation" xml:space="preserve">
+<p>
+<milestone n="1" unit="line"/> In the name of God, the Compassionate, the Merciful.
+<milestone n="2" unit="line"/> Ḥarīr b. Muḥammad has acknowledged and given testimony against himself willingly, while sound in mind and body, fully competent, under no constraint or coercion that he owes, is liable for, and is a debtor from his own funds and under his own responsibility to Muḥammad b. Ayyūb. He owes him, in sifted and winnowed |<hi rend="superscript">4</hi> clover seeds, two-thirds of an <emph rend="italics">irdabb</emph>, that constitutes a confirmed debt and an obligatory, binding right. He has acknowledged this in the presence of the witnesses of this document. He may neither dispute it, nor invoke any evidence, nor offer any excuse to be released from the debt, whose repayment is guaranteed by ʿUmar b. Aḥmad. 
+<milestone n="10" unit="line"/> He has given testimony against himself in the month of Shawwāl, of year four hundred and forty-one. 
+<milestone n="12" unit="line"/> Ḥafāẓ b. Kinānī testifies to all the contents of the document. 
+<milestone n="13" unit="line"/> Written on his behalf with his permission and in his presence. 
+<milestone n="14" unit="line"/> Jamāʿa testifies that the obligor acknowledges the content of the document. 
+<milestone n="15" unit="line"/> Written in his own hand, on the date recorded in the document.
+</p></div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_trans_EpiDoc/1000281.xml
+++ b/HGV_trans_EpiDoc/1000281.xml
@@ -10,7 +10,7 @@
             <idno type="filename">1000281</idno>
             <idno type="TM">1000281</idno>
             <idno type="HGV">1000281</idno>
-            <idno type="ddb-hybrid"/>
+            <idno type="ddb-hybrid">pylon;7;9_1</idno>
             <availability>
                <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/HGV_trans_EpiDoc/1000282.xml
+++ b/HGV_trans_EpiDoc/1000282.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title type="main">Acknowledgements of Debt for Seed Advance</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">1000282</idno>
+            <idno type="TM">1000282</idno>
+            <idno type="HGV">1000282</idno>
+            <idno type="ddb-hybrid"/>
+            <availability>
+               <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p>The contents of this document are generated from SOSOL.</p>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:32-05:00" who="HGV">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="en" type="translation" xml:space="preserve">
+<p>
+<milestone n="1" unit="line"/> In the name of God, the Compassionate, the Merciful.
+<milestone n="2" unit="line"/> Ḥarīr b. Muḥammad has acknowledged and given testimony against himself  willingly, while sound [in mind and body], fully competent, under no constraint or coercion that he owes, is liable for, and is a debtor from his own funds and under his own responsibility to Muḥammad b. Ayyūb, in grass pea (<emph rend="italics">julbān</emph>) free from any admixture and from any defect, in the total amount of one and one-third irdabbs, that constitutes a confirmed debt and an obligatory, binding right. He has acknowledged this in the presence of the witnesses of this document. He may neither dispute it, nor (invoke) anything whatsoever to be released from the debt, whose repayment is guaranteed by ʿUmar b. Aḥmad. He has given testimony against himself in the month of Shawwāl, of the year four hundred and forty-one. 
+<milestone n="11" unit="line"/> Jamāʿa, the preacher at Ṭuṭūn, testifies that the obligor acknowledges the content of the document. 
+<milestone n="12" unit="line"/> Written in his own hand, on the date recorded in the document. Ḥafāẓ b. Kinānī testifies to all the content of the document. 
+<milestone n="13" unit="line"/> Written on his behalf with his permission and in his presence.
+</p></div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_trans_EpiDoc/1000282.xml
+++ b/HGV_trans_EpiDoc/1000282.xml
@@ -10,7 +10,7 @@
             <idno type="filename">1000282</idno>
             <idno type="TM">1000282</idno>
             <idno type="HGV">1000282</idno>
-            <idno type="ddb-hybrid"/>
+            <idno type="ddb-hybrid">pylon;7;9_2</idno>
             <availability>
                <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>

--- a/HGV_trans_EpiDoc/704976.xml
+++ b/HGV_trans_EpiDoc/704976.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title type="main">An Arabic Private Letter from the Eighth Century</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">704976</idno>
+            <idno type="TM">704976</idno>
+            <idno type="HGV">704976</idno>
+            <idno type="ddb-hybrid">pylon;7;3</idno>
+            <availability>
+               <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p>The contents of this document are generated from SOSOL.</p>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">French</language>
+            <language ident="en">English</language>
+            <language ident="de">German</language>
+            <language ident="it">Italian</language>
+            <language ident="es">Spanish</language>
+            <language ident="la">Latin</language>
+            <language ident="el">Modern Greek</language>
+            <language ident="ar">Arabic</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2025-07-21T11:16:31-05:00" who="HGV">Xwalk from Pylon</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div xml:lang="en" type="translation" xml:space="preserve">
+         <div n="r" type="textpart">
+         <p>‘In the name of God, the Compassionate, the Merciful. [From ʿUmar b. Muslim to … ]d and Aḥmad and Fāṭima, the children of ʿUmar. [Peace be upon you. I praise for your sake G]od besides Whom there is no god but He. [As for what follows, may God grant us and you the best of his health and may He perfect it in this world [and the hereafter … ] and God is blessed. Nothing happened to me after you (pl.), [except good things  … ] with the <emph rend="italics">ʿāmil</emph> of Ushmūn and you/I wrote  … [ … ] and you (sing.) have already written to me about the news concerning your condition… [ … ] … the <emph rend="italics">ʿāmil</emph> takes care of/has good intentions towards him/it [ … ] …’</p>
+         </div>
+         <div n="v" type="textpart">
+         <p>‘From ʿUmar b. Muslim to …’</p>
+         </div>
+         </div>
+      </body>
+   </text>
+</TEI>

--- a/HGV_trans_EpiDoc/999672.xml
+++ b/HGV_trans_EpiDoc/999672.xml
@@ -4,13 +4,13 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title type="main">A Karanis penthemeros certificate completed</title>
+            <title type="main">An Arabic Private Letter from the Eighth Century</title>
          </titleStmt>
          <publicationStmt>
-            <idno type="filename">704976</idno>
-            <idno type="TM">704976</idno>
-            <idno type="HGV">704976</idno>
-            <idno type="ddb-hybrid">pylon;2;11</idno>
+            <idno type="filename">999672</idno>
+            <idno type="TM">999672</idno>
+            <idno type="HGV">999672</idno>
+            <idno type="ddb-hybrid">pylon;7;3</idno>
             <availability>
                <p>© Heidelberger Gesamtverzeichnis der griechischen Papyrusurkunden Ägyptens. This work is licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/" type="license">Creative Commons Attribution 3.0 License</ref>.</p>
             </availability>
@@ -38,9 +38,12 @@
    <text>
       <body>
          <div xml:lang="en" type="translation" xml:space="preserve">
-         
-         <p>In the third year of Imperator Caesar Titus Aelius Hadrianus Antoninus Augustus Pius, he has performed the dike work for the same 3rd year (2nd hand) from Pauni 21 to 25 on the canal of Argaitis on behalf of Karanis: Ptolemaios son of Theabennis grandson of Harpaesis, whose mother is Thenamounis. (3rd hand) I, Marion, have signed.</p>
-         
+         <div n="r" type="textpart">
+         <p>‘In the name of God, the Compassionate, the Merciful. [From ʿUmar b. Muslim to … ]d and Aḥmad and Fāṭima, the children of ʿUmar. [Peace be upon you. I praise for your sake G]od besides Whom there is no god but He. [As for what follows, may God grant us and you the best of his health and may He perfect it in this world [and the hereafter … ] and God is blessed. Nothing happened to me after you (pl.), [except good things  … ] with the <emph rend="italics">ʿāmil</emph> of Ushmūn and you/I wrote  … [ … ] and you (sing.) have already written to me about the news concerning your condition… [ … ] … the <emph rend="italics">ʿāmil</emph> takes care of/has good intentions towards him/it [ … ] …’</p>
+         </div>
+         <div n="v" type="textpart">
+         <p>‘From ʿUmar b. Muslim to …’</p>
+         </div>
          </div>
       </body>
    </text>


### PR DESCRIPTION
XWalk to `Biblio`, `DCLP`, `HGV`, `HGV_Trans`, and `DDB` of material from Pylon 7. Also includes updated `title` elements for previously published Pylon files in `DDB`, where the value of `title` was something other than the value of `ddb-filename` (which is otherwise the convention in `DDB`).