### PR TITLE
Metadata consistency: 23 DCLP records, 8 corrections

### DIFF
--- a/DCLP/130/130194.xml
+++ b/DCLP/130/130194.xml
@@ -140,7 +140,7 @@
          </div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient" corresp="#FR8970">
-                  <author xml:lang="grc" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0616">Polyaenus</author>
+                  <author xml:lang="grc">Polyaenus</author>
                   <title type="main" level="m" xml:lang="grc">Adversus Aristonem</title>
                </bibl>
             </listBibl>

--- a/DCLP/154/154374.xml
+++ b/DCLP/154/154374.xml
@@ -37,7 +37,7 @@
                <history>
                   <origin>
                      <origPlace>Found: Egypt; written: Egypt</origPlace>
-                     <origDate notBefore="0099" notAfter="-0001">99 - 1 v. Chr.</origDate>
+                     <origDate notBefore="-0099" notAfter="-0001">99 - 1 v. Chr.</origDate>
                   </origin>
                   <provenance type="found">
                      <p>

--- a/DCLP/171/171906.xml
+++ b/DCLP/171/171906.xml
@@ -90,6 +90,7 @@
          </textClass>
          <langUsage>
             <language ident="grc">Greek</language>
+            <language ident="la">Latin</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/DCLP/243/243958.xml
+++ b/DCLP/243/243958.xml
@@ -46,7 +46,7 @@
                <history>
                   <origin>
                      <origPlace>Found: Herculaneum (Campania, Italy); written: Italy</origPlace>
-                     <origDate notBefore="0199" notAfter="0050">199 - 50</origDate>
+                     <origDate notBefore="-0199" notAfter="0050">199 - 50</origDate>
                   </origin>
                   <provenance type="found">
                      <p>

--- a/DCLP/382/382584.xml
+++ b/DCLP/382/382584.xml
@@ -42,7 +42,7 @@
                     <history>
                         <origin>
                             <origPlace>Fundort: Herculaneum (Campania, Italy); Schreibort: Italy ?; Pisones (Italy)</origPlace>
-                            <origDate notBefore="0199" notAfter="0079">199 - 79</origDate>
+                            <origDate notBefore="-0199" notAfter="0079">199 - 79</origDate>
                         </origin>
                         <provenance n="1" type="found">
                             <p>

--- a/DCLP/59/59256.xml
+++ b/DCLP/59/59256.xml
@@ -85,7 +85,7 @@
       <body><head><ref target="https://papyri.info/editions/tm/59256">tm;;59256</ref>; <ref n="70626"><title>BKT 5.2 p. 110-112 no. XVIII no. 3</title><date>1907</date></ref></head><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0018">Aristophanes com.</author>
+                  <author ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0019">Aristophanes com.</author>
                   <title type="main" level="m" ref="http://www.trismegistos.org/authorwork/628">Nubes</title>
                </bibl>
             </listBibl>

--- a/DCLP/59/59261.xml
+++ b/DCLP/59/59261.xml
@@ -99,7 +99,7 @@
          </div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0018">Aristophanes com.</author>
+                  <author ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0019">Aristophanes com.</author>
                   <title type="main" level="m" ref="http://www.trismegistos.org/authorwork/628">Nubes</title>
                </bibl>
             </listBibl>

--- a/DCLP/59/59262.xml
+++ b/DCLP/59/59262.xml
@@ -105,7 +105,7 @@
 </ab></div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author xml:lang="grc" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0018 http://cwkb.org/author/id/765/rdf">Aristophanes com.</author>
+                  <author xml:lang="grc" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0019 http://cwkb.org/author/id/765/rdf">Aristophanes com.</author>
                   <title type="main" level="m" ref="http://www.trismegistos.org/authorwork/628 http://cwkb.org/work/id/1613/rdf">Nubes</title>
                   <biblScope unit="line" from="1" to="7">1-7</biblScope>
                </bibl>

--- a/DCLP/59/59269.xml
+++ b/DCLP/59/59269.xml
@@ -102,7 +102,7 @@
       <body><head><ref target="https://papyri.info/editions/tm/59269">tm;;59269</ref>; <ref n="70639"><title>BKT 5.2 p. 108-110 no. XVIII no. 2</title><date>1907</date></ref>; <ref n="182168"><title>Bastianini e.a., Commentaria et lexica in auctores (CLGP I.1.4). Editio altera p. 94-96 no. Aristophanes 14</title><date>2012</date></ref></head><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0018">Aristophanes com.</author>
+                  <author ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0019">Aristophanes com.</author>
                   <title type="main" level="m" ref="http://www.trismegistos.org/authorwork/628">Nubes</title>
                </bibl>
             </listBibl>

--- a/DCLP/59/59275.xml
+++ b/DCLP/59/59275.xml
@@ -104,7 +104,7 @@
          </div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0018">Aristophanes com.</author>
+                  <author ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0019">Aristophanes com.</author>
                   <title type="main" level="m" ref="http://www.trismegistos.org/authorwork/628">Nubes</title>
                </bibl>
             </listBibl>

--- a/DCLP/59/59287.xml
+++ b/DCLP/59/59287.xml
@@ -91,7 +91,7 @@
       <body><head><ref target="https://papyri.info/editions/tm/59287">tm;;59287</ref>; <ref n="70657"><title>Hermes 35 (1900), p. 602-604</title><date>1900</date></ref>; <ref n="80679"><title>Byzantion 13 (1938), p. 685-686</title><date>1938</date></ref>; <ref n="411712"><title>Prolegomena de comoedia. Scholia in Acharnenses, Equites, Nubes, fasc. III.1, continens scholia vetera in Nubes p. iii descr.</title><date>1977</date></ref>; <ref n="84069"><title>Trojahn, Die auf Papyri erhaltenen Kommentare zur alten Komödie p. 40-42 no. 1.1.8</title><date>2000</date></ref>; <ref n="182171"><title>Bastianini e.a., Commentaria et lexica in auctores (CLGP I.1.4). Editio altera p. 102-106 no. Aristophanes 16</title><date>2012</date></ref></head><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0018">Aristophanes com.</author>
+                  <author ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0019">Aristophanes com.</author>
                   <title type="main" level="m" ref="http://www.trismegistos.org/authorwork/628">Nubes</title>
                </bibl>
             </listBibl>

--- a/DCLP/62/62721.xml
+++ b/DCLP/62/62721.xml
@@ -86,7 +86,7 @@
          </textClass>
          <langUsage>
             <language ident="en">English</language>
-            <language ident="la">Latin</language>
+            <language ident="grc">Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/DCLP/62/62722.xml
+++ b/DCLP/62/62722.xml
@@ -85,7 +85,7 @@
          </textClass>
          <langUsage>
             <language ident="en">English</language>
-            <language ident="la">Latin</language>
+            <language ident="grc">Greek</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>

--- a/DCLP/62/62939.xml
+++ b/DCLP/62/62939.xml
@@ -236,7 +236,7 @@ In the spirit of amicitia papyrologorum and in respect of intellectual property 
          </div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author xml:lang="la" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg2734">Domitius Ulpianus</author>
+                  <author xml:lang="la">Domitius Ulpianus</author>
                   <title type="main" level="m" xml:lang="la" ref="http://www.trismegistos.org/authorwork/1039">Ad edictum</title>
                   <biblScope unit="book">32</biblScope>
                </bibl>

--- a/DCLP/62/62940.xml
+++ b/DCLP/62/62940.xml
@@ -191,7 +191,7 @@ In the spirit of amicitia papyrologorum and in respect of intellectual property 
          </div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author xml:lang="la" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg2734">Ulpianus?</author>
+                  <author xml:lang="la">Ulpianus?</author>
                   <title type="main" level="m" xml:lang="la" ref="http://www.trismegistos.org/authorwork/1039">Ad edictum</title>
                   <biblScope unit="book">22</biblScope>
                </bibl>

--- a/DCLP/62/62941.xml
+++ b/DCLP/62/62941.xml
@@ -172,7 +172,7 @@ In the spirit of amicitia papyrologorum and in respect of intellectual property 
          </div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author xml:lang="grc" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg2734">Domitius Ulpianus?</author>
+                  <author xml:lang="grc">Domitius Ulpianus?</author>
                   <title type="main" level="m" ref="http://www.trismegistos.org/authorwork/1039">Ad edictum</title>
                   <biblScope n="1" unit="book">16?</biblScope>
                   <biblScope n="2" unit="volume"/>

--- a/DCLP/62/62944.xml
+++ b/DCLP/62/62944.xml
@@ -162,7 +162,7 @@ In the spirit of amicitia papyrologorum and in respect of intellectual property 
 </ab></div></div></div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author xml:lang="grc" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg2734">Ulpianus</author>
+                  <author xml:lang="grc">Ulpianus</author>
                   <title type="main" level="m" ref="http://www.trismegistos.org/authorwork/1040">Institutiones</title>
                   <biblScope unit="book">2</biblScope>
                </bibl>

--- a/DCLP/62/62945.xml
+++ b/DCLP/62/62945.xml
@@ -293,7 +293,7 @@ In the spirit of amicitia papyrologorum and in respect of intellectual property 
          </div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author xml:lang="la" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg2734">Ulpianus</author>
+                  <author xml:lang="la">Ulpianus</author>
                   <title type="main" level="m" xml:lang="la" ref="http://www.trismegistos.org/authorwork/1041">Disputationes</title>
                </bibl>
             </listBibl>

--- a/DCLP/63/63009.xml
+++ b/DCLP/63/63009.xml
@@ -116,7 +116,7 @@
          </div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author xml:lang="grc" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg1754">Xenophon</author>
+                  <author xml:lang="grc" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0032">Xenophon</author>
                   <title type="main" level="m" ref="http://www.trismegistos.org/authorwork/1052">Hellenica</title>
                </bibl>
             </listBibl>

--- a/DCLP/63/63036.xml
+++ b/DCLP/63/63036.xml
@@ -198,7 +198,7 @@ Parchment folia written on the recto and verso re-adopted to reinforce the bindi
          </div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author xml:lang="la" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg2734">Ulpianus?</author>
+                  <author xml:lang="la">Ulpianus?</author>
                   <title type="main" level="m" xml:lang="la" ref="http://www.trismegistos.org/authorwork/1039">Ad edictum?</title>
                </bibl>
             </listBibl>

--- a/DCLP/64/64840.xml
+++ b/DCLP/64/64840.xml
@@ -259,7 +259,7 @@ The dimensions of the fragments are: A: 167 mm x 337 mm; B: 125 mm x 230 mm.</p>
          </div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" n="1" subtype="ancientQuote">
-                  <author xml:lang="la" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg2734">Ulpianus</author>
+                  <author xml:lang="la">Ulpianus</author>
                   <title type="main" level="m" xml:lang="la">Ad Sabinum</title>
                   <biblScope n="1" unit="book">20</biblScope>
                   <biblScope n="2" unit="volume"/>

--- a/DCLP/65/65547.xml
+++ b/DCLP/65/65547.xml
@@ -114,7 +114,7 @@
          </div><div type="bibliography" subtype="ancientEdition">
             <listBibl>
                <bibl type="publication" subtype="ancient">
-                  <author xml:lang="grc" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0018 http://cwkb.org/author/id/765/rdf">Aristophanes com.</author>
+                  <author xml:lang="grc" ref="http://data.perseus.org/catalog/urn:cts:greekLit:tlg0019 http://cwkb.org/author/id/765/rdf">Aristophanes com.</author>
                   <title type="main" level="m" ref="http://www.trismegistos.org/authorwork/628 http://cwkb.org/work/id/1613/rdf">Nubes</title>
                   <biblScope unit="line" from="974" to="975">974-975</biblScope>
                </bibl>

--- a/DCLP/67/67691.xml
+++ b/DCLP/67/67691.xml
@@ -45,7 +45,7 @@
                <history>
                   <origin>
                      <origPlace>Written: Novaria (Transpadana, Italy)</origPlace>
-                     <origDate notBefore="0775" notAfter="0725">775 - 725</origDate>
+                     <origDate notBefore="0725" notAfter="0775">725 - 775</origDate>
                   </origin>
                   <provenance type="composed">
                      <p>


### PR DESCRIPTION
This is a batch of metadata corrections to DCLP, found by checking records
against the rest of the base rather than against papyrological judgement:
each one is a record contradicting itself or the identifier it carries.
The 23 records fall into 8 groups, one commit each, so they can be
reviewed — or rejected — separately.

Everything here is internal evidence. No new attribution is proposed, no
reading of any text is changed, and no date is asserted that the base does
not already assert elsewhere.

### 1. Aristophanes' *Clouds* filed under Philo Judaeus (7 records)

TM 59256, 59261, 59262, 59269, 59275, 59287, 65547 name `Aristophanes com.`
in `<author>` and point `@ref` at `urn:cts:greekLit:tlg0018`, which is Philo
Judaeus. Aristophanes is `tlg0019`, which the other 57 `Aristophanes com.`
records carry.

These seven are not seven unrelated slips: all seven are papyri of the
*Clouds* (six titled `Nubes` with line ranges, one "Opening Lines of
Clouds"). An eighth witness of the same comedy, TM 901286, is filed
correctly under `tlg0019`.

In TM 59262 and 65547 the same `@ref` also lists `cwkb.org/author/id/765`.
That identifier is Aristophanes — it co-occurs with `tlg0019` in 19 records
— so those two records already pointed at the right author with their
second identifier.

### 2. Ulpian filed under Justinian (7 records)

TM 62939, 62940, 62941, 62944, 62945, 63036, 64840 name the Latin jurist
Ulpian in `<author>` and point `@ref` at `urn:cts:greekLit:tlg2734`, which
is Flavius Justinianus — roughly three centuries later.

This is not a house convention for Latin legal texts: across all records
with Latin in `<langUsage>`, other Latin jurists carry their own
identifiers (`Aemilius Papinianus` = `tlg2374`, `Iulianus antecessor` =
`tlg4053`), and no other jurist sits under `tlg2734` — the 16 records that
belong there are Justinian's own. Within TM 64840 itself, `Paulus
iuridicus` and `Pomponius` are cited in the same passage with no `@ref` at
all.

**The ref is removed, not replaced.** `tlg2604` is a different Ulpian (the
rhetorician, commentator on Demosthenes); the jurist may have no greekLit
identifier at all. An `<author>` with no `@ref` is not a degraded record
here but ordinary practice: of the 9800 DCLP records that carry an
`<author>` at all, **4376 — nearly half — carry no `@ref` on any of them**.
It seemed better to leave the identifier absent than to assert a second
wrong one.

A related record is deliberately **not** included: TM 65841 also carries
`tlg2734` on an early record, but there the text reached us through the
*Digesta* and the overview says so ("letter of Severus Alexander, later
included in Digesta 049 1 25"). That is a convention, not an error — it is
what tells the two cases apart.

### 3. P.Herc. 573 filed under the tactician Polyaenus (1 record)

TM 130194 carries `<title>Adversus Aristonem</title>`, a work of Polyaenus
of Lampsacus, the Epicurean, which fits both the Herculaneum library and
the record's own date (200–101 BC). `urn:cts:greekLit:tlg0616` is Polyaenus
Macedo, the tactician of the 2nd c. AD. The same base holds TM 59495,
Demetrius Lacon's polemic against that same Epicurean.

Removed rather than replaced, for the same reason as above: the Epicurean
has no identifier in the open corpora. The date is not touched.

### 4. P.Köln 7 305: *Hellenica* filed under Xenophon's letters (1 record)

TM 63009 carries `<title ref="trismegistos.org/authorwork/1052">Hellenica</title>`
with `@ref` at `tlg1754`, the separate corpus of *Xenophontis Epistulae*.
Corrected to `tlg0032`.

### 5. A dropped minus sign in three date ranges (3 records)

TM 154374, 243958, 382584 carry `notBefore` later than `notAfter`. Unlike
the swapped ranges of #649 these are a lost minus, and swapping them would
be wrong:

- TM 154374 labels itself "99 - 1 v. Chr." — both bounds are BC;
- TM 243958 (P.Herc. 671) and TM 382584 (P.Herc. 153) are Herculaneum
  rolls, which cannot postdate the eruption of AD 79, as a swap would make
  them. For TM 382584 the resulting `-0199..0079` is exactly what TM
  942310, 942311 and 942312 carry, spelled out there as "199 v.Chr. - 79";
  for TM 243958 the resulting `-0199..0050` matches the five neighbouring
  Herculaneum records TM 243960–243964, which carry `-0200..0050`.

  (Those five label that range "200 n. Chr. - 50", i.e. AD where the
  attributes say BC. That is a separate inconsistency, in the label rather
  than in the range, and this batch does not touch it.)

### 6. One genuinely inverted range (1 record)

TM 67691 (Augustine, *Sermones*, a Carolingian manuscript of the 8th c.):
`notBefore="0775"`, `notAfter="0725"`. Same class as #649, and as there the
human-readable label is updated together with the attributes.

### 7. Two records declared Latin are written in Greek (2 records)

TM 62721 (P.Oxy. 53 3701) and TM 62722 declare only `<language ident="la">`
while their editions are Greek throughout and contain **no Latin letters at
all**: the only Latin characters anywhere in `<div type="edition">` are the
word "Column" in the `<head>` of each column. `la` replaced with `grc`.

### 8. A Graeco-Latin glossary declared Greek only (1 record)

TM 171906 is titled "Graeco-Latin Alphabetical Glossary of Conjugated
Verbs" and its edition holds 576 Latin letters against 448 Greek ones
(ῥάπτω *consuo*, σπείρω *spargo*, κινέω *moveo*), yet `<langUsage>`
declares Greek only. Added `<language ident="la">Latin</language>`.

### Noticed but deliberately left alone

So that these do not look overlooked: TM 171906 declares no `en` in
`<langUsage>` although its neighbours do; TM 62941 and 62944 carry
`xml:lang="grc"` on Ulpian's Latin name, which stays visible once the
`@ref` is gone. Both are outside what this batch claims to fix.

### Validation

All 23 files validate against `Validation/EpiDoc/8.23/tei-epidoc.rng` with
`Validation/jing.jar` — the same schema and tool this repository's XML
Validation workflow uses for DCLP.

Every construction introduced is one the base already uses. Counted over
DCLP at `2249c22c92`, before this batch: `<author>` without `@ref` — 9144
elements; `<language ident="la">` — 1266; a negative `notBefore` — 1520.

### One question

None of these commits touch `<revisionDesc>`. Almost every DCLP file
carries `<change>` entries with `@who` pointing at a papyri.info user, and
those are written by the Papyrological Editor's workflow, which a GitHub
pull request does not go through — #649 likewise merged without any. Should
I add a `<change>` per record, and if so under which identity, or is that
something finalization handles?

Happy to split this into smaller pull requests, or to withdraw any group
that reflects a convention I have misread.
