### PR TITLE
clean up keywords from HGV

### DIFF
--- a/HGV_meta_EpiDoc/HGV110/109822.xml
+++ b/HGV_meta_EpiDoc/HGV110/109822.xml
@@ -62,7 +62,6 @@
          <textClass>
             <keywords scheme="hgv">
                <term>Ordre à incipit «peneiôt petshai»</term>
-               <term/>
             </keywords>
          </textClass>
       </profileDesc>

--- a/HGV_meta_EpiDoc/HGV119/118474.xml
+++ b/HGV_meta_EpiDoc/HGV119/118474.xml
@@ -67,7 +67,6 @@
                <term>Notiz</term>
                <term>Arbeiter (Steinbruch)</term>
                <term>Schmied</term>
-               <term/>
             </keywords>
          </textClass>
       </profileDesc>

--- a/HGV_meta_EpiDoc/HGV221/220309.xml
+++ b/HGV_meta_EpiDoc/HGV221/220309.xml
@@ -63,7 +63,6 @@
                <term>Lettre</term>
                <term>Demande d’envoi</term>
                <term>Livre</term>
-               <term/>
             </keywords>
          </textClass>
       </profileDesc>

--- a/HGV_meta_EpiDoc/HGV5/4088.xml
+++ b/HGV_meta_EpiDoc/HGV5/4088.xml
@@ -75,7 +75,6 @@
                <term>Haus</term>
                <term>Namen</term>
                <term>Bestrafung</term>
-               <term/>
             </keywords>
          </textClass>
       </profileDesc>

--- a/HGV_meta_EpiDoc/HGV654/653716.xml
+++ b/HGV_meta_EpiDoc/HGV654/653716.xml
@@ -31,13 +31,13 @@
                   </objectDesc>
                </physDesc>
                <history>
-                 <origin>
-                    <origPlace>Thebes ?</origPlace>
-                    <origDate notBefore="0501" notAfter="0600" cert="low" precision="low">VI (?)</origDate>
-                 </origin>
-                 <provenance type="found" when="1917">
+                  <origin>
+                     <origPlace>Thebes ?</origPlace>
+                     <origDate notBefore="0501" notAfter="0600" cert="low" precision="low">VI (?)</origDate>
+                  </origin>
+                  <provenance type="found" when="1917">
                      <p xml:id="geoEHD3A7">
-                       <placeName type="ancient"
+                        <placeName type="ancient"
                                    cert="low"
                                    ref="https://pleiades.stoa.org/places/786017 https://www.trismegistos.org/place/2355">Thebes</placeName>
                      </p>
@@ -45,10 +45,10 @@
                </history>
             </msDesc>
             <listBibl>
-              <bibl type="SB">
+               <bibl type="SB">
                   <ptr target="http://papyri.info/biblio/86523"/>
                   <biblScope type="pp">71</biblScope>
-              </bibl>
+               </bibl>
             </listBibl>
          </sourceDesc>
       </fileDesc>
@@ -71,7 +71,6 @@
             <keywords scheme="hgv">
                <term>Brief (privat)</term>
                <term>Kyriakos an Kyros</term>
-               <term/>
             </keywords>
          </textClass>
       </profileDesc>
@@ -93,9 +92,9 @@
             </listBibl>
          </div>
          <div type="bibliography" subtype="illustrations">
-           <p>
+            <p>
                <bibl type="illustration">S. 73; S. 74</bibl>
-           </p>
+            </p>
          </div>
          <div type="figure">
             <p>

--- a/HGV_meta_EpiDoc/HGV698/697573.xml
+++ b/HGV_meta_EpiDoc/HGV698/697573.xml
@@ -68,7 +68,6 @@
                <term>Auktion</term>
                <term>Verzögerungen</term>
                <term>Durchführung</term>
-               <term/>
             </keywords>
          </textClass>
       </profileDesc>

--- a/HGV_meta_EpiDoc/HGV71/70017.xml
+++ b/HGV_meta_EpiDoc/HGV71/70017.xml
@@ -66,7 +66,6 @@
          <textClass>
             <keywords scheme="hgv">
                <term>Liste (Soldaten, Zenturionen)</term>
-               <term/>
             </keywords>
          </textClass>
       </profileDesc>

--- a/HGV_meta_EpiDoc/HGV845/844328.xml
+++ b/HGV_meta_EpiDoc/HGV845/844328.xml
@@ -66,7 +66,6 @@
                <term>Vertrag</term>
                <term>Sklave</term>
                <term>Kauf</term>
-               <term/>
             </keywords>
          </textClass>
       </profileDesc>

--- a/HGV_meta_EpiDoc/HGV976/975006.xml
+++ b/HGV_meta_EpiDoc/HGV976/975006.xml
@@ -1,101 +1,100 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
-    <fileDesc>
-      <titleStmt>
-        <title>Writing Exercises of Coptic Epistolary Formulas</title>
-      </titleStmt>
-      <publicationStmt>
-        <idno type="filename">975006</idno>
-        <idno type="TM">975006</idno>
-        <idno type="ddb-filename">p.yale.4.189</idno>
-        <idno type="ddb-hybrid">p.yale;4;189</idno>
-      </publicationStmt>
-      <sourceDesc>
-        <msDesc>
-          <msIdentifier>
-            <placeName>
-              <settlement>New Haven</settlement>
-            </placeName>
-<collection>Yale University, Beinecke Library</collection>
-            <idno type="invNo">P.CtYBR 3680 A</idno>
-          </msIdentifier>
-          <physDesc>
-            <objectDesc>
-              <supportDesc>
-                <support>
-                  <material>Holz</material>
-                </support>
-              </supportDesc>
-            </objectDesc>
-          </physDesc>
-          <history>
-            <origin>
-              <origPlace>Oxyrhynchites</origPlace>
-              <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
-            </origin>
-            <provenance type="located">
-              <p>
-                <placeName type="ancient"
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Writing Exercises of Coptic Epistolary Formulas</title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">975006</idno>
+            <idno type="TM">975006</idno>
+            <idno type="ddb-filename">p.yale.4.189</idno>
+            <idno type="ddb-hybrid">p.yale;4;189</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>New Haven</settlement>
+                  </placeName>
+                  <collection>Yale University, Beinecke Library</collection>
+                  <idno type="invNo">P.CtYBR 3680 A</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Holz</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Oxyrhynchites</origPlace>
+                     <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName type="ancient"
                                    subtype="nome"
                                    ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982">Oxyrhynchites</placeName>
-              </p>
-            </provenance>
-          </history>
-        </msDesc>
-      </sourceDesc>
-    </fileDesc>
-    <encodingDesc>
-      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
-    </encodingDesc>
-    <profileDesc>
-      <langUsage>
-        <language ident="fr">Französisch</language>
-        <language ident="en">Englisch</language>
-        <language ident="de">Deutsch</language>
-        <language ident="it">Italienisch</language>
-        <language ident="es">Spanisch</language>
-        <language ident="la">Latein</language>
-        <language ident="el">Griechisch</language>
-      </langUsage>
-      <textClass>
-        <keywords scheme="hgv">
-          <term n="1"></term>
-          <term n="2">Schreibübungen</term>
-        </keywords>
-      </textClass>
-    </profileDesc>
-    <revisionDesc>
-      <change when="2023-05-31" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
-    </revisionDesc>
-  </teiHeader>
-  <text>
-    <body>
-      <div type="bibliography" subtype="principalEdition">
-        <listBibl>
-          <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Yale</title>
-            <biblScope n="1" type="volume">4</biblScope>
-            <biblScope n="2" type="numbers">189</biblScope>
-          </bibl>
-        </listBibl>
-      </div>
-      <div type="bibliography" subtype ="illustrations">
-        <p>
-          <bibl type="illustration">Pl. 62</bibl>
-        </p>
-      </div>
-      <div type="figure">
-        <p>
-          <figure>
-            <graphic url="https://hdl.handle.net/10079/digcoll/2765050"/>
-          </figure>
-        </p>
-      </div>
-      <div type="commentary" subtype="general">
-        <p>Rückseite P.Yale IV 188</p>
-      </div>
-    </body>
-  </text>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Schreibübungen</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-05-31" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">P.Yale</title>
+                  <biblScope n="1" type="volume">4</biblScope>
+                  <biblScope n="2" type="numbers">189</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">Pl. 62</bibl>
+            </p>
+         </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://hdl.handle.net/10079/digcoll/2765050"/>
+               </figure>
+            </p>
+         </div>
+         <div type="commentary" subtype="general">
+            <p>Rückseite P.Yale IV 188</p>
+         </div>
+      </body>
+   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV976/975007.xml
+++ b/HGV_meta_EpiDoc/HGV976/975007.xml
@@ -1,103 +1,102 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
-    <fileDesc>
-      <titleStmt>
-        <title>Schreibübungen zu griechischem Vertragsformular </title>
-      </titleStmt>
-      <publicationStmt>
-        <idno type="filename">975007</idno>
-        <idno type="TM">975007</idno>
-        <idno type="ddb-filename">p.yale.4.190</idno>
-        <idno type="ddb-hybrid">p.yale;4;190</idno>
-      </publicationStmt>
-      <sourceDesc>
-        <msDesc>
-          <msIdentifier>
-            <placeName>
-              <settlement>New Haven</settlement>
-            </placeName>
-            <collection>Yale University, Beinecke Library</collection>
-            <idno type="invNo">P.CtYBR 3674 A</idno>
-          </msIdentifier>
-          <physDesc>
-            <objectDesc>
-              <supportDesc>
-                <support>
-                  <material>Holz</material>
-                </support>
-              </supportDesc>
-            </objectDesc>
-          </physDesc>
-          <history>
-            <origin>
-              <origPlace>Oxyrhynchites ?</origPlace>
-              <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
-            </origin>
-            <provenance type="located">
-              <p>
-                <placeName type="ancient"
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Schreibübungen zu griechischem Vertragsformular </title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">975007</idno>
+            <idno type="TM">975007</idno>
+            <idno type="ddb-filename">p.yale.4.190</idno>
+            <idno type="ddb-hybrid">p.yale;4;190</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>New Haven</settlement>
+                  </placeName>
+                  <collection>Yale University, Beinecke Library</collection>
+                  <idno type="invNo">P.CtYBR 3674 A</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Holz</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Oxyrhynchites ?</origPlace>
+                     <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName type="ancient"
                                    subtype="nome"
-                                   ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982" 
+                                   ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982"
                                    cert="low">Oxyrhynchites</placeName>
-              </p>
-            </provenance>
-          </history>
-        </msDesc>
-      </sourceDesc>
-    </fileDesc>
-    <encodingDesc>
-      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
-    </encodingDesc>
-    <profileDesc>
-      <langUsage>
-        <language ident="fr">Französisch</language>
-        <language ident="en">Englisch</language>
-        <language ident="de">Deutsch</language>
-        <language ident="it">Italienisch</language>
-        <language ident="es">Spanisch</language>
-        <language ident="la">Latein</language>
-        <language ident="el">Griechisch</language>
-      </langUsage>
-      <textClass>
-        <keywords scheme="hgv">
-          <term n="1"></term>
-          <term n="2">Schreibübungen</term>
-          <term n="3">Vertrag</term>
-        </keywords>
-      </textClass>
-    </profileDesc>
-    <revisionDesc>
-      <change when="2023-05-31" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
-    </revisionDesc>
-  </teiHeader>
-  <text>
-    <body>
-      <div type="bibliography" subtype="principalEdition">
-        <listBibl>
-          <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Yale</title>
-            <biblScope n="1" type="volume">4</biblScope>
-            <biblScope n="2" type="numbers">190</biblScope>
-          </bibl>
-        </listBibl>
-      </div>
-      <div type="bibliography" subtype ="illustrations">
-        <p>
-          <bibl type="illustration">Pl. 63</bibl>
-        </p>
-      </div>
-      <div type="figure">
-        <p>
-          <figure>
-            <graphic url="https://hdl.handle.net/10079/digcoll/2764943"/>
-          </figure>
-        </p>
-      </div>
-      <div type="commentary" subtype="general">
-        <p>Rückseite P.Yale IV 191</p>
-      </div>
-    </body>
-  </text>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Schreibübungen</term>
+               <term n="2">Vertrag</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-05-31" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">P.Yale</title>
+                  <biblScope n="1" type="volume">4</biblScope>
+                  <biblScope n="2" type="numbers">190</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">Pl. 63</bibl>
+            </p>
+         </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://hdl.handle.net/10079/digcoll/2764943"/>
+               </figure>
+            </p>
+         </div>
+         <div type="commentary" subtype="general">
+            <p>Rückseite P.Yale IV 191</p>
+         </div>
+      </body>
+   </text>
 </TEI>

--- a/HGV_meta_EpiDoc/HGV976/975008.xml
+++ b/HGV_meta_EpiDoc/HGV976/975008.xml
@@ -1,103 +1,102 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/8.13/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
-    <fileDesc>
-      <titleStmt>
-        <title>Schreibübungen zu griechischem Vertragsformular </title>
-      </titleStmt>
-      <publicationStmt>
-        <idno type="filename">975008</idno>
-        <idno type="TM">975008</idno>
-        <idno type="ddb-filename">p.yale.4.191</idno>
-        <idno type="ddb-hybrid">p.yale;4;191</idno>
-      </publicationStmt>
-      <sourceDesc>
-        <msDesc>
-          <msIdentifier>
-            <placeName>
-              <settlement>New Haven</settlement>
-            </placeName>
-            <collection>Yale University, Beinecke Library</collection>
-            <idno type="invNo">P.CtYBR 3674 B</idno>
-          </msIdentifier>
-          <physDesc>
-            <objectDesc>
-              <supportDesc>
-                <support>
-                  <material>Holz</material>
-                </support>
-              </supportDesc>
-            </objectDesc>
-          </physDesc>
-          <history>
-            <origin>
-              <origPlace>Oxyrhynchites ?</origPlace>
-              <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
-            </origin>
-            <provenance type="located">
-              <p>
-                <placeName type="ancient"
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Schreibübungen zu griechischem Vertragsformular </title>
+         </titleStmt>
+         <publicationStmt>
+            <idno type="filename">975008</idno>
+            <idno type="TM">975008</idno>
+            <idno type="ddb-filename">p.yale.4.191</idno>
+            <idno type="ddb-hybrid">p.yale;4;191</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <placeName>
+                     <settlement>New Haven</settlement>
+                  </placeName>
+                  <collection>Yale University, Beinecke Library</collection>
+                  <idno type="invNo">P.CtYBR 3674 B</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc>
+                        <support>
+                           <material>Holz</material>
+                        </support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origPlace>Oxyrhynchites ?</origPlace>
+                     <origDate notBefore="0601" notAfter="0700" precision="low">VII</origDate>
+                  </origin>
+                  <provenance type="located">
+                     <p>
+                        <placeName type="ancient"
                                    subtype="nome"
-                                   ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982" 
+                                   ref="https://www.trismegistos.org/place/2722 https://pleiades.stoa.org/places/736982"
                                    cert="low">Oxyrhynchites</placeName>
-              </p>
-            </provenance>
-          </history>
-        </msDesc>
-      </sourceDesc>
-    </fileDesc>
-    <encodingDesc>
-      <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
-    </encodingDesc>
-    <profileDesc>
-      <langUsage>
-        <language ident="fr">Französisch</language>
-        <language ident="en">Englisch</language>
-        <language ident="de">Deutsch</language>
-        <language ident="it">Italienisch</language>
-        <language ident="es">Spanisch</language>
-        <language ident="la">Latein</language>
-        <language ident="el">Griechisch</language>
-      </langUsage>
-      <textClass>
-        <keywords scheme="hgv">
-          <term n="1"></term>
-          <term n="2">Schreibübungen</term>
-          <term n="3">Vertrag</term>
-        </keywords>
-      </textClass>
-    </profileDesc>
-    <revisionDesc>
-      <change when="2023-05-31" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
-    </revisionDesc>
-  </teiHeader>
-  <text>
-    <body>
-      <div type="bibliography" subtype="principalEdition">
-        <listBibl>
-          <bibl type="publication" subtype="principal">
-            <title level="s" type="abbreviated">P.Yale</title>
-            <biblScope n="1" type="volume">4</biblScope>
-            <biblScope n="2" type="numbers">191</biblScope>
-          </bibl>
-        </listBibl>
-      </div>
-      <div type="bibliography" subtype ="illustrations">
-        <p>
-          <bibl type="illustration">Pl. 64</bibl>
-        </p>
-      </div>
-      <div type="figure">
-        <p>
-          <figure>
-            <graphic url="https://hdl.handle.net/10079/digcoll/2764943"/>
-          </figure>
-        </p>
-      </div>
-      <div type="commentary" subtype="general">
-        <p>Rückseite P.Yale IV 190</p>
-      </div>
-    </body>
-  </text>
+                     </p>
+                  </provenance>
+               </history>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <p>This file encoded to comply with EpiDoc Guidelines and Schema version 8</p>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="fr">Französisch</language>
+            <language ident="en">Englisch</language>
+            <language ident="de">Deutsch</language>
+            <language ident="it">Italienisch</language>
+            <language ident="es">Spanisch</language>
+            <language ident="la">Latein</language>
+            <language ident="el">Griechisch</language>
+         </langUsage>
+         <textClass>
+            <keywords scheme="hgv">
+               <term n="1">Schreibübungen</term>
+               <term n="2">Vertrag</term>
+            </keywords>
+         </textClass>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2023-05-31" who="https://papyri.info/editor/users/Mike%20Sampson">HGV entry Xwalked</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="bibliography" subtype="principalEdition">
+            <listBibl>
+               <bibl type="publication" subtype="principal">
+                  <title level="s" type="abbreviated">P.Yale</title>
+                  <biblScope n="1" type="volume">4</biblScope>
+                  <biblScope n="2" type="numbers">191</biblScope>
+               </bibl>
+            </listBibl>
+         </div>
+         <div type="bibliography" subtype="illustrations">
+            <p>
+               <bibl type="illustration">Pl. 64</bibl>
+            </p>
+         </div>
+         <div type="figure">
+            <p>
+               <figure>
+                  <graphic url="https://hdl.handle.net/10079/digcoll/2764943"/>
+               </figure>
+            </p>
+         </div>
+         <div type="commentary" subtype="general">
+            <p>Rückseite P.Yale IV 190</p>
+         </div>
+      </body>
+   </text>
 </TEI>


### PR DESCRIPTION
remove empty keywords like `<term/>`
normalise space (like trailing, leading or double space)

