### PR TITLE
Remove duplicated identifiers

### DIFF
--- a/HGV_meta_EpiDoc/HGV141/140266.xml
+++ b/HGV_meta_EpiDoc/HGV141/140266.xml
@@ -9,7 +9,7 @@
          <publicationStmt>
             <idno type="filename">140266</idno>
             <idno type="TM">140266</idno>
-            <idno type="ddb-hybrid">sb.30.17765</idno>
+            <idno type="ddb-filename">sb.30.17765</idno>
             <idno type="ddb-hybrid">sb;30;17765</idno>
          </publicationStmt>
          <sourceDesc>

--- a/HGV_meta_EpiDoc/HGV999/998114.xml
+++ b/HGV_meta_EpiDoc/HGV999/998114.xml
@@ -9,7 +9,7 @@
             <publicationStmt>
                 <idno type="filename">998114</idno>
                 <idno type="TM">998114</idno>
-                <idno type="ddb-hybrid">ddbdp.2021.4</idno>
+                <idno type="ddb-filename">ddbdp.2021.4</idno>
                 <idno type="ddb-hybrid">ddbdp;2021;4</idno>
             </publicationStmt>
             <sourceDesc>


### PR DESCRIPTION
These <idno> tags are exact duplicates of their preceding lines.