### PR TITLE
Fix Biblio XML files that show inconsistencies in their xml:id

### DIFF
--- a/Biblio/96/95869.xml
+++ b/Biblio/96/95869.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b95689" type="article" subtype="journal" xml:lang="fr">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b95869" type="article" subtype="journal" xml:lang="fr">
   <title level="a" type="main">Documents d’Asie Mineur</title>
   <author n="1">
     <forename>Louis</forename>

--- a/Biblio/97/96145.xml
+++ b/Biblio/97/96145.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b2022-0014" type="article" subtype="book" xml:lang="en">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96145" type="article" subtype="book" xml:lang="en">
   <title level="a" type="main">Coptic fragments from a Festal Letter of the Late Sixth Century (John Rylands Library, Coptic Suppl. N. 47-48): Damian or Eulogius?</title>
   <author n="1">
     <forename>Alberto</forename>

--- a/Biblio/97/96521.xml
+++ b/Biblio/97/96521.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96520" type="book">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96521" type="book">
   <title level="m" type="main">Otto Handwerker (1877 - 1947). Bibliothekar und Historiker</title>
   <series>
     <title level="s" type="main">Kleine Drucke der Universitätsbibliothek Würzburg</title>

--- a/Biblio/97/96643.xml
+++ b/Biblio/97/96643.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b2023-0085" type="article" subtype="journal" xml:lang="it">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b96643" type="article" subtype="journal" xml:lang="it">
   <title level="a" type="main">Un &apos;dimenticato&apos; registro latino: PSI II 119 recto + ChLA IV 264</title>
   <author n="1">
     <forename>Ornella</forename>

--- a/Biblio/98/97689.xml
+++ b/Biblio/98/97689.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97688" type="article" subtype="book" xml:lang="en">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97689" type="article" subtype="book" xml:lang="en">
    <title level="a" type="main">Archiatres id est medicus sapientissimus – Changes in the meaning of the term archiatros in the Roman Empire</title>
    <author n="1">
       <forename>Ákos</forename>

--- a/Biblio/98/97733.xml
+++ b/Biblio/98/97733.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97533" type="book" subtype="edited" xml:lang="it">
+<bibl xmlns="http://www.tei-c.org/ns/1.0" xml:id="b97733" type="book" subtype="edited" xml:lang="it">
    <title level="m" type="main">Illness and Healing in Late Antique Egypt. Medical Practices and Social Experience</title>
    <series>
       <title level="s" type="main">Papyrotheke</title>


### PR DESCRIPTION
Throughout Biblio, typically the filenames, the xml:ids and the <idno> in the XML files match up. This commit fixes 6 instances were this does not hold true:
* 4 of them look very much like typos
* 2 of them look like an oversight, because somebody used a different (datebased?) xml:id scheme