### PR TITLE
Correct inverted date interval ranges

### DIFF
--- a/HGV_meta_EpiDoc/HGV20/19007.xml
+++ b/HGV_meta_EpiDoc/HGV20/19007.xml
@@ -41,9 +41,9 @@
                                notAfter="0530"
                                cert="low">529 - 530 (?)</origDate>
                      <origDate xml:id="dateAlternativeZ"
-                               notBefore="0554"
+                               notBefore="0544"
                                notAfter="0545"
-                               cert="low">554 - 545 (?)</origDate>
+                               cert="low">544 - 545 (?)</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV958/957826.xml
+++ b/HGV_meta_EpiDoc/HGV958/957826.xml
@@ -34,7 +34,7 @@
                   <origin>
                      <origPlace>Bir Shawish (Oasis Parva)</origPlace>
                      <origDate xml:id="dateAlternativeX" notBefore="0392" notAfter="0393">392 - 393</origDate>
-                     <origDate xml:id="dateAlternativeY" notBefore="0408" notAfter="0407">408 - 407</origDate>
+                     <origDate xml:id="dateAlternativeY" notBefore="0407" notAfter="0408">407 - 408</origDate>
                   </origin>
                   <provenance type="located">
                      <p>


### PR DESCRIPTION
This corrects two instances where notBefore and notAfter where flipped to result in an empty date range. For HGV19007, the source of truth is the general commentary "Alternativdatierungen: 529 - 530 und 544 - 545."