### PR TITLE
Update chr.mitt.6.xml

### DIFF
--- a/DDB_EpiDoc_XML/chr.mitt/chr.mitt.6.xml
+++ b/DDB_EpiDoc_XML/chr.mitt/chr.mitt.6.xml
@@ -45,7 +45,7 @@
          <head n="7424" xml:lang="en">
             <date>220 BC</date>
             <placeName>Arsinoite</placeName>
-            <ref n="p.petr;2;18|p.petr;3;32C" type="reprint-from">PPetr2,18,1;PPetr3,32C</ref>
+            <ref n="p.petr;2;18_1|p.petr;3;32c" type="reprint-from">PPetr2,18,1;PPetr3,32C</ref>
          </head>
          <div xml:lang="grc" type="edition" xml:space="preserve"><ab>
     <lb n="1"/>Διονυσοδώρωι οἰκονόμωι τῆς 


### PR DESCRIPTION
For cross-references problems, this papyrus displays wrongly in the Navigator. M.Chr. 6 is a reprint of P.Petr. II 18 (1) and of P.Petr. III 32 c; neither of them has a DDB entry; I created the cross-references as file-filler just to avoid M.Chr. to aggregate with other TMs and display wrongly.