### PR TITLE
Encode century date ranges machine-readable

### DIFF
--- a/HGV_meta_EpiDoc/HGV41/40745.xml
+++ b/HGV_meta_EpiDoc/HGV41/40745.xml
@@ -32,7 +32,7 @@
                <history>
                   <origin>
                      <origPlace>Soknopaiu Nesos (Arsinoites)</origPlace>
-                     <origDate precision="low">II - III</origDate>
+                     <origDate notBefore="0101" notAfter="0300" precision="low">II - III</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV41/40746.xml
+++ b/HGV_meta_EpiDoc/HGV41/40746.xml
@@ -32,7 +32,7 @@
                <history>
                   <origin>
                      <origPlace>Soknopaiu Nesos (Arsinoites)</origPlace>
-                     <origDate precision="low">II - III</origDate>
+                     <origDate notBefore="0101" notAfter="0300" precision="low">II - III</origDate>
                   </origin>
                   <provenance type="located">
                      <p>

--- a/HGV_meta_EpiDoc/HGV999/998374.xml
+++ b/HGV_meta_EpiDoc/HGV999/998374.xml
@@ -32,7 +32,7 @@
                <history>
                   <origin>
                      <origPlace>unbekannt</origPlace>
-                     <origDate>
+                     <origDate notBefore="0501" notAfter="0700">
                         <precision degree="0.1"/>ca. VI - VII</origDate>
                   </origin>
                </history>


### PR DESCRIPTION
With these changes, the only text-only `<origDate>` tags are the ones that are indeed "unbekannt" or "unbestimmbar" (or in one case, a weird string, but that is a different story).