### PR TITLE
Correct potentially wrong Biblio ID

### DIFF
--- a/Biblio/97/96420.xml
+++ b/Biblio/97/96420.xml
@@ -15,7 +15,7 @@
       <!-- ignore - stop -->
     </bibl>
   </relatedItem>
-  <idno type="pi">96640</idno>
+  <idno type="pi">96420</idno>
   <idno type="bp">2020-0188</idno>
   <seg type="original" subtype="index" resp="#BP">180    510    870</seg>
   <seg type="original" subtype="titre" resp="#BP">Clementina Caputo, Pottery Sherds for Writing: An Overview of the Practice.</seg>


### PR DESCRIPTION
This commit fixes a Biblio idno which is de facto non-unique because it was handed out twice. Once here, an once in `96640.xml`. I think that this is the most likely fix. I am submitting this separately, because I do not know where else this might need to be corrected if the erroneous identifier has actually been used somewhere.