### PR TITLE
Some biblio updates

### DIFF
--- a/Biblio/57/56102.xml
+++ b/Biblio/57/56102.xml
@@ -206,6 +206,6 @@
   <seg type="original" subtype="publication" resp="#BP">Leeds, Leeds Philosophical and Literary Society, 1983, x-37 pp. [pp. 53-99], 3 pll.</seg>
   <seg type="original" subtype="resume" resp="#BP">P. Leeds Museum 1-136.</seg>
   <seg type="original" subtype="sbSeg" resp="#BP">S.B. XVI, 12958-12978.</seg>
-  <seg type="original" subtype="cr" resp="#BP">C.R. par Jean Bingen, ChrEg 58 (1983) Nos 115-116, pp. 262-263. - Revel Coles, CR N.S., 35 (1985) pp. 173-174. - Revel Coles, CR N.S., 35 (1985) pp. 173-174.</seg>
+  <seg type="original" subtype="cr" resp="#BP">C.R. par Jean Bingen, ChrEg 58 (1983) Nos 115-116, pp. 262-263. - Revel Coles, CR N.S., 35 (1985) pp. 173-174.</seg>
   <seg type="original" subtype="nom" resp="#BP">Strassi</seg>
 </bibl>

--- a/Biblio/96/95659.xml
+++ b/Biblio/96/95659.xml
@@ -1,49 +1,45 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0"
-      xml:id="b95659"
-      type="article"
-      subtype="journal"
-      xml:lang="en">
-   <title level="a" type="main">P.Brit.Col. Inv. 1 and Invitations to Sarapis Dinners</title>
-   <author n="1">
-      <forename>Max</forename>
-      <surname>Nelson</surname>
-  </author>
-   <author n="2">
-      <forename>C.W.</forename>
-      <surname>Marshall</surname>
-  </author>
-   <author n="3">
-      <forename>Chelsea</forename>
-      <surname>Gardner</surname>
-  </author>
-   <date>2018</date>
-   <biblScope type="pp" from="207" to="212">207-212</biblScope>
-   <note n="1" resp="#BP">P. Vancouver Univ. Libr. [P. Brit. Col.] Inv. 1. The papyrus is housed in Rare Books and Special Collections (RBSC) at the University of British Columbia (UBC) Library in Vancouver. Invitation to a Sarapis Dinner. Oxyrhynchus?, II CE. - Table 1: Papyrus Invitations to Sarapis Dinners and Related Texts; - Table 2: Papyrus Invitations to Secular Dinners.</note>
-   <relatedItem type="appearsIn" n="1">
-      <bibl>
-         <ptr target="https://papyri.info/biblio/511"/>
-         <!-- ignore - start, i.e. SoSOL users may not edit this -->
-         <!-- ignore - stop -->
-      </bibl>
-  </relatedItem>
-   <biblScope type="issue">205</biblScope>
-   <relatedItem type="mentions" n="1">
-      <bibl>
-         <title level="s" type="short">ZPE</title>
-         <biblScope type="vol">205</biblScope>
-         <biblScope type="num">208</biblScope>
-         <idno type="ddb">zpe;205;208</idno>
-         <idno type="tm">749345</idno>
-         <idno type="invNo">P.Brit.Col. inv. 1</idno>
-      </bibl>
-   </relatedItem>
-   <idno type="pi">95659</idno>
-   <idno type="bp">2018-0037</idno>
-   <seg type="original" subtype="index" resp="#BP">141.4 364 Epistulae 750</seg>
-   <seg type="original" subtype="indexBis" resp="#BP">141.4 P. Vancouver Univ. Libr. Inv. 1</seg>
-   <seg type="original" subtype="titre" resp="#BP">Max Nelson, C.W. Marshall &amp; Chelsea Gardner, P.Brit.Col. Inv. 1 and Invitations to Sarapis Dinners.</seg>
-   <seg type="original" subtype="publication" resp="#BP">ZPE 205 (2018) pp. 207-212, figg.</seg>
-   <seg type="original" subtype="resume" resp="#BP">P. Vancouver Univ. Libr. [P. Brit. Col.] Inv. 1. The papyrus is housed in Rare Books and Special Collections (RBSC) at the University of British Columbia (UBC) Library in Vancouver. Invitation to a Sarapis Dinner. Oxyrhynchus?, II CE. - Table 1: Papyrus Invitations to Sarapis Dinners and Related Texts; - Table 2: Papyrus Invitations to Secular Dinners.</seg>
-   <seg type="original" subtype="nom" resp="#BP">Nelson Marshall Gardner</seg>
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b95659" type="article" subtype="journal" xml:lang="en">
+    <title level="a" type="main">P.Brit.Col. Inv. 1 and Invitations to Sarapis Dinners</title>
+    <author n="1">
+        <forename>Max</forename>
+        <surname>Nelson</surname>
+    </author>
+    <author n="2">
+        <forename>C.W.</forename>
+        <surname>Marshall</surname>
+    </author>
+    <author n="3">
+        <forename>Chelsea</forename>
+        <surname>Gardner</surname>
+    </author>
+    <date>2018</date>
+    <biblScope type="pp" from="207" to="212">207-212</biblScope>
+    <note n="1" resp="#BP">P. Vancouver Univ. Libr. [P. Brit. Col.] Inv. 1. The papyrus is housed in Rare Books and Special Collections (RBSC) at the University of British Columbia (UBC) Library in Vancouver. Invitation to a Sarapis Dinner. Oxyrhynchus?, II CE. - Table 1: Papyrus Invitations to Sarapis Dinners and Related Texts; - Table 2: Papyrus Invitations to Secular Dinners.</note>
+    <relatedItem type="appearsIn" n="1">
+        <bibl>
+            <ptr target="https://papyri.info/biblio/511" />
+            <!-- ignore - start, i.e. SoSOL users may not edit this -->
+            <!-- ignore - stop -->
+        </bibl>
+    </relatedItem>
+    <biblScope type="issue">205</biblScope>
+    <relatedItem type="mentions" n="1">
+        <bibl>
+            <title level="s" type="short">ZPE</title>
+            <biblScope type="vol">205</biblScope>
+            <biblScope type="num">208</biblScope>
+            <idno type="ddb">zpe;205;208</idno>
+            <idno type="tm">749345</idno>
+            <idno type="invNo">P.Brit.Col. inv. 1</idno>
+        </bibl>
+    </relatedItem>
+    <idno type="pi">95659</idno>
+    <idno type="bp">2018-0037</idno>
+    <seg type="original" subtype="index" resp="#BP">141.4 364 Epistulae 750</seg>
+    <seg type="original" subtype="indexBis" resp="#BP">141.4 P. Vancouver Univ. Libr. Inv. 1</seg>
+    <seg type="original" subtype="titre" resp="#BP">Max Nelson, C.W. Marshall &amp; Chelsea Gardner, P.Brit.Col. Inv. 1 and Invitations to Sarapis Dinners.</seg>
+    <seg type="original" subtype="publication" resp="#BP">ZPE 205 (2018) pp. 207-212, figg.</seg>
+    <seg type="original" subtype="resume" resp="#BP">P. Vancouver Univ. Libr. [P. Brit. Col.] Inv. 1. The papyrus is housed in Rare Books and Special Collections (RBSC) at the University of British Columbia (UBC) Library in Vancouver. Invitation to a Sarapis Dinner. Oxyrhynchus?, II CE. - Table 1: Papyrus Invitations to Sarapis Dinners and Related Texts; - Table 2: Papyrus Invitations to Secular Dinners.</seg>
+    <seg type="original" subtype="nom" resp="#BP">Nelson Marshall Gardner</seg>
 </bibl>

--- a/Biblio/96/95860.xml
+++ b/Biblio/96/95860.xml
@@ -1,27 +1,29 @@
-<?xml version='1.0' encoding='UTF-8'?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b95860" type="book" subtype="authored" xml:lang="en">
-  <publisher n="1">de Gruyter</publisher>
-  <pubPlace n="1">Berlin - Boston</pubPlace>
-  <title level="m" type="main">Material aspects of letter writing in the Graeco-Roman world. 500 BC - AD 300</title>
-  <series>
-    <title level="s" type="main">Materiale Textkulturen</title>
-    <biblScope type="volume">12</biblScope>
-  </series>
-  <author n="1">
-    <forename>Antonia</forename>
-    <surname>Sarri</surname>
-  </author>
-  <date>2018</date>
-  <note type="pageCount">388</note>
-  <note type="prefacePageCount">viii</note>
-  <ptr target="https://doi.org/10.1515/9783110426953"/>
-  <idno type="pi">95860</idno>
-  <idno type="bp">2018-0042</idno>
-  <idno type="isbn">978-3-11-042694-6</idno>
-  <seg type="original" subtype="index" resp="#BP">146 364 Epistulae 530</seg>
-  <seg type="original" subtype="titre" resp="#BP">Antonia Sarri, Material Aspects of Letter Writing in the Graeco-Roman World. 500 BC - AD 300 = Materiale Textkulturen. 12.</seg>
-  <seg type="original" subtype="publication" resp="#BP">Berlin - Boston, W. de Gruyter, 2018, viii-388 pp. ISBN 978-3-11-042694-6. €79,95.</seg>
-  <seg type="original" subtype="resume" resp="#BP">Preface. - 1. The development of the ancient letter. - 2. Evidence. - 3. Format and layout. - 4. Authentication. - Appendix 1: Letters in archives; - Appendix 2: Dimensions of letters; - Appendix 3: Letters with handshifts. - Bibliography. Index.</seg>
-  <seg type="original" subtype="cr" resp="#BP">C.R. par Günter Poethke, ArchPF 64 (2018) pp. 272-274. - Paola Ceccarelli, CR N.S., 69 (2019) pp. 286-287. - Celia Sánchez Natalías, BMCRev. &lt; http://bmcr.brynmawr.edu/2019/2019-05-47.html &gt;</seg>
-  <seg type="original" subtype="nom" resp="#BP">Sarri</seg>
+    <publisher n="1">de Gruyter</publisher>
+    <pubPlace n="1">Berlin - Boston</pubPlace>
+    <title level="m" type="main">Material aspects of letter writing in the Graeco-Roman world. 500 BC - AD 300</title>
+    <series>
+        <title level="s" type="main">Materiale Textkulturen</title>
+        <biblScope type="volume">12</biblScope>
+    </series>
+    <author n="1">
+        <forename>Antonia</forename>
+        <surname>Sarri</surname>
+    </author>
+    <date>2018</date>
+    <note type="pageCount">388</note>
+    <note type="prefacePageCount">viii</note>
+    <ptr target="https://doi.org/10.1515/9783110426953" />
+    <idno type="pi">95860</idno>
+    <idno type="bp">2018-0042</idno>
+    <idno type="isbn">978-3-11-042694-6</idno>
+    <seg type="original" subtype="index" resp="#BP">146 364 Epistulae 530</seg>
+    <seg type="original" subtype="titre" resp="#BP">Antonia Sarri, Material Aspects of Letter Writing in the Graeco-Roman World. 500 BC - AD 300 = Materiale Textkulturen. 12.</seg>
+    <seg type="original" subtype="publication" resp="#BP">Berlin - Boston, W. de Gruyter, 2018, viii-388 pp. ISBN 978-3-11-042694-6. €79,95.</seg>
+    <seg type="original" subtype="resume" resp="#BP">Preface. - 1. The development of the ancient letter. - 2. Evidence. - 3. Format and layout. - 4. Authentication. - Appendix 1: Letters in archives; - Appendix 2: Dimensions of letters; - Appendix 3: Letters with handshifts. - Bibliography. Index.</seg>
+    <seg type="original" subtype="cr" resp="#BP">C.R. par Günter Poethke, ArchPF 64 (2018) pp. 272-274. - Paola Ceccarelli, CR N.S., 69 (2019) pp. 286-287. - Celia Sánchez Natalías, BMCRev &amp;lt; http://bmcr.brynmawr.edu/2019/2019-05-47.html &amp;gt;. - Yasmine Amory, Gnomon 92 (2020) pp. 180-181.</seg>
+    <seg type="original" subtype="nom" resp="#BP">Sarri</seg>
+    <note resp="#BP">Preface. - 1. The development of the ancient letter. - 2. Evidence. - 3. Format and layout. - 4. Authentication. - Appendix 1: Letters in archives; - Appendix 2: Dimensions of letters; - Appendix 3: Letters with handshifts. - Bibliography. Index.</note>
+    <seg subtype="internet" resp="#BP" type="original">https://www.degruyter.com/viewbooktoc/product/456723</seg>
 </bibl>

--- a/Biblio/96/95966.xml
+++ b/Biblio/96/95966.xml
@@ -1,36 +1,36 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b95966" type="article" subtype="journal" xml:lang="fr">
-   <title level="a" type="main">Papyrus Coptes de la Pierpont Morgan Museum Library II. Lettre de condoLéances d’une nourrice.</title>
-   <author>
-      <forename>Alain</forename>
-      <surname>Delattre</surname>
-   </author>
-   <author>
-      <forename>Perrine</forename>
-      <surname>Pilette</surname>
-   </author>
-   <author>
-      <forename>Naïm</forename>
-      <surname>Vanthieghem</surname>
-   </author>
-   <date>2018</date>
-   <note resp="#BP">Suite de: Journal of Coptic Studies 17 (2015) pp. 33-53, figg. - Les nourrices en Égypte, de l'époque romaine à l'époque arabe. - Les lettres de condoléances en Égypte, de l'époque romaine à l'époque arabe. - La lettre de condoléances copte P. Amh. II 188 descr. (provenance inconnue, VIIe siècle).</note>
-   <relatedItem type="appearsIn">
-      <bibl>
-         <ptr target="https://papyri.info/biblio/1410"/>
-         <!--ignore - start, i.e. SoSOL users may not edit this-->
-         <title level="j" type="main">Journal of Coptic Studies</title>
-         <!--ignore - stop-->
-      </bibl>
-   </relatedItem>
-   <biblScope type="issue">20</biblScope>
-   <biblScope type="pp" from="1" to="10">1-10</biblScope>
-   <idno type="pi">95966</idno>
-  <idno type="bp">2018-0070</idno>
-  <seg type="original" subtype="index" resp="#BP">141.13 361.3 Epistulae 760</seg>
-  <seg type="original" subtype="indexBis" resp="#BP">141.13 P. Amh. II, 188 descr.</seg>
-  <seg type="original" subtype="titre" resp="#BP">Alain Delattre, Perrine Pilette &amp; Naïm Vanthieghem, Papyrus coptes de la Pierpont Morgan Library II. Lettre de condoléances d'une nourrice.</seg>
-  <seg type="original" subtype="publication" resp="#BP">Journal of Coptic Studies 20 (2018) pp. 1-10, figg.</seg>
-  <seg type="original" subtype="resume" resp="#BP">Suite de: Journal of Coptic Studies 17 (2015) pp. 33-53, figg. - Les nourrices en Égypte, de l'époque romaine à l'époque arabe. - Les lettres de condoléances en Égypte, de l'époque romaine à l'époque arabe. - La lettre de condoléances copte P. Amh. II 188 descr. (provenance inconnue, VIIe siècle).</seg>
-  <seg type="original" subtype="nom" resp="#BP">Delattre Pilette Vanthieghem</seg>
+    <title level="a" type="main">Papyrus Coptes de la Pierpont Morgan Museum Library II. Lettre de condoLéances d’une nourrice.</title>
+    <author>
+        <forename>Alain</forename>
+        <surname>Delattre</surname>
+    </author>
+    <author>
+        <forename>Perrine</forename>
+        <surname>Pilette</surname>
+    </author>
+    <author>
+        <forename>Naïm</forename>
+        <surname>Vanthieghem</surname>
+    </author>
+    <date>2018</date>
+    <note resp="#BP">Suite de: JCoptS 17 (2015) pp. 33-53, figg. - Les nourrices en Égypte, de l'époque romaine à l'époque arabe. - Les lettres de condoléances en Égypte, de l'époque romaine à l'époque arabe. - La lettre de condoléances copte P. Amh. II 188 descr. (provenance inconnue, VIIe siècle).</note>
+    <relatedItem type="appearsIn">
+        <bibl>
+            <ptr target="https://papyri.info/biblio/1410" />
+            <!--ignore - start, i.e. SoSOL users may not edit this-->
+            <title level="j" type="main">Journal of Coptic Studies</title>
+            <!--ignore - stop-->
+        </bibl>
+    </relatedItem>
+    <biblScope type="issue">20</biblScope>
+    <biblScope type="pp" from="1" to="10">1-10</biblScope>
+    <idno type="pi">95966</idno>
+    <idno type="bp">2018-0070</idno>
+    <seg type="original" subtype="index" resp="#BP">141.13 361.3 Epistulae 760</seg>
+    <seg type="original" subtype="indexBis" resp="#BP">141.13 P. Amh. II, 188 descr.</seg>
+    <seg type="original" subtype="titre" resp="#BP">Alain Delattre, Perrine Pilette &amp; Naïm Vanthieghem, Papyrus coptes de la Pierpont Morgan Library II. Lettre de condoléances d'une nourrice.</seg>
+    <seg type="original" subtype="publication" resp="#BP">JCoptS 20 (2018) pp. 1-10, figg.</seg>
+    <seg type="original" subtype="resume" resp="#BP">Suite de: JCoptS 17 (2015) pp. 33-53, figg. - Les nourrices en Égypte, de l'époque romaine à l'époque arabe. - Les lettres de condoléances en Égypte, de l'époque romaine à l'époque arabe. - La lettre de condoléances copte P. Amh. II 188 descr. (provenance inconnue, VIIe siècle).</seg>
+    <seg type="original" subtype="nom" resp="#BP">Delattre Pilette Vanthieghem</seg>
 </bibl>

--- a/Biblio/97/96242.xml
+++ b/Biblio/97/96242.xml
@@ -1,30 +1,30 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96242" type="book">
-  <title level="m" type="main">Bulletin of Online Emendations to Papyri [BOEP]. Version 7.1 (March 29, 2018).</title>
-  <author n="1">
-      <forename>Rodney</forename>
-      <surname>Ast</surname>
-   </author>
-  <author n="2">
-      <forename>Lajos</forename>
-      <surname>Berkes</surname>
-   </author>
-  <author n="3">
-      <forename>James</forename>
-      <surname>Cowey</surname>
-   </author>
-  <date>2018</date>
-  <pubPlace>Heidelberg</pubPlace>
-  <note type="pageCount">5</note>
-  <ptr target="https://archiv.ub.uni-heidelberg.de/propylaeumdok/5522/"/>
-  <note resp="#BP">Emendations appearing in this bulletin have been entered online at www.papyri.info/editor/ via the Papyrological Editor (PE), and have been vetted by members of the PE's editorial board. The list contains corrections [by P. Arzt-Grabner, T. Backhuys, A. Bernini, S. Bounta, R. Duttenhöfer, M.G. Elmaghrabi, L. Ferreti, E. Garel, N. Gonis, D. Hagedorn, P. Heilporn, D. Kiss, T. Kruse, N. Litinas, J. Mangerud, G. Mirizio, N. Reggiani, F. Reiter, O. Salati, U. Yiftach] that were adopted between March 22, 2017 and March 29, 2018. - At the end of the bulletin, notice is given of one papyrus which has been reedited using the PE: P.S.I. Inv. 1686 recto = P. Bagnall 5 recto descr. [by R. Ast &amp; G. Bastianini].</note>
-  <idno type="pi">96242</idno>
-  <idno type="bp">2018-0098</idno>
-  <seg type="original" subtype="index" resp="#BP">140 145.4</seg>
-  <seg type="original" subtype="indexBis" resp="#BP">145.4 P.S.I. Inv. 1686 recto = P. Bagnall 5 recto descr.</seg>
-  <seg type="original" subtype="titre" resp="#BP">Rodney Ast, Lajos Berkes &amp; James M.S. Cowey (edd.), Bulletin of Online Emendations to Papyri [BOEP]. Version 7.1 (March 29, 2018).</seg>
-  <seg type="original" subtype="publication" resp="#BP">Heidelberg, Ruprecht-Karls-Universität Heidelberg, Institut für Papyrologie, 2018, 5 pp.</seg>
-  <seg type="original" subtype="internet" resp="#BP">https://www.uni-heidelberg.de/md/zaw/papy/projekt/7.1_bullemendpap2018.pdf	</seg>
-  <seg type="original" subtype="resume" resp="#BP">Emendations appearing in this bulletin have been entered online at www.papyri.info/editor/ via the Papyrological Editor (PE), and have been vetted by members of the PE's editorial board. The list contains corrections [by P. Arzt-Grabner, T. Backhuys, A. Bernini, S. Bounta, R. Duttenhöfer, M.G. Elmaghrabi, L. Ferreti, E. Garel, N. Gonis, D. Hagedorn, P. Heilporn, D. Kiss, T. Kruse, N. Litinas, J. Mangerud, G. Mirizio, N. Reggiani, F. Reiter, O. Salati, U. Yiftach] that were adopted between March 22, 2017 and March 29, 2018. - At the end of the bulletin, notice is given of one papyrus which has been reedited using the PE: P.S.I. Inv. 1686 recto = P. Bagnall 5 recto descr. [by R. Ast &amp; G. Bastianini].</seg>
-  <seg type="original" subtype="nom" resp="#BP">Ast Berkes Cowey Arzt-Grabner Backhuys Bastianini Bernini Bounta Duttenhöfer Elmaghrabi Ferreti Garel Gonis Hagedorn Heilporn Kiss Kruse Litinas Mangerud Mirizio Reggiani Reiter Salati Yiftach</seg> 
+    <title level="m" type="main">Bulletin of Online Emendations to Papyri [BOEP]. Version 7.1 (March 29, 2018).</title>
+    <author n="1">
+        <forename>Rodney</forename>
+        <surname>Ast</surname>
+    </author>
+    <author n="2">
+        <forename>Lajos</forename>
+        <surname>Berkes</surname>
+    </author>
+    <author n="3">
+        <forename>James</forename>
+        <surname>Cowey</surname>
+    </author>
+    <date>2018</date>
+    <pubPlace>Heidelberg</pubPlace>
+    <note type="pageCount">5</note>
+    <ptr target="https://archiv.ub.uni-heidelberg.de/propylaeumdok/5522/" />
+    <note resp="#BP">Emendations appearing in this bulletin have been entered online at www.papyri.info/editor/ via the Papyrological Editor (PE), and have been vetted by members of the PE's editorial board. The list contains corrections [by P. Arzt-Grabner, T. Backhuys, A. Bernini, S. Bounta, R. Duttenhöfer, M.G. Elmaghrabi, L. Ferreti, E. Garel, N. Gonis, D. Hagedorn, P. Heilporn, D. Kiss, T. Kruse, N. Litinas, J. Mangerud, G. Mirizio, N. Reggiani, F. Reiter, O. Salati, U. Yiftach] that were adopted between March 22, 2017 and March 29, 2018. - At the end of the bulletin, notice is given of one papyrus which has been reedited using the PE: P.S.I. Inv. 1686 recto = P. Bagnall 5 recto descr. [by R. Ast &amp; G. Bastianini].</note>
+    <idno type="pi">96242</idno>
+    <idno type="bp">2018-0098</idno>
+    <seg type="original" subtype="index" resp="#BP">140 145.4</seg>
+    <seg type="original" subtype="indexBis" resp="#BP">145.4 P.S.I. Inv. 1686 recto = P. Bagnall 5 recto descr.</seg>
+    <seg type="original" subtype="titre" resp="#BP">Rodney Ast, Lajos Berkes &amp; James M.S. Cowey (edd.), Bulletin of Online Emendations to Papyri [BOEP]. Version 7.1 (March 29, 2018).</seg>
+    <seg type="original" subtype="publication" resp="#BP">Heidelberg, Ruprecht-Karls-Universität Heidelberg, Institut für Papyrologie, 2018, 5 pp.</seg>
+    <seg type="original" subtype="internet" resp="#BP">https://www.uni-heidelberg.de/md/zaw/papy/projekt/7.1_bullemendpap2018.pdf</seg>
+    <seg type="original" subtype="resume" resp="#BP">Emendations appearing in this bulletin have been entered online at www.papyri.info/editor/ via the Papyrological Editor (PE), and have been vetted by members of the PE's editorial board. The list contains corrections [by P. Arzt-Grabner, T. Backhuys, A. Bernini, S. Bounta, R. Duttenhöfer, M.G. Elmaghrabi, L. Ferreti, E. Garel, N. Gonis, D. Hagedorn, P. Heilporn, D. Kiss, T. Kruse, N. Litinas, J. Mangerud, G. Mirizio, N. Reggiani, F. Reiter, O. Salati, U. Yiftach] that were adopted between March 22, 2017 and March 29, 2018. - At the end of the bulletin, notice is given of one papyrus which has been reedited using the PE: P.S.I. Inv. 1686 recto = P. Bagnall 5 recto descr. [by R. Ast &amp; G. Bastianini].</seg>
+    <seg type="original" subtype="nom" resp="#BP">Ast Berkes Cowey Arzt-Grabner Backhuys Bastianini Bernini Bounta Duttenhöfer Elmaghrabi Ferreti Garel Gonis Hagedorn Heilporn Kiss Kruse Litinas Mangerud Mirizio Reggiani Reiter Salati Yiftach</seg>
 </bibl>

--- a/Biblio/97/96416.xml
+++ b/Biblio/97/96416.xml
@@ -1,26 +1,26 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96416" type="article" subtype="journal" xml:lang="de">
-  <title level="a" type="main">Aus dem Archiv des Διοικητής Athenodoros: Neuedition von BGU XVI 2601, 2605 und 2618</title>
-  <author n="1">
-      <forename>Charikleia</forename>
-      <surname>Armoni</surname>
-  </author>
-  <date>2018</date>
-  <biblScope type="pp" from="123" to="134">123-134</biblScope>
-  <relatedItem type="appearsIn" n="1">
-      <bibl>
-         <ptr target="https://papyri.info/biblio/511"/>
-         <!-- ignore - start, i.e. SoSOL users may not edit this -->
-         <title level="j" type="short-BP">ZPE</title>
-         <!-- ignore - stop -->
-      </bibl>
-  </relatedItem>
-  <biblScope type="issue">207</biblScope>
-  <idno type="pi">96416</idno>
-  <idno type="bp">2018-0097</idno>
-  <seg type="original" subtype="index" resp="#BP">145.4 B.G.U. 146</seg>
-  <seg type="original" subtype="indexBis" resp="#BP">145.4 B.G.U. XVI, 2601; 2605; 2618	</seg>
-  <seg type="original" subtype="titre" resp="#BP">Charikleia Armoni, Aus dem Archiv des Διοικητής Athenodoros: Neuedition von BGU XVI 2601, 2605 und 2618.</seg>
-  <seg type="original" subtype="publication" resp="#BP">ZPE 207 (2018) pp. 123-134.</seg>
-  <seg type="original" subtype="nom" resp="#BP">Armoni</seg>
+    <title level="a" type="main">Aus dem Archiv des Διοικητής Athenodoros: Neuedition von BGU XVI 2601, 2605 und 2618</title>
+    <author n="1">
+        <forename>Charikleia</forename>
+        <surname>Armoni</surname>
+    </author>
+    <date>2018</date>
+    <biblScope type="pp" from="123" to="134">123-134</biblScope>
+    <relatedItem type="appearsIn" n="1">
+        <bibl>
+            <ptr target="https://papyri.info/biblio/511" />
+            <!-- ignore - start, i.e. SoSOL users may not edit this -->
+            <title level="j" type="short-BP">ZPE</title>
+            <!-- ignore - stop -->
+        </bibl>
+    </relatedItem>
+    <biblScope type="issue">207</biblScope>
+    <idno type="pi">96416</idno>
+    <idno type="bp">2018-0097</idno>
+    <seg type="original" subtype="index" resp="#BP">145.4 B.G.U. 146</seg>
+    <seg type="original" subtype="indexBis" resp="#BP">145.4 B.G.U. XVI, 2601; 2605; 2618</seg>
+    <seg type="original" subtype="titre" resp="#BP">Charikleia Armoni, Aus dem Archiv des Διοικητής Athenodoros: Neuedition von BGU XVI 2601, 2605 und 2618.</seg>
+    <seg type="original" subtype="publication" resp="#BP">ZPE 207 (2018) pp. 123-134.</seg>
+    <seg type="original" subtype="nom" resp="#BP">Armoni</seg>
 </bibl>

--- a/Biblio/97/96486.xml
+++ b/Biblio/97/96486.xml
@@ -1,30 +1,31 @@
-<?xml version='1.0' encoding='UTF-8'?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96486" type="article" subtype="journal" xml:lang="en">
-  <title level="a" type="main">A most remarkable fourth century letter in Greek, recovered from House 4 at Ismant el-Kharab</title>
-  <author n="1">
-    <forename>Iain</forename>
-    <surname>Gardner</surname>
-  </author>
-  <author n="2">
-    <forename>Klaas A.</forename>
-    <surname>Worp</surname>
-  </author>
-  <date>2018</date>
-  <biblScope type="pp" from="127" to="142">127-142</biblScope>
-  <relatedItem type="appearsIn" n="1">
-    <bibl>
-      <ptr target="http://papyri.info/biblio/511"/>
-      <!-- ignore - start, i.e. SoSOL users may not edit this -->
-      <!-- ignore - stop -->
-    </bibl>
-  </relatedItem>
-  <biblScope type="issue">205</biblScope>
-  <idno type="pi">96486</idno>
-  <idno type="bp">2018-0022</idno>
-  <seg type="original" subtype="index" resp="#BP">141.4 364 Epistulae 714</seg>
-  <seg type="original" subtype="indexBis" resp="#BP">141.4 P. Kellis Gr. Inv. P93.103	</seg>
-  <seg type="original" subtype="titre" resp="#BP">Iain Gardner &amp; Klaas A. Worp, A Most Remarkable Fourth Century Letter in Greek, Recovered from House 4 at Ismant el-Kharab.</seg>
-  <seg type="original" subtype="publication" resp="#BP">ZPE 205 (2018) pp. 127-142, figg.</seg>
-  <seg type="original" subtype="resume" resp="#BP">Greek letter, sent to certain leaders of a church community in Kellis (IVp). - General Remarks on the Document and Scribal Production. - Introductory Remarks on the Content. - Commentary. - Word List.</seg>
-  <seg type="original" subtype="nom" resp="#BP">Gardner Worp</seg>
+    <title level="a" type="main">A most remarkable fourth century letter in Greek, recovered from House 4 at Ismant el-Kharab</title>
+    <author n="1">
+        <forename>Iain</forename>
+        <surname>Gardner</surname>
+    </author>
+    <author n="2">
+        <forename>Klaas A.</forename>
+        <surname>Worp</surname>
+    </author>
+    <date>2018</date>
+    <biblScope type="pp" from="127" to="142">127-142</biblScope>
+    <relatedItem type="appearsIn" n="1">
+        <bibl>
+            <ptr target="http://papyri.info/biblio/511" />
+            <!-- ignore - start, i.e. SoSOL users may not edit this -->
+            <!-- ignore - stop -->
+        </bibl>
+    </relatedItem>
+    <biblScope type="issue">205</biblScope>
+    <idno type="pi">96486</idno>
+    <idno type="bp">2018-0022</idno>
+    <seg type="original" subtype="index" resp="#BP">141.4 364 Epistulae 714</seg>
+    <seg type="original" subtype="indexBis" resp="#BP">141.4 P. Kellis Gr. Inv. P93.103</seg>
+    <seg type="original" subtype="titre" resp="#BP">Iain Gardner &amp; Klaas A. Worp, A Most Remarkable Fourth Century Letter in Greek, Recovered from House 4 at Ismant el-Kharab.</seg>
+    <seg type="original" subtype="publication" resp="#BP">ZPE 205 (2018) pp. 127-142, figg.</seg>
+    <seg type="original" subtype="resume" resp="#BP">Greek letter, sent to certain leaders of a church community in Kellis (IVp). - General Remarks on the Document and Scribal Production. - Introductory Remarks on the Content. - Commentary. - Word List.</seg>
+    <seg type="original" subtype="nom" resp="#BP">Gardner Worp</seg>
+    <note resp="#BP">Greek letter, sent to certain leaders of a church community in Kellis (IVp). - General Remarks on the Document and Scribal Production. - Introductory Remarks on the Content. - Commentary. - Word List.</note>
 </bibl>

--- a/Biblio/97/96533.xml
+++ b/Biblio/97/96533.xml
@@ -1,23 +1,25 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96533" type="book" subtype="edited">
-  <title level="m" type="main">Digital Papyrology II. Case Studies on the Digital Edition of Ancient Greek Papyri</title>
-  <editor n="1">
-    <forename>Nicola</forename>
-    <surname>Reggiani</surname>
-  </editor>
-  <date>2018</date>
-  <pubPlace n="1">Berlin</pubPlace>
-  <publisher n="1">DeGruyter</publisher>
-  <note type="prefacePageCount">viii</note>
-  <note type="pageCount">190</note>
-  <idno type="pi">96533</idno>
-  <idno type="isbn">978-3-11-053852-6</idno>
-  <ptr target="https://doi.org/10.1515/9783110547450"/>
-  <idno type="bp">2018-0088</idno>
-  <seg type="original" subtype="index" resp="#BP">181</seg>
-  <seg type="original" subtype="titre" resp="#BP">Nicola Reggiani (ed.), Digital Papyrology II. Case Studies on the Digital Edition of Ancient Greek Papyri.</seg>
-  <seg type="original" subtype="publication" resp="#BP">Berlin - Boston, de Gruyter, 2018, viii-190 pp. ISBN 978-3-11-053852-6. €89,95.</seg>
-  <seg type="original" subtype="resume" resp="#BP">Pp. v-vi: Foreword; - 175-190: Indices. - 8 contributions.</seg>
-  <seg type="original" subtype="cr" resp="#BP">C.R. par Thomas J. Kraus, TC: A Journal of Biblical Textual Criticism 23 (2018) 6 pp. &lt; http://rosetta.reltech.org/TC/v23/TC-2018-Rev-Reggiani-Kraus.pdf &gt; [concerne également: Nicola Reggiani, Digital Papyrology I. Methods, Tools and Trends (Berlin - Boston, 2017)].</seg>
-  <seg type="original" subtype="nom" resp="#BP">Reggiani</seg>
+    <title level="m" type="main">Digital Papyrology II. Case Studies on the Digital Edition of Ancient Greek Papyri</title>
+    <editor n="1">
+        <forename>Nicola</forename>
+        <surname>Reggiani</surname>
+    </editor>
+    <date>2018</date>
+    <pubPlace n="1">Berlin</pubPlace>
+    <publisher n="1">DeGruyter</publisher>
+    <note type="prefacePageCount">viii</note>
+    <note type="pageCount">190</note>
+    <idno type="pi">96533</idno>
+    <idno type="isbn">978-3-11-053852-6</idno>
+    <ptr target="https://doi.org/10.1515/9783110547450" />
+    <idno type="bp">2018-0088</idno>
+    <seg type="original" subtype="index" resp="#BP">181</seg>
+    <seg type="original" subtype="titre" resp="#BP">Nicola Reggiani (ed.), Digital Papyrology II. Case Studies on the Digital Edition of Ancient Greek Papyri.</seg>
+    <seg type="original" subtype="publication" resp="#BP">Berlin - Boston, de Gruyter, 2018, viii-190 pp. ISBN 978-3-11-053852-6. €89,95.</seg>
+    <seg type="original" subtype="resume" resp="#BP">Pp. v-vi: Foreword; - 175-190: Indices. - 8 contributions.</seg>
+    <seg type="original" subtype="cr" resp="#BP">C.R. par Thomas J. Kraus, TC: A Journal of Biblical Textual Criticism 23 (2018) 6 pp. &amp;lt; http://rosetta.reltech.org/TC/v23/TC-2018-Rev-Reggiani-Kraus.pdf &amp;gt; [concerne également: Nicola Reggiani, Digital Papyrology I. Methods, Tools and Trends (Berlin - Boston, 2017)].</seg>
+    <seg type="original" subtype="nom" resp="#BP">Reggiani</seg>
+    <note resp="#BP">Pp. v-vi: Foreword; - 175-190: Indices. - 8 contributions.</note>
+    <seg subtype="internet" resp="#BP" type="original">https://www.degruyter.com/view/product/486983?format=EBOK</seg>
 </bibl>

--- a/Biblio/97/96534.xml
+++ b/Biblio/97/96534.xml
@@ -1,29 +1,31 @@
-<?xml version='1.0' encoding='UTF-8'?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96534" type="article" subtype="book" xml:lang="en">
-  <title level="a" type="main">Anagnosis, Herculaneum, and the Digital Corpus of Literary Papyri</title>
-  <author n="1">
-    <forename>Rodney</forename>
-    <surname>Ast</surname>
-  </author>
-  <author n="2">
-    <forename>Holger</forename>
-    <surname>Essler</surname>
-  </author>
-  <date>2018</date>
-  <biblScope type="pp" from="63" to="74">63-74</biblScope>
-  <relatedItem type="appearsIn" n="1">
-    <bibl>
-      <ptr target="https://papyri.info/biblio/96533"/>
-      <!-- ignore - start, i.e. SoSOL users may not edit this -->
-      <!-- ignore - stop -->
-      <title level="m" type="main">Digital Papyrology II. Case Studies on the Digital Edition of Ancient Greek Papyri</title>
-    </bibl>
-  </relatedItem>
-  <idno type="pi">96534</idno>
-  <idno type="bp">2018-0054</idno>
-  <seg type="original" subtype="index" resp="#BP">181    360    520</seg>
-  <seg type="original" subtype="titre" resp="#BP">Rodney Ast &amp; Holger Essler, Anagnosis, Herculaneum, and the Digital Corpus of Literary Papyri.</seg>
-  <seg type="original" subtype="publication" resp="#BP">Nicola Reggiani (ed.), Digital Papyrology II. Case Studies on the Digital Edition of Ancient Greek Papyri (Berlin - Boston, 2018) pp. 63-74, figg.</seg>
-  <seg type="original" subtype="resume" resp="#BP">1. Overview. - 2. Herculaneum. - 3. Anagnosis.</seg>
-  <seg type="original" subtype="nom" resp="#BP">Ast Essler</seg>
+    <title level="a" type="main">Anagnosis, Herculaneum, and the Digital Corpus of Literary Papyri</title>
+    <author n="1">
+        <forename>Rodney</forename>
+        <surname>Ast</surname>
+    </author>
+    <author n="2">
+        <forename>Holger</forename>
+        <surname>Essler</surname>
+    </author>
+    <date>2018</date>
+    <biblScope type="pp" from="63" to="74">63-74</biblScope>
+    <relatedItem type="appearsIn" n="1">
+        <bibl>
+            <ptr target="https://papyri.info/biblio/96533" />
+            <!-- ignore - start, i.e. SoSOL users may not edit this -->
+            <!-- ignore - stop -->
+            <title level="m" type="main">Digital Papyrology II. Case Studies on the Digital Edition of Ancient Greek Papyri</title>
+        </bibl>
+    </relatedItem>
+    <idno type="pi">96534</idno>
+    <idno type="bp">2018-0054</idno>
+    <seg type="original" subtype="index" resp="#BP">181 360 520</seg>
+    <seg type="original" subtype="titre" resp="#BP">Rodney Ast &amp; Holger Essler, Anagnosis, Herculaneum, and the Digital Corpus of Literary Papyri.</seg>
+    <seg type="original" subtype="publication" resp="#BP">Nicola Reggiani (ed.), Digital Papyrology II. Case Studies on the Digital Edition of Ancient Greek Papyri (Berlin - Boston, 2018) pp. 63-74, figg.</seg>
+    <seg type="original" subtype="resume" resp="#BP">1. Overview. - 2. Herculaneum. - 3. Anagnosis.</seg>
+    <seg type="original" subtype="nom" resp="#BP">Ast Essler</seg>
+    <note resp="#BP">1. Overview. - 2. Herculaneum. - 3. Anagnosis.</note>
+    <seg subtype="internet" resp="#BP" type="original">https://www.degruyter.com/view/books/9783110547450/9783110547450-003/9783110547450-003.xml</seg>
 </bibl>

--- a/Biblio/97/96831.xml
+++ b/Biblio/97/96831.xml
@@ -1,25 +1,27 @@
-<?xml version='1.0' encoding='UTF-8'?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96831" type="article" subtype="book" xml:lang="en">
-  <title level="a" type="main">Archives and Libraries in Greco-Roman Egypt</title>
-  <author n="1">
-    <forename>Jean-Luc</forename>
-    <surname>Fournet</surname>
-  </author>
-  <date>2018</date>
-  <biblScope type="pp" from="171" to="200">171-200</biblScope>
-  <relatedItem type="appearsIn" n="1">
-    <bibl>
-      <ptr target="https://papyri.info/biblio/96819"/>
-      <!-- ignore - start, i.e. SoSOL users may not edit this -->
-      <!-- ignore - stop -->
-    </bibl>
-  </relatedItem>
-  <idno type="pi">96831</idno>
-  <idno type="bp">2018-0019</idno>
-  <ptr target="https://doi.org/10.1515/9783110541397-006"/>
-  <seg type="original" subtype="index" resp="#BP">146    540</seg>
-  <seg type="original" subtype="titre" resp="#BP">Jean-Luc Fournet, Archives and Libraries in Greco-Roman Egypt.</seg>
-  <seg type="original" subtype="publication" resp="#BP">Alessandro Bausi, Christian Brockmann, Michael Friedrich &amp; Sabine Kienitz (edd.), Manuscripts and Archives. Comparative Views on Record-Keeping = Studies in Manuscript Cultures. 11 (Berlin, 2018) pp. 171-199, figg.</seg>
-  <seg type="original" subtype="resume" resp="#BP">1. Introduction. - 2. Archives. - 3. Libraries. - 4. Archives and libraries: two sides of the same coin.</seg>
-  <seg type="original" subtype="nom" resp="#BP">Fournet</seg>
+    <title level="a" type="main">Archives and Libraries in Greco-Roman Egypt</title>
+    <author n="1">
+        <forename>Jean-Luc</forename>
+        <surname>Fournet</surname>
+    </author>
+    <date>2018</date>
+    <biblScope type="pp" from="171" to="200">171-200</biblScope>
+    <relatedItem type="appearsIn" n="1">
+        <bibl>
+            <ptr target="https://papyri.info/biblio/96819" />
+            <!-- ignore - start, i.e. SoSOL users may not edit this -->
+            <!-- ignore - stop -->
+        </bibl>
+    </relatedItem>
+    <idno type="pi">96831</idno>
+    <idno type="bp">2018-0019</idno>
+    <ptr target="https://doi.org/10.1515/9783110541397-006" />
+    <seg type="original" subtype="index" resp="#BP">146 540</seg>
+    <seg type="original" subtype="titre" resp="#BP">Jean-Luc Fournet, Archives and Libraries in Greco-Roman Egypt.</seg>
+    <seg type="original" subtype="publication" resp="#BP">Alessandro Bausi, Christian Brockmann, Michael Friedrich &amp; Sabine Kienitz (edd.), Manuscripts and Archives. Comparative Views on Record-Keeping = Studies in Manuscript Cultures. 11 (Berlin, 2018) pp. 171-199, figg.</seg>
+    <seg type="original" subtype="resume" resp="#BP">1. Introduction. - 2. Archives. - 3. Libraries. - 4. Archives and libraries: two sides of the same coin.</seg>
+    <seg type="original" subtype="nom" resp="#BP">Fournet</seg>
+    <note resp="#BP">1. Introduction. - 2. Archives. - 3. Libraries. - 4. Archives and libraries: two sides of the same coin.</note>
+    <seg subtype="internet" resp="#BP" type="original">https://www.degruyter.com/downloadpdf/books/9783110541397/9783110541397-006/9783110541397-006.pdf</seg>
 </bibl>

--- a/Biblio/98/97422.xml
+++ b/Biblio/98/97422.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97422" type="review">
+  <author>
+      <forename>Hans</forename>
+      <surname>Ankum</surname>
+  </author>
+   <date>1987</date>
+  <biblScope type="pp" from="219" to="230">219-230</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/1386"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">38</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/58723"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97422</idno>
+  <seg type="original" subtype="cr" resp="#BP">Hans Ankum, Iura 38 (1987 [1990]) pp. 219-230.</seg>
+</bibl>

--- a/Biblio/98/97423.xml
+++ b/Biblio/98/97423.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97423" type="review">
+  <author>
+      <forename>Revel</forename>
+      <surname>Coles</surname>
+  </author>
+   <date>1985</date>
+  <biblScope type="pp" from="173" to="174">173-174</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/182"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">35</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/56102"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97423</idno>
+  <seg type="original" subtype="cr" resp="#BP">Revel Coles, CR N.S., 35 (1985) pp. 173-174.</seg>
+</bibl>

--- a/Biblio/98/97424.xml
+++ b/Biblio/98/97424.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0"
+    xml:id="b97424"
+    type="book"
+    subtype="edited"
+    xml:lang="fr">
+    <title level="m" type="main">Appréhender la culture écrite des Anciens. La catégorisation en papyrologie et ses limites</title>
+    <series>
+        <title level="s" type="main">Papyrologica Leodiensia</title>
+        <biblScope type="volume">11</biblScope>
+    </series>
+    <editor n="1">
+        <forename>Jean-Luc</forename>
+        <surname>Fournet</surname>
+    </editor>
+    <editor n="2">
+        <forename>Antonio</forename>
+        <surname>Ricciardetto</surname>
+    </editor>
+    <date>2025</date>
+    <pubPlace>Liège</pubPlace>
+    <publisher>Presses Universitaires de Liège</publisher>
+    <note type="pageCount">286</note>
+    <idno type="pi">97424</idno>
+    <idno type="isbn">978-2-87562-472-7</idno>
+</bibl>

--- a/Biblio/98/97425.xml
+++ b/Biblio/98/97425.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97425" type="review">
+  <author>
+      <forename>Dominic</forename>
+      <surname>Montserrat</surname>
+  </author>
+   <date>1999</date>
+  <biblScope type="pp" from="190" to="192">190-192</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/174"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">74</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31476"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97425</idno>
+  <seg type="original" subtype="cr" resp="#BP">Dominic Montserrat, ChrEg 74 (1999) No. 147, pp. 190-192.</seg>
+</bibl>

--- a/Biblio/98/97426.xml
+++ b/Biblio/98/97426.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97426" type="review">
+  <author>
+      <forename>Roger S.</forename>
+      <surname>Bagnall</surname>
+  </author>
+   <date>2000</date>
+  <biblScope type="pp" from="702" to="706">702-706</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/277"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">13</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31310"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97426</idno>
+  <seg type="original" subtype="cr" resp="#BP">Roger S. Bagnall, JRA 13 (2000) pp. 702-706.</seg>
+</bibl>

--- a/Biblio/98/97427.xml
+++ b/Biblio/98/97427.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97427" type="review">
+  <author>
+      <forename>Orsolina</forename>
+      <surname>Montevecchi</surname>
+  </author>
+   <date>1997</date>
+  <biblScope type="pp" from="153" to="155">153-155</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/912"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">77</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31304"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97427</idno>
+  <seg type="original" subtype="cr" resp="#BP">Orsolina Montevecchi, Aegyptus 77 (1997) pp. 153-155.</seg>
+</bibl>

--- a/Biblio/98/97428.xml
+++ b/Biblio/98/97428.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97428" type="review">
+  <author>
+      <forename>Simon</forename>
+      <surname>Swain</surname>
+  </author>
+   <date>2000</date>
+  <biblScope type="pp" from="307" to="308">307-308</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/182"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">50</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31462"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97428</idno>
+  <seg type="original" subtype="cr" resp="#BP">Simon Swain, CR N.S., 50 (2000) pp. 307-308.</seg>
+</bibl>

--- a/Biblio/98/97429.xml
+++ b/Biblio/98/97429.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97429" type="review">
+  <author>
+      <forename>Roland</forename>
+      <surname>Delmaire</surname>
+  </author>
+   <date>2000</date>
+  <biblScope type="pp" from="164" to="165">164-165</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/1483"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">59</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31338"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97429</idno>
+  <seg type="original" subtype="cr" resp="#BP">Roland Delmaire, Latomus 59 (2000) pp. 164-165.</seg>
+</bibl>

--- a/Biblio/98/97430.xml
+++ b/Biblio/98/97430.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97430" type="review">
+  <author>
+      <forename>Richard</forename>
+      <surname>Alston</surname>
+  </author>
+   <date>1998</date>
+  <biblScope type="pp" from="539" to="540">539-540</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/182"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">48</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31489"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97430</idno>
+  <seg type="original" subtype="cr" resp="#BP">Richard Alston, CR N.S., 48 (1998) pp. 539-540.</seg>
+</bibl>

--- a/Biblio/98/97431.xml
+++ b/Biblio/98/97431.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97431" type="review">
+  <author>
+      <forename>S.M.</forename>
+      <surname>Goldberg</surname>
+  </author>
+   <date>1998</date>
+  <biblScope type="pp" from="601" to="604">601-604</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/843"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">9</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31112"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97431</idno>
+  <seg type="original" subtype="cr" resp="#BP">S.M. Goldberg, BMCRev 9 (1998) pp. 601-604.</seg>
+</bibl>

--- a/Biblio/98/97432.xml
+++ b/Biblio/98/97432.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97432" type="review">
+  <author>
+      <forename>Jutta</forename>
+      <surname>Henner</surname>
+  </author>
+   <date>2000</date>
+  <biblScope type="pp" from="429" to="431">429-431</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/1075"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">49</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31674"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97432</idno>
+  <seg type="original" subtype="cr" resp="#BP">Jutta Henner, Biblos 49 (2000) pp. 429-431;</seg>
+</bibl>

--- a/Biblio/98/97433.xml
+++ b/Biblio/98/97433.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97433" type="review">
+  <author>
+      <forename>Jean A.</forename>
+      <surname>Straus</surname>
+  </author>
+   <date>2000</date>
+  <biblScope>259</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/206"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">68</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31660"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97433</idno>
+  <seg type="original" subtype="cr" resp="#BP">Jean A. Straus, EtCl 68 (2000) p. 259.</seg>
+</bibl>

--- a/Biblio/98/97434.xml
+++ b/Biblio/98/97434.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97434" type="review">
+  <author>
+      <forename>Maxime</forename>
+      <surname>Lemosse</surname>
+  </author>
+   <date>1997</date>
+  <biblScope type="pp" from="463" to="464">463-464</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/385"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">75</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31106"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97434</idno>
+  <seg type="original" subtype="cr" resp="#BP">Maxime Lemosse, RD 75 (1997) pp. 463-464.</seg>
+</bibl>

--- a/Biblio/98/97435.xml
+++ b/Biblio/98/97435.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97435" type="review">
+  <author>
+      <forename>S.</forename>
+      <surname>Pellegrini</surname>
+  </author>
+   <date>2002</date>
+  <biblScope type="pp" from="27" to="30">27-30</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/476"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">127</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31890"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97435</idno>
+  <seg type="original" subtype="cr" resp="#BP">S. Pellegrini, ThLZ 127 (2002) coll. 27-30 [concerne aussi: IDEM, Reading and Writing in the Time of Jesus (Sheffield, 2000)].</seg>
+</bibl>

--- a/Biblio/98/97436.xml
+++ b/Biblio/98/97436.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97436" type="review">
+  <author>
+      <forename>A.M.</forename>
+      <surname>Bowie</surname>
+  </author>
+   <date>2001</date>
+  <biblScope type="pp" from="6" to="7">6-7</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/182"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">51</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31648"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97436</idno>
+  <seg type="original" subtype="cr" resp="#BP">A.M. Bowie, CR N.S., 51 (2001) pp. 6-7.</seg>
+</bibl>

--- a/Biblio/98/97437.xml
+++ b/Biblio/98/97437.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97437" type="review">
+  <author>
+      <forename>Jean</forename>
+      <surname>Lenaerts</surname>
+  </author>
+   <date>2001</date>
+  <biblScope type="pp" from="304" to="305">304-305</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/174"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">76</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31884"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97437</idno>
+  <seg type="original" subtype="cr" resp="#BP">Jean Lenaerts, ChrEg 76 (2001) Nos 151-152, pp. 304-305.</seg>
+</bibl>

--- a/Biblio/98/97438.xml
+++ b/Biblio/98/97438.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97438" type="review">
+  <author>
+      <forename>Henri</forename>
+      <surname>Melaerts</surname>
+  </author>
+   <date>2001</date>
+  <biblScope type="pp" from="324" to="326">324-326</biblScope>
+  <relatedItem type="appearsIn">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/174"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <biblScope type="issue">76</biblScope>
+  <relatedItem type="reviews" n="1">
+      <bibl>
+         <ptr target="https://papyri.info/biblio/31853"/>
+         <!--ignore - start, i.e. SoSOL users may not edit this-->
+         <!--ignore - stop-->
+      </bibl>
+  </relatedItem>
+  <idno type="pi">97438</idno>
+  <seg type="original" subtype="cr" resp="#BP">Henri Melaerts, ChrEg 76 (2001) Nos 151-152, pp. 324-326.</seg>
+</bibl>

--- a/Biblio/98/97439.xml
+++ b/Biblio/98/97439.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bibl xmlns="http://www.tei-c.org/ns/1.0"
+    xml:id="b97439"
+    type="book"
+    subtype="authored"
+    xml:lang="en">
+    <title level="m" type="main">The Village Gymnasium at Philoteris/Watfa in the Fayum</title>
+    <series>
+        <title level="s" type="main">Deutsches Archäologisches Institut - Archäologische Veröffentlichungen</title>
+        <biblScope type="volume">10</biblScope>
+    </series>
+    <author n="1">
+        <forename>Cornelia</forename>
+        <surname>Römer</surname>
+    </author>
+    <author n="2">
+        <forename>Peter</forename>
+        <surname>Kopp</surname>
+    </author>
+    <date>2025</date>
+    <pubPlace>Wiesbaden</pubPlace>
+    <publisher>Harrassowitz</publisher>
+    <note type="prefacePageCount">x</note>
+    <note type="pageCount">150</note>
+    <idno type="pi">97439</idno>
+    <idno type="isbn">978-3-447-12353-2</idno>
+</bibl>


### PR DESCRIPTION
Following some tests on @halosm1th's [CRChecker ](https://github.com/halosm1th/PapyriCRChecker) program, which is designed to make sure that, for every review in a file's `seg[@resp="#BP"][@subtype="cr"]`, there is a corresponding Biblio file with `bibl[@type="review"]`, it seemed prudent to add the new files that it generated to the database. There are thousands more, to be added in due course. I took the same opportunity to create files for some new books announced via the PAPY list.