### PR TITLE
Correct a typo in origDate

### DIFF
--- a/DCLP/67/66296.xml
+++ b/DCLP/67/66296.xml
@@ -39,7 +39,7 @@
                <history>
                   <origin>
                      <origPlace>Written: Italy</origPlace>
-                     <origDate notBefore="0592" notAfter="6499">592 - 6499</origDate>
+                     <origDate notBefore="0592" notAfter="0649">592 - 649</origDate>
                   </origin>
                   <provenance type="composed">
                      <p>


### PR DESCRIPTION
Source of truth for the correction is the Trismegistos entry https://www.trismegistos.org/text/66296